### PR TITLE
move shadow cast mode out of materials

### DIFF
--- a/examples/sprite_instanced.c
+++ b/examples/sprite_instanced.c
@@ -39,7 +39,7 @@ const char* Init(void)
     texture = LoadTexture(RESOURCES_PATH "tree.png");
 
     sprite = R3D_LoadSprite(texture, 1, 1);
-    sprite.material.shadowCastMode = R3D_SHADOW_CAST_ALL_FACES;
+    sprite.shadowCastMode = R3D_SHADOW_CAST_ALL_FACES;
 
     /* --- Create multiple transforms for instanced sprites with random positions and scales --- */
 

--- a/examples/transparency.c
+++ b/examples/transparency.c
@@ -24,13 +24,14 @@ const char* Init(void)
     mesh = R3D_GenMeshCube(1, 1, 1, true);
     cube = R3D_LoadModelFromMesh(&mesh);
 
+    cube.meshes[0].shadowCastMode = R3D_SHADOW_CAST_DISABLED;
+
     cube.materials[0].albedo.color = (Color){ 100, 100, 255, 100 };
     cube.materials[0].orm.occlusion = 1.0f;
     cube.materials[0].orm.roughness = 0.2f;
     cube.materials[0].orm.metalness = 0.2f;
 
     cube.materials[0].blendMode = R3D_BLEND_ALPHA;
-    cube.materials[0].shadowCastMode = R3D_SHADOW_CAST_DISABLED;
 
     /* --- Load plane model --- */
 

