### PR TITLE
Setting blending state and Raylib

### DIFF
--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -2209,5 +2209,7 @@ void r3d_reset_raylib_state(void)
     rlEnableDepthMask();
 
     rlSetBlendMode(RL_BLEND_ALPHA);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendEquation(GL_FUNC_ADD);
     glDepthFunc(GL_LEQUAL);
 }


### PR DESCRIPTION
What's happening is OpenGL's blend mode state can end up out of sync with what Raylib is tracking it to be since sometimes Raylib is called to change it, like in `r3d_pass_deferred_lights`, but other places it's not and doing so would break things anyway because `rlSetBlendMode` calls `rlDrawRenderBatch`. You can see the problem when using forward rendering and trying to use Raylib's drawing functions after calling `R3D_End`.

This is just still calling Raylib, and that will work if it thinks the blend mode has changed, but also setting it directly in case it didn't. It's kind of hacky, but I didn't see a clear way to either always use Raylib, or completely bypass it without having to do something like this anyway.

Feel free to close this if I'm missing something obvious.