### PR TITLE
flag shadowmap for update on creation

### DIFF
--- a/src/details/r3d_light.c
+++ b/src/details/r3d_light.c
@@ -142,7 +142,7 @@ void r3d_light_init(r3d_light_t* light, R3D_LightType type)
     light->shadow.updateConf.mode = R3D_SHADOW_UPDATE_INTERVAL;
     light->shadow.updateConf.frequencySec = 0.016f;
     light->shadow.updateConf.timerSec = 0.0f;
-    light->shadow.updateConf.shoudlUpdate = true;
+    light->shadow.updateConf.shouldUpdate = true;
 
     /* --- Set specific shadow config --- */
 
@@ -178,6 +178,8 @@ void r3d_light_create_shadow_map(r3d_light_t* light, int resolution)
         light->shadow.map = r3d_light_create_shadow_map_omni(resolution);
         break;
     }
+
+    light->shadow.updateConf.shouldUpdate = true;
 }
 
 void r3d_light_destroy_shadow_map(r3d_light_t* light)
@@ -194,16 +196,16 @@ void r3d_light_process_shadow_update(r3d_light_t* light)
     case R3D_SHADOW_UPDATE_MANUAL:
         break;
     case R3D_SHADOW_UPDATE_INTERVAL:
-        if (!light->shadow.updateConf.shoudlUpdate) {
+        if (!light->shadow.updateConf.shouldUpdate) {
             light->shadow.updateConf.timerSec += GetFrameTime();
             if (light->shadow.updateConf.timerSec >= light->shadow.updateConf.frequencySec) {
-                light->shadow.updateConf.shoudlUpdate = true;
+                light->shadow.updateConf.shouldUpdate = true;
                 light->shadow.updateConf.timerSec = 0.0f;
             }
         }
         break;
     case R3D_SHADOW_UPDATE_CONTINUOUS:
-        light->shadow.updateConf.shoudlUpdate = true;
+        light->shadow.updateConf.shouldUpdate = true;
         break;
     }
 }
@@ -212,10 +214,10 @@ void r3d_light_indicate_shadow_update(r3d_light_t* light)
 {
     switch (light->shadow.updateConf.mode) {
     case R3D_SHADOW_UPDATE_MANUAL:
-        light->shadow.updateConf.shoudlUpdate = false;
+        light->shadow.updateConf.shouldUpdate = false;
         break;
     case R3D_SHADOW_UPDATE_INTERVAL:
-        light->shadow.updateConf.shoudlUpdate = false;
+        light->shadow.updateConf.shouldUpdate = false;
         light->shadow.updateConf.timerSec = 0.0f;
         break;
     case R3D_SHADOW_UPDATE_CONTINUOUS:

--- a/src/details/r3d_light.h
+++ b/src/details/r3d_light.h
@@ -29,7 +29,7 @@ typedef struct {
     R3D_ShadowUpdateMode mode;
     float frequencySec;
     float timerSec;
-    bool shoudlUpdate;
+    bool shouldUpdate;
 } r3d_shadow_update_conf_t;
 
 typedef struct {

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -1146,7 +1146,7 @@ void r3d_pass_shadow_maps(void)
         if (!light->data->shadow.enabled) continue;
 
         // Skip if it's not time to update shadows
-        if (!light->data->shadow.updateConf.shoudlUpdate) continue;
+        if (!light->data->shadow.updateConf.shouldUpdate) continue;
         else r3d_light_indicate_shadow_update(light->data);
 
         // TODO: The lights could be sorted to avoid too frequent

--- a/src/r3d_lighting.c
+++ b/src/r3d_lighting.c
@@ -86,7 +86,7 @@ void R3D_ToggleLight(R3D_Light id)
     light->enabled = !light->enabled;
 
     if (light->enabled && light->shadow.enabled) {
-        light->shadow.updateConf.shoudlUpdate = true;
+        light->shadow.updateConf.shouldUpdate = true;
     }
 }
 
@@ -99,7 +99,7 @@ void R3D_SetLightActive(R3D_Light id, bool active)
     }
 
     if (active && light->shadow.enabled) {
-        light->shadow.updateConf.shoudlUpdate = true;
+        light->shadow.updateConf.shouldUpdate = true;
     }
 
     light->enabled = active;
@@ -321,7 +321,7 @@ void R3D_SetShadowUpdateFrequency(R3D_Light id, int msec)
 void R3D_UpdateShadowMap(R3D_Light id)
 {
     r3d_get_and_check_light(light, id);
-    light->shadow.updateConf.shoudlUpdate = true;
+    light->shadow.updateConf.shouldUpdate = true;
 }
 
 float R3D_GetShadowSoftness(R3D_Light id)


### PR DESCRIPTION
Sets the `shouldUpdate` flag to true when creating a shadowmap. If the shadowmap for a light is modified, like changing the resolution with `R3D_EnableShadow`, and the light is not set for continuous update it's left in an incorrect state until the next update.

It's debatable if this is needed and the user should have to manually update when modifying a shadowmap since that's how they configured it, but if nothing else this corrects a typo for `shouldUpdate`.