### PR TITLE
improved precision for color conversion

### DIFF
--- a/src/r3d_model.c
+++ b/src/r3d_model.c
@@ -1943,10 +1943,10 @@ static inline Vector2 r3d_vec2_from_ai_vec2(const struct aiVector2D* aiVec)
 static inline Color r3d_color_from_ai_color(const struct aiColor4D* aiCol)
 {
     return (Color) {
-        (unsigned char)(Clamp(aiCol->r, 0.0f, 1.0f) * 255),
-        (unsigned char)(Clamp(aiCol->g, 0.0f, 1.0f) * 255),
-        (unsigned char)(Clamp(aiCol->b, 0.0f, 1.0f) * 255),
-        (unsigned char)(Clamp(aiCol->a, 0.0f, 1.0f) * 255)
+        (unsigned char)(roundf(Clamp(aiCol->r, 0.0f, 1.0f) * 255.0f)),
+        (unsigned char)(roundf(Clamp(aiCol->g, 0.0f, 1.0f) * 255.0f)),
+        (unsigned char)(roundf(Clamp(aiCol->b, 0.0f, 1.0f) * 255.0f)),
+        (unsigned char)(roundf(Clamp(aiCol->a, 0.0f, 1.0f) * 255.0f))
     };
 }
 


### PR DESCRIPTION
Added rounding to get whatever extra accuracy we can get going from 32 bit to 8 bit. (Does raising the thought of not using Raylib's `Color` internally in materials)