### PR TITLE
remove piping when processing shaders

### DIFF
--- a/cmake/EmbedShaders.cmake
+++ b/cmake/EmbedShaders.cmake
@@ -8,9 +8,11 @@ function(process_shader shader_file output_file_var)
     add_custom_command(
         OUTPUT "${output_file}"
         COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/generated/include/shaders"
-        COMMAND "${PYTHON_EXECUTABLE}" "${R3D_ROOT_PATH}/scripts/glsl_processor.py" "${shader_file}" | 
-                "${PYTHON_EXECUTABLE}" "${R3D_ROOT_PATH}/scripts/bin2c.py" 
-                --stdin --name "${shader_name}" --mode text "${output_file}"
+        COMMAND "${PYTHON_EXECUTABLE}" "${R3D_ROOT_PATH}/scripts/glsl_processor.py" 
+                "${shader_file}" > "${R3D_ROOT_PATH}/scripts/shader.tmp"
+        COMMAND "${PYTHON_EXECUTABLE}" "${R3D_ROOT_PATH}/scripts/bin2c.py" 
+                --stdin --name "${shader_name}" --mode text "${output_file}" < "${R3D_ROOT_PATH}/scripts/shader.tmp"
+        COMMAND ${CMAKE_COMMAND} -E remove "${R3D_ROOT_PATH}/scripts/shader.tmp"
         DEPENDS "${shader_file}"
         COMMENT "Processing shader: ${shader_file}"
         VERBATIM


### PR DESCRIPTION
As far as I know cmake commands don't support piping, and it was causing errors. There's likely a cleaner way to handle this than using a temporary file (a wrapper script that calls the other two, or possibly combining them) but this does fix the issue.