### PR TITLE
fixed an issue with path concatenation during R3D_LoadModel

### DIFF
--- a/src/r3d_model.c
+++ b/src/r3d_model.c
@@ -2296,7 +2296,7 @@ static Image r3d_load_assimp_image(
             );
             return image;
         }
-        image = LoadImage(TextFormat("%s%s", basePath, texPath.data));
+        image = LoadImage(TextFormat("%s/%s", basePath, texPath.data));
         *isAllocated = true;
     }
 


### PR DESCRIPTION
I experienced a bug when loading 3D models where it wouldn't put / in the concated path when loading textures.
For example I was trying to load `car/scene.glb` which has textures in `car/textures/`

 it was trying to load `cartextures/albedo.png` (and other textures), which was causing runtime error.