### PR TITLE
Make R3D_SetRenderTarget const friendly

### DIFF
--- a/include/r3d.h
+++ b/include/r3d.h
@@ -412,7 +412,7 @@ R3DAPI void R3D_UpdateResolution(int width, int height);
  * 
  * @param target The custom render target (can be NULL to revert to the default framebuffer).
  */
-R3DAPI void R3D_SetRenderTarget(RenderTexture* target);
+R3DAPI void R3D_SetRenderTarget(const RenderTexture* target);
 
 /**
  * @brief Defines the bounds of the scene for directional light calculations.

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -257,7 +257,7 @@ void R3D_UpdateResolution(int width, int height)
     R3D.state.resolution.texelY = 1.0f / height;
 }
 
-void R3D_SetRenderTarget(RenderTexture* target)
+void R3D_SetRenderTarget(const RenderTexture* target)
 {
     if (target == NULL) {
         memset(&R3D.framebuffer.customTarget, 0, sizeof(RenderTexture));


### PR DESCRIPTION
Changed  R3D_SetRenderTarget to take const RenderTexture*. This allows calling it from const methods, example "Engine::Draw() const {}".