--- a/include/r3d.h
+++ b/include/r3d.h
@@ -98,10 +98,10 @@ typedef enum R3D_CullMode {
  * performance and visual accuracy depending on the rendering technique used.
  */
 typedef enum R3D_ShadowCastMode {
-    R3D_SHADOW_CAST_DISABLED,     ///< The object does not cast shadows.
     R3D_SHADOW_CAST_FRONT_FACES,  ///< Only front-facing polygons cast shadows.
     R3D_SHADOW_CAST_BACK_FACES,   ///< Only back-facing polygons cast shadows.
-    R3D_SHADOW_CAST_ALL_FACES     ///< Both front and back-facing polygons cast shadows.
+    R3D_SHADOW_CAST_ALL_FACES,    ///< Both front and back-facing polygons cast shadows.
+    R3D_SHADOW_CAST_DISABLED      ///< The object does not cast shadows.
 } R3D_ShadowCastMode;
 
 /**
@@ -213,20 +213,22 @@ typedef struct R3D_Vertex {
  */
 typedef struct R3D_Mesh {
 
-    R3D_Vertex* vertices;   /**< Pointer to the array of vertices. */
-    unsigned int* indices;  /**< Pointer to the array of indices. */
+    R3D_Vertex* vertices;                 /**< Pointer to the array of vertices. */
+    unsigned int* indices;                /**< Pointer to the array of indices. */
+                                          
+    int vertexCount;                      /**< Number of vertices. */
+    int indexCount;                       /**< Number of indices. */
+                                          
+    unsigned int vbo;                     /**< Vertex Buffer Object (GPU handle). */
+    unsigned int ebo;                     /**< Element Buffer Object (GPU handle). */
+    unsigned int vao;                     /**< Vertex Array Object (GPU handle). */
+                                          
+    Matrix* boneMatrices;                 /**< Cached animation matrices for all passes. */
+    int boneCount;                        /**< Number of bones (and matrices) that affect the mesh. */
 
-    int vertexCount;        /**< Number of vertices. */
-    int indexCount;         /**< Number of indices. */
+    R3D_ShadowCastMode shadowCastMode;    /**< Shadow casting mode for the mesh. */
 
-    unsigned int vbo;       /**< Vertex Buffer Object (GPU handle). */
-    unsigned int ebo;       /**< Element Buffer Object (GPU handle). */
-    unsigned int vao;       /**< Vertex Array Object (GPU handle). */
-
-    Matrix* boneMatrices;   /**< Cached animation matrices for all passes. */
-    int boneCount;          /**< Number of bones (and matrices) that affect the mesh. */
-
-    BoundingBox aabb;       /**< Axis-Aligned Bounding Box in local space. */
+    BoundingBox aabb;                     /**< Axis-Aligned Bounding Box in local space. */
 
 } R3D_Mesh;
 
@@ -263,7 +265,6 @@ typedef struct R3D_Material {
     R3D_BlendMode blendMode;              /**< Blend mode used for rendering the material. */
     R3D_CullMode cullMode;                /**< Face culling mode used for the material. */
 
-    R3D_ShadowCastMode shadowCastMode;    /**< Shadow casting mode for the object. */
     R3D_BillboardMode billboardMode;      /**< Billboard mode applied to the object. */
 
     Vector2 uvOffset;                     /**< UV offset applied to the texture coordinates.
@@ -354,11 +355,12 @@ typedef struct R3D_Skybox {
  * potentially causing undesired visual artifacts for semi-transparent sprites.
  */
 typedef struct R3D_Sprite {
-    R3D_Material material;  ///< The material used for rendering the sprite, including its texture and shading properties.
-    float currentFrame;     ///< The current animation frame, represented as a floating-point value to allow smooth interpolation.
-    Vector2 frameSize;      ///< The size of a single animation frame, in texture coordinates (width and height).
-    int xFrameCount;        ///< The number of frames along the horizontal (X) axis of the texture.
-    int yFrameCount;        ///< The number of frames along the vertical (Y) axis of the texture.
+    R3D_Material material;                 ///< The material used for rendering the sprite, including its texture and shading properties.
+    R3D_ShadowCastMode shadowCastMode;     ///< The shadow casting mode for the sprite.
+    float currentFrame;                    ///< The current animation frame, represented as a floating-point value to allow smooth interpolation.
+    Vector2 frameSize;                     ///< The size of a single animation frame, in texture coordinates (width and height).
+    int xFrameCount;                       ///< The number of frames along the horizontal (X) axis of the texture.
+    int yFrameCount;                       ///< The number of frames along the vertical (Y) axis of the texture.
 } R3D_Sprite;
 
 /**

--- a/src/details/r3d_drawcall.c
+++ b/src/details/r3d_drawcall.c
@@ -156,7 +156,7 @@ void r3d_drawcall_raster_depth(const r3d_drawcall_t* call, bool forward, bool sh
 
     // Applying material parameters that are independent of shaders
     if (shadow) {
-        r3d_drawcall_apply_shadow_cast_mode(call->material.shadowCastMode);
+        r3d_drawcall_apply_shadow_cast_mode(call->shadowCastMode);
     }
     else {
         r3d_drawcall_apply_cull_mode(call->material.cullMode);
@@ -226,7 +226,7 @@ void r3d_drawcall_raster_depth_inst(const r3d_drawcall_t* call, bool forward, bo
 
     // Applying material parameters that are independent of shaders
     if (shadow) {
-        r3d_drawcall_apply_shadow_cast_mode(call->material.shadowCastMode);
+        r3d_drawcall_apply_shadow_cast_mode(call->shadowCastMode);
     }
     else {
         r3d_drawcall_apply_cull_mode(call->material.cullMode);
@@ -293,7 +293,7 @@ void r3d_drawcall_raster_depth_cube(const r3d_drawcall_t* call, bool forward, bo
 
     // Applying material parameters that are independent of shaders
     if (shadow) {
-        r3d_drawcall_apply_shadow_cast_mode(call->material.shadowCastMode);
+        r3d_drawcall_apply_shadow_cast_mode(call->shadowCastMode);
     }
     else {
         r3d_drawcall_apply_cull_mode(call->material.cullMode);
@@ -363,7 +363,7 @@ void r3d_drawcall_raster_depth_cube_inst(const r3d_drawcall_t* call, bool forwar
 
     // Applying material parameters that are independent of shaders
     if (shadow) {
-        r3d_drawcall_apply_shadow_cast_mode(call->material.shadowCastMode);
+        r3d_drawcall_apply_shadow_cast_mode(call->shadowCastMode);
     }
     else {
         r3d_drawcall_apply_cull_mode(call->material.cullMode);

--- a/src/details/r3d_drawcall.h
+++ b/src/details/r3d_drawcall.h
@@ -40,6 +40,7 @@ typedef struct {
 
     Matrix transform;
     R3D_Material material;
+    R3D_ShadowCastMode shadowCastMode;
 
     r3d_drawcall_geometry_e geometryType;
     r3d_drawcall_render_mode_e renderMode;

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -458,6 +458,7 @@ void R3D_DrawMesh(const R3D_Mesh* mesh, const R3D_Material* material, Matrix tra
 
     drawCall.transform = transform;
     drawCall.material = material ? *material : R3D_GetDefaultMaterial();
+    drawCall.shadowCastMode = mesh->shadowCastMode;
     drawCall.geometry.model.mesh = mesh;
     drawCall.geometryType = R3D_DRAWCALL_GEOMETRY_MODEL;
     drawCall.renderMode = R3D_DRAWCALL_RENDER_DEFERRED;
@@ -495,6 +496,7 @@ void R3D_DrawMeshInstancedPro(const R3D_Mesh* mesh, const R3D_Material* material
 
     drawCall.transform = globalTransform;
     drawCall.material = material ? *material : R3D_GetDefaultMaterial();
+    drawCall.shadowCastMode = mesh->shadowCastMode;
     drawCall.geometry.model.mesh = mesh;
     drawCall.geometryType = R3D_DRAWCALL_GEOMETRY_MODEL;
     drawCall.renderMode = R3D_DRAWCALL_RENDER_DEFERRED;
@@ -569,6 +571,7 @@ void R3D_DrawModelPro(const R3D_Model* model, Matrix transform)
 
         drawCall.transform = transform;
         drawCall.material = material ? *material : R3D_GetDefaultMaterial();
+        drawCall.shadowCastMode = mesh->shadowCastMode;
         drawCall.geometry.model.mesh = mesh;
         drawCall.geometryType = R3D_DRAWCALL_GEOMETRY_MODEL;
         drawCall.renderMode = R3D_DRAWCALL_RENDER_DEFERRED;
@@ -759,6 +762,7 @@ void R3D_DrawSpriteInstancedPro(const R3D_Sprite* sprite, const BoundingBox* glo
 
     drawCall.transform = globalTransform;
     drawCall.material = sprite->material;
+    drawCall.shadowCastMode = sprite->shadowCastMode;
     drawCall.geometryType = R3D_DRAWCALL_GEOMETRY_SPRITE;
     drawCall.renderMode = R3D_DRAWCALL_RENDER_DEFERRED;
 
@@ -1106,14 +1110,14 @@ void r3d_pass_shadow_maps(void)
 
                         for (size_t k = 0; k < R3D.container.aDrawDeferredInst.count; k++) {
                             r3d_drawcall_t* call = (r3d_drawcall_t*)R3D.container.aDrawDeferredInst.data + k;
-                            if (call->material.shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
+                            if (call->shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
                                 r3d_drawcall_raster_depth_cube_inst(call, false, true, &matVP);
                             }
                         }
 
                         for (size_t k = 0; k < R3D.container.aDrawForwardInst.count; k++) {
                             r3d_drawcall_t* call = (r3d_drawcall_t*)R3D.container.aDrawForwardInst.data + k;
-                            if (call->material.shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
+                            if (call->shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
                                 r3d_drawcall_raster_depth_cube_inst(call, true, true, &matVP);
                             }
                         }
@@ -1125,14 +1129,14 @@ void r3d_pass_shadow_maps(void)
 
                         for (size_t k = 0; k < R3D.container.aDrawDeferred.count; k++) {
                             r3d_drawcall_t* call = (r3d_drawcall_t*)R3D.container.aDrawDeferred.data + k;
-                            if (call->material.shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
+                            if (call->shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
                                 r3d_drawcall_raster_depth_cube(call, false, true, &matVP);
                             }
                         }
 
                         for (size_t k = 0; k < R3D.container.aDrawForward.count; k++) {
                             r3d_drawcall_t* call = (r3d_drawcall_t*)R3D.container.aDrawForward.data + k;
-                            if (call->material.shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
+                            if (call->shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
                                 r3d_drawcall_raster_depth_cube(call, true, true, &matVP);
                             }
                         }
@@ -1166,13 +1170,13 @@ void r3d_pass_shadow_maps(void)
                 {
                     for (size_t j = 0; j < R3D.container.aDrawDeferredInst.count; j++) {
                         r3d_drawcall_t* call = (r3d_drawcall_t*)R3D.container.aDrawDeferredInst.data + j;
-                        if (call->material.shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
+                        if (call->shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
                             r3d_drawcall_raster_depth_inst(call, false, true, &matVP);
                         }
                     }
                     for (size_t j = 0; j < R3D.container.aDrawForwardInst.count; j++) {
                         r3d_drawcall_t* call = (r3d_drawcall_t*)R3D.container.aDrawForwardInst.data + j;
-                        if (call->material.shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
+                        if (call->shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
                             r3d_drawcall_raster_depth_inst(call, true, true, &matVP);
                         }
                     }
@@ -1181,13 +1185,13 @@ void r3d_pass_shadow_maps(void)
                 {
                     for (size_t j = 0; j < R3D.container.aDrawDeferred.count; j++) {
                         r3d_drawcall_t* call = (r3d_drawcall_t*)R3D.container.aDrawDeferred.data + j;
-                        if (call->material.shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
+                        if (call->shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
                             r3d_drawcall_raster_depth(call, false, true, &matVP);
                         }
                     }
                     for (size_t j = 0; j < R3D.container.aDrawForward.count; j++) {
                         r3d_drawcall_t* call = (r3d_drawcall_t*)R3D.container.aDrawForward.data + j;
-                        if (call->material.shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
+                        if (call->shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
                             r3d_drawcall_raster_depth(call, true, true, &matVP);
                         }
                     }

--- a/src/r3d_model.c
+++ b/src/r3d_model.c
@@ -1900,7 +1900,6 @@ R3D_Material R3D_GetDefaultMaterial(void)
     // Misc
     material.blendMode = R3D_BLEND_OPAQUE;
     material.cullMode = R3D_CULL_BACK;
-    material.shadowCastMode = R3D_SHADOW_CAST_FRONT_FACES;
     material.billboardMode = R3D_BILLBOARD_DISABLED;
     material.uvOffset = (Vector2) { 0.0f, 0.0f };
     material.uvScale = (Vector2) { 1.0f, 1.0f };


### PR DESCRIPTION
The idea here is that having per object shadow casting is generally more useful and common than per material. I initially tried including both but the added complexity didn't seem worth it and did not add any additional functionality. This moves the shadow casting mode to base objects(mesh/sprite) that is then used inside draw calls.

This does reorder the `R3D_ShadowCastMode` enum so that front face shadow casting is the default, which currently does apply to sprites as well which might be undesirable.

I think this is a better solution on the whole, but feedback is welcome. It does of course break compatibility with the previous method.