### PR TITLE
additional options for shadow cast modes

### DIFF
--- a/examples/sprite_instanced.c
+++ b/examples/sprite_instanced.c
@@ -39,7 +39,7 @@ const char* Init(void)
     texture = LoadTexture(RESOURCES_PATH "tree.png");
 
     sprite = R3D_LoadSprite(texture, 1, 1);
-    sprite.shadowCastMode = R3D_SHADOW_CAST_DOUBLE_SIDED;
+    sprite.shadowCastMode = R3D_SHADOW_CAST_ON_DOUBLE_SIDED;
 
     /* --- Create multiple transforms for instanced sprites with random positions and scales --- */
 

--- a/include/r3d.h
+++ b/include/r3d.h
@@ -140,10 +140,15 @@ typedef enum R3D_CullMode {
  * and if so, whether it is also rendered in the main pass.
  */
 typedef enum R3D_ShadowCastMode {
-    R3D_SHADOW_CAST_ON,             ///< The object casts shadows; the faces used are determined by the mesh culling mode.
-    R3D_SHADOW_CAST_DOUBLE_SIDED,   ///< The object casts shadows with both front and back faces, ignoring face culling.
-    R3D_SHADOW_CAST_ONLY,           ///< The object does not render normally, but still contributes to shadow maps.
-    R3D_SHADOW_CAST_DISABLED        ///< The object does not cast shadows at all.
+    R3D_SHADOW_CAST_ON                = 1 << 0,  ///< The object casts shadows; the faces used are determined by the material's culling mode.
+    R3D_SHADOW_CAST_ON_DOUBLE_SIDED   = 1 << 1,  ///< The object casts shadows with both front and back faces, ignoring face culling.
+    R3D_SHADOW_CAST_ON_FRONT_SIDE     = 1 << 2,  ///< The object casts shadows with only front faces, culling back faces.
+    R3D_SHADOW_CAST_ON_BACK_SIDE      = 1 << 3,  ///< The object casts shadows with only back faces, culling front faces.
+    R3D_SHADOW_CAST_ONLY              = 1 << 4,  ///< The object only casts shadows; the faces used are determined by the material's culling mode.
+    R3D_SHADOW_CAST_ONLY_DOUBLE_SIDED = 1 << 5,  ///< The object only casts shadows with both front and back faces, ignoring face culling.
+    R3D_SHADOW_CAST_ONLY_FRONT_SIDE   = 1 << 6,  ///< The object only casts shadows with only front faces, culling back faces.
+    R3D_SHADOW_CAST_ONLY_BACK_SIDE    = 1 << 7,  ///< The object only casts shadows with only back faces, culling front faces.
+    R3D_SHADOW_CAST_DISABLED          = 1 << 8   ///< The object does not cast shadows at all.
 } R3D_ShadowCastMode;
 
 /**
@@ -267,14 +272,14 @@ typedef struct R3D_Mesh {
 
     R3D_Vertex* vertices;                 /**< Pointer to the array of vertices. */
     unsigned int* indices;                /**< Pointer to the array of indices. */
-                                          
+
     int vertexCount;                      /**< Number of vertices. */
     int indexCount;                       /**< Number of indices. */
-                                          
+
     unsigned int vbo;                     /**< Vertex Buffer Object (GPU handle). */
     unsigned int ebo;                     /**< Element Buffer Object (GPU handle). */
     unsigned int vao;                     /**< Vertex Array Object (GPU handle). */
-                                          
+
     Matrix* boneMatrices;                 /**< Cached animation matrices for all passes. */
     int boneCount;                        /**< Number of bones (and matrices) that affect the mesh. */
 

--- a/src/details/r3d_drawcall.c
+++ b/src/details/r3d_drawcall.c
@@ -720,11 +720,32 @@ static void r3d_drawcall_apply_shadow_cast_mode(R3D_ShadowCastMode castMode, R3D
     switch (castMode)
     {
     case R3D_SHADOW_CAST_ON:
+        r3d_drawcall_apply_cull_mode(cullMode);
+        break;
+    case R3D_SHADOW_CAST_ON_DOUBLE_SIDED:
+        glDisable(GL_CULL_FACE);
+        break;
+    case R3D_SHADOW_CAST_ON_FRONT_SIDE:
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_BACK);
+        break;
+    case R3D_SHADOW_CAST_ON_BACK_SIDE:
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_FRONT);
+        break;
     case R3D_SHADOW_CAST_ONLY:
         r3d_drawcall_apply_cull_mode(cullMode);
         break;
-    case R3D_SHADOW_CAST_DOUBLE_SIDED:
+    case R3D_SHADOW_CAST_ONLY_DOUBLE_SIDED:
         glDisable(GL_CULL_FACE);
+        break;
+    case R3D_SHADOW_CAST_ONLY_FRONT_SIDE:
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_BACK);
+        break;
+    case R3D_SHADOW_CAST_ONLY_BACK_SIDE:
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_FRONT);
         break;
     case R3D_SHADOW_CAST_DISABLED:
     default:

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -42,6 +42,11 @@
 #define R3D_IS_ACTIVE_LAYERS(bitfield) \
     ((bitfield) == 0 || ((bitfield) & R3D.state.layers) != 0)
 
