### PR TITLE
control of mipmap levels for bloom

### DIFF
--- a/include/r3d.h
+++ b/include/r3d.h
@@ -2411,6 +2411,30 @@ R3DAPI void R3D_SetBloomMode(R3D_Bloom mode);
 R3DAPI R3D_Bloom R3D_GetBloomMode(void);
 
 /**
+ * @brief Sets the number of mipmap levels used for the bloom effect.
+ *
+ * This function controls how many mipmap level are generated for use in the bloom effect.
+ * More levels will give a smoother and more widely dispersed effect, while less mipmaps
+ * can provide a tighter effect. Setting this value to 0 will result in the maximum
+ * possible amount of levels to be used. Use of this function will rebuild the
+ * mipmaps and may give a one time performance hit.
+ *
+ * @param value The number of mipmap level to be used for the bloom effect.
+ *
+ * Default: 7
+ */
+R3DAPI void R3D_SetBloomLevels(int value);
+
+/**
+ * @brief Gets the current amount of mipmap levels used for the bloom effect.
+ *
+ * This function retrieves the current amount of mipmap levels in use by the bloom effect.
+ *
+ * @return The number of mipmap level currently used for the bloom effect.
+ */
+R3DAPI int R3D_GetBloomLevels(void);
+
+/**
  * @brief Sets the bloom intensity.
  *
  * This function controls the strength of the bloom effect. Higher values result

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -123,6 +123,7 @@ void R3D_Init(int resWidth, int resHeight, unsigned int flags)
     R3D.env.ssaoPower = 1.0f;
     R3D.env.ssaoLightAffect = 0.0f;
     R3D.env.bloomMode = R3D_BLOOM_DISABLED;
+    R3D.env.bloomLevels = 7;
     R3D.env.bloomIntensity = 0.05f;
     R3D.env.bloomFilterRadius = 0;
     R3D.env.bloomThreshold = 0.0f;

--- a/src/r3d_environment.c
+++ b/src/r3d_environment.c
@@ -190,6 +190,26 @@ R3D_Bloom R3D_GetBloomMode(void)
 	return R3D.env.bloomMode;
 }
 
+void R3D_SetBloomLevels(int value)
+{
+	if (R3D.target.mipChainHs.chain != NULL) {
+		for (int i = 0; i < R3D.target.mipChainHs.count; i++) {
+			glDeleteTextures(1, &R3D.target.mipChainHs.chain[i].id);
+		}
+		RL_FREE(R3D.target.mipChainHs.chain);
+
+	    r3d_target_load_mip_chain_hs(R3D.state.resolution.width, R3D.state.resolution.height, value);
+	}
+
+	// Update value based on actual number of mip levels generated
+	R3D.env.bloomLevels = R3D.target.mipChainHs.count;
+}
+
+int R3D_GetBloomLevels(void)
+{
+	return R3D.env.bloomLevels;
+}
+
 void R3D_SetBloomIntensity(float value)
 {
 	R3D.env.bloomIntensity = value;

--- a/src/r3d_state.c
+++ b/src/r3d_state.c
@@ -833,7 +833,7 @@ static void r3d_target_load_scene_pp(int width, int height)
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
-static void r3d_target_load_mip_chain_hs(int width, int height)
+void r3d_target_load_mip_chain_hs(int width, int height, int count)
 {
     assert(R3D.target.mipChainHs.chain == NULL);
 
@@ -847,9 +847,17 @@ static void r3d_target_load_mip_chain_hs(int width, int height)
         internalFormat = r3d_support_get_internal_format(GL_RGB16F, true);
     }
 
-    // Calculate max mip levels based on smallest dimension
+    // Calculate the maximum mip levels based on smallest dimension
     int maxDimension = (width > height) ? width : height;
-    R3D.target.mipChainHs.count = 1 + (int)floor(log2((float)maxDimension));
+    int maxLevels = 1 + (int)floor(log2((float)maxDimension));
+
+    // Use maximum level if count is too large or not specified
+    if (count <= 0 || count > maxLevels) {
+        R3D.target.mipChainHs.count = maxLevels;
+    }
+    else {
+        R3D.target.mipChainHs.count = count;
+    }
 
     // Allocate the array containing the mipmaps
     R3D.target.mipChainHs.chain = RL_MALLOC(R3D.target.mipChainHs.count * sizeof(struct r3d_mip));
@@ -983,7 +991,7 @@ void r3d_framebuffer_load_bloom(int width, int height)
     /* --- Ensures that targets exist --- */
 
     if (R3D.target.mipChainHs.chain == NULL) {
-        r3d_target_load_mip_chain_hs(width, height);
+        r3d_target_load_mip_chain_hs(width, height, R3D.env.bloomLevels);
     }
 
     /* --- Create and configure the framebuffer --- */

--- a/src/r3d_state.h
+++ b/src/r3d_state.h
@@ -229,6 +229,7 @@ extern struct R3D_State {
                                         
         R3D_Bloom bloomMode;            // (post pass)
         float bloomIntensity;           // (post pass)
+        int bloomLevels;                // (gen pass)
         int bloomFilterRadius;          // (gen pass)
         float bloomThreshold;           // (gen pass)
         float bloomSoftThreshold;       // (gen pass)
@@ -404,6 +405,10 @@ void r3d_texture_load_blue_noise(void);
 void r3d_texture_load_ssao_noise(void);
 void r3d_texture_load_ssao_kernel(void);
 void r3d_texture_load_ibl_brdf_lut(void);
+
+/* === Target loading functions === */
+
+void r3d_target_load_mip_chain_hs(int width, int height, int count);
 
 /* === Framebuffer helper macros === */
 


### PR DESCRIPTION
Right now the maximum possible amount of mipmap levels are used for the bloom effect. This is what you'd want for a lot of other uses of mipmaps, but doesn't usually give good results for bloom/glow.

The issue is that with the maximum amount of mipmaps any part of the image can have a significant impact on the whole output since it's dispersed across the entire image. This can really wash out the result (like an early 2000s "bloom everywhere!" game).

Here's an example.

Maximum possible (in this case 10)
<img width="1922" height="1112" alt="bloom-chain-max-10" src="https://github.com/user-attachments/assets/b83a011c-51c5-4836-acce-42677b8f884b" />

Using a more reasonable amount (6)
<img width="1922" height="1112" alt="bloom-chain-6" src="https://github.com/user-attachments/assets/02b83d83-faf5-4574-a182-a5623fa5f8af" />


This add the ability to set the number of levels, but it does still allow the maximum to be used if that is desired. The default I chose is around a typical amount used elsewhere. I did expose `r3d_target_load_mip_chain_hs` in the r3d_state header so it can be accessed (I think it used to be like this?). There could also be a corresponding function to unload to avoid duplicating that code if this seems alright. Just let me know thoughts about this.