### PR TITLE
removed premature allocations

### DIFF
--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -441,11 +441,11 @@ void R3D_End(void)
 
 void R3D_DrawMesh(const R3D_Mesh* mesh, const R3D_Material* material, Matrix transform)
 {
-    r3d_drawcall_t drawCall = { 0 };
-
     if (mesh == NULL || mesh->skipRender) {
         return;
     }
+
+    r3d_drawcall_t drawCall = { 0 };
 
     switch (material->billboardMode) {
     case R3D_BILLBOARD_FRONT:
@@ -490,11 +490,11 @@ void R3D_DrawMeshInstancedPro(const R3D_Mesh* mesh, const R3D_Material* material
                               const Color* instanceColors, int colorsStride,
                               int instanceCount)
 {
-    r3d_drawcall_t drawCall = { 0 };
-
     if (mesh == NULL || mesh->skipRender || instanceCount == 0 || instanceTransforms == NULL) {
         return;
     }
+
+    r3d_drawcall_t drawCall = { 0 };
 
     drawCall.transform = globalTransform;
     drawCall.material = material ? *material : R3D_GetDefaultMaterial();

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -553,10 +553,10 @@ void R3D_DrawModelPro(const R3D_Model* model, Matrix transform)
 
     for (int i = 0; i < model->meshCount; i++)
     {
-        r3d_drawcall_t drawCall = { 0 };
-
         const R3D_Mesh* mesh = &model->meshes[i];
         if (mesh->skipRender) continue;
+
+        r3d_drawcall_t drawCall = { 0 };
 
         const R3D_Material* material = &model->materials[model->meshMaterials[i]];
 
@@ -634,10 +634,10 @@ void R3D_DrawModelInstancedPro(const R3D_Model* model,
 
     for (int i = 0; i < model->meshCount; i++)
     {
-        r3d_drawcall_t drawCall = { 0 };
-
         const R3D_Mesh* mesh = &model->meshes[i];
         if (mesh->skipRender) continue;
+
+        r3d_drawcall_t drawCall = { 0 };
 
         const R3D_Material* material = &model->materials[model->meshMaterials[i]];
 
@@ -762,11 +762,11 @@ void R3D_DrawSpriteInstancedPro(const R3D_Sprite* sprite, const BoundingBox* glo
                                 const Color* instanceColors, int colorsStride,
                                 int instanceCount)
 {
-    r3d_drawcall_t drawCall = { 0 };
-
     if (sprite == NULL || instanceCount == 0 || instanceTransforms == NULL) {
         return;
     }
+
+    r3d_drawcall_t drawCall = { 0 };
 
     drawCall.transform = globalTransform;
     drawCall.material = sprite->material;


### PR DESCRIPTION
Draw calls were being allocated before the checks to see if they would even be used.