### PR TITLE
separate flags for skybox drawing and IBL

### DIFF
--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -104,7 +104,8 @@ void R3D_Init(int resWidth, int resHeight, unsigned int flags)
     R3D.env.backgroundColor = (Vector3) { 0.2f, 0.2f, 0.2f };
     R3D.env.ambientColor = (Vector3) { 0.2f, 0.2f, 0.2f };
     R3D.env.quatSky = QuaternionIdentity();
-    R3D.env.useSky = false;
+    R3D.env.useSkyIbl = false;
+    R3D.env.drawSky = false;
     R3D.env.skyBackgroundIntensity = 1.0f;
     R3D.env.skyAmbientIntensity = 1.0f;
     R3D.env.skyReflectIntensity = 1.0f;
@@ -1390,7 +1391,7 @@ void r3d_pass_deferred_ambient(void)
             r3d_stencil_disable();
         }
 
-        if (R3D.env.useSky)
+        if (R3D.env.useSkyIbl)
         {
             // Compute skybox IBL
             r3d_shader_enable(screen.ambientIbl);
@@ -1629,7 +1630,7 @@ void r3d_pass_scene_background(void)
     {
         glViewport(0, 0, R3D.state.resolution.width, R3D.state.resolution.height);
 
-        if (R3D.env.useSky && R3D.env.skyBackgroundIntensity > 0.0f)
+        if (R3D.env.drawSky)
         {
             // Setup projection matrix
             rlMatrixMode(RL_PROJECTION);
@@ -1973,7 +1974,7 @@ void r3d_pass_scene_forward(void)
             {
                 r3d_shader_bind_sampler2D(raster.forwardInst, uTexNoise, R3D.texture.blueNoise);
 
-                if (R3D.env.useSky) {
+                if (R3D.env.useSkyIbl) {
                     r3d_shader_bind_samplerCube(raster.forwardInst, uCubeIrradiance, R3D.env.sky.irradiance.id);
                     r3d_shader_bind_samplerCube(raster.forwardInst, uCubePrefilter, R3D.env.sky.prefilter.id);
                     r3d_shader_bind_sampler2D(raster.forwardInst, uTexBrdfLut, R3D.texture.iblBrdfLut);
@@ -1998,7 +1999,7 @@ void r3d_pass_scene_forward(void)
 
                 r3d_shader_unbind_sampler2D(raster.forwardInst, uTexNoise);
 
-                if (R3D.env.useSky) {
+                if (R3D.env.useSkyIbl) {
                     r3d_shader_unbind_samplerCube(raster.forwardInst, uCubeIrradiance);
                     r3d_shader_unbind_samplerCube(raster.forwardInst, uCubePrefilter);
                     r3d_shader_unbind_sampler2D(raster.forwardInst, uTexBrdfLut);
@@ -2018,7 +2019,7 @@ void r3d_pass_scene_forward(void)
             {
                 r3d_shader_bind_sampler2D(raster.forward, uTexNoise, R3D.texture.blueNoise);
 
-                if (R3D.env.useSky) {
+                if (R3D.env.useSkyIbl) {
                     r3d_shader_bind_samplerCube(raster.forward, uCubeIrradiance, R3D.env.sky.irradiance.id);
                     r3d_shader_bind_samplerCube(raster.forward, uCubePrefilter, R3D.env.sky.prefilter.id);
                     r3d_shader_bind_sampler2D(raster.forward, uTexBrdfLut, R3D.texture.iblBrdfLut);
@@ -2043,7 +2044,7 @@ void r3d_pass_scene_forward(void)
 
                 r3d_shader_unbind_sampler2D(raster.forward, uTexNoise);
 
-                if (R3D.env.useSky) {
+                if (R3D.env.useSkyIbl) {
                     r3d_shader_unbind_samplerCube(raster.forward, uCubeIrradiance);
                     r3d_shader_unbind_samplerCube(raster.forward, uCubePrefilter);
                     r3d_shader_unbind_sampler2D(raster.forward, uTexBrdfLut);

--- a/src/r3d_environment.c
+++ b/src/r3d_environment.c
@@ -39,12 +39,14 @@ void R3D_SetAmbientColor(Color color)
 void R3D_EnableSkybox(R3D_Skybox skybox)
 {
 	R3D.env.sky = skybox;
-	R3D.env.useSky = true;
+	R3D.env.useSkyIbl = true;
+	R3D.env.drawSky = (R3D.env.skyBackgroundIntensity > 0.0f) ? true : false;
 }
 
 void R3D_DisableSkybox(void)
 {
-	R3D.env.useSky = false;
+	R3D.env.useSkyIbl = false;
+	R3D.env.drawSky = false;
 }
 
 void R3D_SetSkyboxRotation(float pitch, float yaw, float roll)
@@ -62,6 +64,7 @@ void R3D_SetSkyboxIntensity(float background, float ambient, float reflection)
 	R3D.env.skyBackgroundIntensity = background;
 	R3D.env.skyAmbientIntensity = ambient;
 	R3D.env.skyReflectIntensity = reflection;
+	R3D.env.drawSky = (R3D.env.skyBackgroundIntensity > 0.0f) ? true : false;
 }
 
 void R3D_GetSkyboxIntensity(float* background, float* ambient, float* reflection)

--- a/src/r3d_state.h
+++ b/src/r3d_state.h
@@ -200,8 +200,9 @@ extern struct R3D_State {
                                         
         Quaternion quatSky;             // Rotation of the skybox (raster / light passes)
         R3D_Skybox sky;                 // Skybox textures (raster / light passes)
-        bool useSky;                    // Flag to indicate if skybox is enabled (light pass)
-        float skyBackgroundIntensity;   // Intensity of the visible background from the skybox (raster / light passes) 
+        bool useSkyIbl;                 // Flag to indicate if skybox IBL is enabled (light pass)
+        bool drawSky;                   // Flag to indicate if rendering the skybox is enabled (raster pass)
+        float skyBackgroundIntensity;   // Intensity of the visible background from the skybox (raster pass)
         float skyAmbientIntensity;      // Intensity of the ambient light from the skybox (light pass)
         float skyReflectIntensity;      // Intensity of reflections from the skybox (light pass)
                                         


### PR DESCRIPTION
I didn't really like how I had the check for rendering the skybox so I split `R3D.env.useSky` into separate flags for drawing and IBL. I think it makes all the checks clearer and adds a little more distinction between skyboxes and IBL. Just let me know if you'd rather not have it this way.