### PR TITLE
Cache bloom prefilter data

### DIFF
--- a/include/r3d.h
+++ b/include/r3d.h
@@ -1591,25 +1591,25 @@ R3DAPI void R3D_SetBloomThreshold(float value);
 R3DAPI float R3D_GetBloomThreshold(void);
 
 /**
- * @brief Sets the bloom brightness softness threshold.
+ * @brief Sets the bloom brightness threshold's softness.
  *
  * Controls the softness of the cutoff between being include or excluded in the
  * bloom effect. A value of 0 will result in a hard transition between being
- * included or excluded, while values up to 1 will give a softer transition
- * as the value increases.
+ * included or excluded, while larger values will give an increasingly
+ * softer transition.
  *
- * @param value The value of of the soft threshold (in the range [0.0, 1.0).
+ * @param value The value of of the bloom brightness threshold's softness.
  */
 R3DAPI void R3D_SetBloomSoftThreshold(float value);
 
 /**
- * @brief Gets the current bloom brightness softness threshold.
+ * @brief Gets the current bloom brightness threshold's softness.
  *
  * Retrieves the softness of the brightness cutoff for the bloom effect.
  * This value determines the softness of the transition between being
  * included or excluded in the bloom effect
  *
- * @return The current bloom brightness soft threshold.
+ * @return The current bloom brightness threshold's softness.
  */
 R3DAPI float R3D_GetBloomSoftThreshold(void);
 

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -1851,14 +1851,8 @@ void r3d_pass_post_bloom(void)
             ))
             r3d_shader_set_int(generate.downsampling, uMipLevel, 0);
 
-            // Set prefilter cutoff values
-            float knee = R3D.env.bloomThreshold * R3D.env.bloomSoftThreshold;
-            Vector4 bloomPrefilter;
-            bloomPrefilter.x = R3D.env.bloomThreshold;
-            bloomPrefilter.y = bloomPrefilter.x - knee;
-            bloomPrefilter.z = 2.0f * knee;
-            bloomPrefilter.w = 0.25f / (knee + 0.00001f);
-            r3d_shader_set_vec4(generate.downsampling, uPrefilter, bloomPrefilter);
+            // Set brightness threshold prefilter data
+            r3d_shader_set_vec4(generate.downsampling, uPrefilter, R3D.env.bloomPrefilter);
 
             // Bind scene color (HDR color buffer) as initial texture input
             r3d_shader_bind_sampler2D(generate.downsampling, uTexture, R3D.framebuffer.scene.color);

--- a/src/r3d_environment.c
+++ b/src/r3d_environment.c
@@ -169,6 +169,8 @@ int R3D_GetBloomFilterRadius(void)
 void R3D_SetBloomThreshold(float value)
 {
 	R3D.env.bloomThreshold = value;
+
+	r3d_calculate_bloom_prefilter_data();
 }
 
 float R3D_GetBloomThreshold(void)
@@ -179,6 +181,8 @@ float R3D_GetBloomThreshold(void)
 void R3D_SetBloomSoftThreshold(float value)
 {
 	R3D.env.bloomSoftThreshold = value;
+
+	r3d_calculate_bloom_prefilter_data();
 }
 
 float R3D_GetBloomSoftThreshold(void)

--- a/src/r3d_state.c
+++ b/src/r3d_state.c
@@ -104,6 +104,15 @@ bool r3d_check_texture_format_support(unsigned int format)
     return (supported == GL_TRUE);
 }
 
+void r3d_calculate_bloom_prefilter_data()
+{
+    float knee = R3D.env.bloomThreshold * R3D.env.bloomSoftThreshold;
+    R3D.env.bloomPrefilter.x = R3D.env.bloomThreshold;
+    R3D.env.bloomPrefilter.y = R3D.env.bloomPrefilter.x - knee;
+    R3D.env.bloomPrefilter.z = 2.0f * knee;
+    R3D.env.bloomPrefilter.w = 0.25f / (knee + 0.00001f);
+}
+
 
 /* === Main loading functions === */
 

--- a/src/r3d_state.h
+++ b/src/r3d_state.h
@@ -184,6 +184,7 @@ extern struct R3D_State {
         int bloomFilterRadius;      // (gen pass)
         float bloomThreshold;       // (gen pass)
         float bloomSoftThreshold;   // (gen pass)
+        Vector4 bloomPrefilter;     // (gen pass)
 
         R3D_Fog fogMode;            // (post pass)
         Vector3 fogColor;           // (post pass)
@@ -272,6 +273,8 @@ extern struct R3D_State {
 /* === Helper functions === */
 
 bool r3d_check_texture_format_support(unsigned int format);
+
+void r3d_calculate_bloom_prefilter_data();
 
 
 /* === Main loading functions === */


### PR DESCRIPTION
Let me know if the function to calculate the data is alright where it is.

Also technically storing bloomThreshold as a separate value is redundant now since it's stored inside R3D.env.bloomPrefilter.x for the shader uniform as well, but I think it's more readable and maintainable the way it is. If you'd prefer to not have it there, I can alter it.