+#define SHADOW_CAST_ONLY_MASK (R3D_SHADOW_CAST_ONLY | \
+                               R3D_SHADOW_CAST_ONLY_DOUBLE_SIDED | \
+                               R3D_SHADOW_CAST_ONLY_FRONT_SIDE | \
+                               R3D_SHADOW_CAST_ONLY_BACK_SIDE)
+
 /* === Internal Functions Declarations === */
 
 static bool r3d_has_deferred_calls(void);
@@ -992,7 +997,7 @@ void r3d_prepare_cull_drawcalls(void)
     count = (int)R3D.container.aDrawDeferred.count;
 
     for (int i = count - 1; i >= 0; i--) {
-        if (calls->shadowCastMode == R3D_SHADOW_CAST_ONLY) {
+        if ((calls->shadowCastMode & SHADOW_CAST_ONLY_MASK) != 0) {
             calls[i] = calls[--count];
             continue;
         }
@@ -1012,7 +1017,7 @@ void r3d_prepare_cull_drawcalls(void)
     count = (int)R3D.container.aDrawForward.count;
 
     for (int i = count - 1; i >= 0; i--) {
-        if (calls->shadowCastMode == R3D_SHADOW_CAST_ONLY) {
+        if ((calls->shadowCastMode & SHADOW_CAST_ONLY_MASK) != 0) {
             calls[i] = calls[--count];
             continue;
         }
@@ -1032,7 +1037,7 @@ void r3d_prepare_cull_drawcalls(void)
     count = (int)R3D.container.aDrawDeferredInst.count;
 
     for (int i = count - 1; i >= 0; i--) {
-        if (calls->shadowCastMode == R3D_SHADOW_CAST_ONLY) {
+        if ((calls->shadowCastMode & SHADOW_CAST_ONLY_MASK) != 0) {
             calls[i] = calls[--count];
             continue;
         }
@@ -1052,7 +1057,7 @@ void r3d_prepare_cull_drawcalls(void)
     count = (int)R3D.container.aDrawForwardInst.count;
 
     for (int i = count - 1; i >= 0; i--) {
-        if (calls->shadowCastMode == R3D_SHADOW_CAST_ONLY) {
+        if ((calls->shadowCastMode & SHADOW_CAST_ONLY_MASK) != 0) {
             calls[i] = calls[--count];
             continue;
         }


### PR DESCRIPTION
I tired multiple approaches to this, but what I was trying to address was shadow casting modes and face culling having become somewhat inflexible. This allows any combination of enabling/disabling shadow casting and what face culling is used as well as using the object's material to determine face culling.

As I said, I tried different ways to do this (like separate options for casting mode and culling mode) and there still might be a better way to handle this. Open to any feedback, but I do think this functionality should exist.