### PR TITLE
fix for unit scaling for loaded models

### DIFF
--- a/examples/pbr_car.c
+++ b/examples/pbr_car.c
@@ -31,6 +31,7 @@ const char* Init(void)
     R3D_SetBloomMode(R3D_BLOOM_MIX);
     R3D_SetTonemapMode(R3D_TONEMAP_ACES);
 
+    R3D_SetModelImportScale(0.01f);
 	model = R3D_LoadModel(RESOURCES_PATH "pbr/car.glb");
     ground = R3D_GenMeshPlane(100.0f, 100.0f, 1, 1, true);
 

--- a/examples/pbr_musket.c
+++ b/examples/pbr_musket.c
@@ -26,6 +26,7 @@ const char* Init(void)
 	R3D_SetTonemapExposure(0.75f);
 	R3D_SetTonemapWhite(1.25f);
 
+	R3D_SetModelImportScale(0.01f);
 	model = R3D_LoadModel(RESOURCES_PATH "pbr/musket.glb");
 	{
 		Matrix transform = MatrixRotateY(PI / 2);

--- a/examples/sponza.c
+++ b/examples/sponza.c
@@ -25,6 +25,7 @@ const char* Init(void)
 
     R3D_SetAmbientColor(GRAY);
 
+    R3D_SetModelImportScale(0.01f);
     sponza = R3D_LoadModel(RESOURCES_PATH "sponza.glb");
     skybox = R3D_LoadSkybox(RESOURCES_PATH "sky/skybox3.png", CUBEMAP_LAYOUT_AUTO_DETECT);
 

--- a/include/r3d.h
+++ b/include/r3d.h
@@ -1429,7 +1429,7 @@ R3DAPI void R3D_SetModelImportScale(float value);
  *
  * @return The percentage value used to scaled loaded models.
  */
-R3DAPI void R3D_GetModelImportScale(void);
+R3DAPI float R3D_GetModelImportScale(void);
 
 
 

--- a/include/r3d.h
+++ b/include/r3d.h
@@ -1412,6 +1412,25 @@ R3DAPI R3D_ModelAnimation* R3D_GetModelAnimation(R3D_ModelAnimation* animations,
  */
 R3DAPI void R3D_ListModelAnimations(R3D_ModelAnimation* animations, int animCount);
 
+/**
+ * @brief Sets the scaling factor applied to models on loading.
+ *
+ * The functions sets the scaling factor to be used when loading models. This value
+ * is only applied to models loaded after this value is set.
+ *
+ * @value Scaling factor to be used (i.e. 0.01 for meters to centimeters).
+ */
+R3DAPI void R3D_SetModelImportScale(float value);
+
+/**
+ * @brief Gets the scaling factor applied to models on loading.
+ *
+ * This function retrieves the scaling factor applied to models when loaded.
+ *
+ * @return The percentage value used to scaled loaded models.
+ */
+R3DAPI void R3D_GetModelImportScale(void);
+
 
 
 // --------------------------------------------

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -139,6 +139,7 @@ void R3D_Init(int resWidth, int resHeight, unsigned int flags)
 
     // Init default loading parameters
     R3D.state.loading.textureFilter = TEXTURE_FILTER_TRILINEAR;
+    R3D.state.loading.unitScaleFactor = 1.0f;
 
     // Load primitive shapes
     glGenVertexArrays(1, &R3D.primitive.dummyVAO);

--- a/src/r3d_model.c
+++ b/src/r3d_model.c
@@ -3481,7 +3481,7 @@ void R3D_SetModelImportScale(float value)
     R3D.state.loading.unitScaleFactor = value;
 }
 
-void R3D_GetModelImportScale(void)
+float R3D_GetModelImportScale(void)
 {
     return R3D.state.loading.unitScaleFactor;
 }

--- a/src/r3d_model.c
+++ b/src/r3d_model.c
@@ -3144,9 +3144,9 @@ R3D_Model R3D_LoadModel(const char* filePath)
 
     /* --- Configure Assimp properties --- */
 
-    // Set the global scale from 'cm' to 'm'
+    // Set the global unit scaling factor
     struct aiPropertyStore* props = aiCreatePropertyStore();
-    aiSetImportPropertyFloat(props, AI_CONFIG_GLOBAL_SCALE_FACTOR_KEY, 0.01f);
+    aiSetImportPropertyFloat(props, AI_CONFIG_GLOBAL_SCALE_FACTOR_KEY, R3D.state.loading.unitScaleFactor);
 
     /* --- Import scene using Assimp --- */
 
@@ -3474,4 +3474,14 @@ void R3D_ListModelAnimations(R3D_ModelAnimation* animations, int animCount)
         TraceLog(LOG_INFO, "  [%d] '%s' - %d frames, %d bones", 
                  i, animations[i].name, animations[i].frameCount, animations[i].boneCount);
     }
+}
+
+void R3D_SetModelImportScale(float value)
+{
+    R3D.state.loading.unitScaleFactor = value;
+}
+
+void R3D_GetModelImportScale(void)
+{
+    return R3D.state.loading.unitScaleFactor;
 }

--- a/src/r3d_state.h
+++ b/src/r3d_state.h
@@ -281,6 +281,7 @@ extern struct R3D_State {
         // Loading param
         struct {
             TextureFilter textureFilter;
+            float unitScaleFactor;
         } loading;
 
         // Miscellaneous flags


### PR DESCRIPTION
_Fixed bad function definition in previous closed PR. I can make cleaner PR later if wanted_

The assumed units and scaling isn't something that should be happening when importing models. This adds functions for having an optional scaling factor and I added it in the examples so they still work as they did.

I don't think any of this is really needed as it's up to the user to know and work with whatever units/scale they are using. Not really the primary reason to avoid it, but this scaling also does make model sizes inconsistent between R3D and Raylib.
