### PR TITLE
improve texture filtering

### DIFF
--- a/src/r3d_model.c
+++ b/src/r3d_model.c
@@ -2353,7 +2353,7 @@ static Image r3d_load_assimp_image(
     return image;
 }
 
-static r3d_apply_texture_filtering(Texture2D* texture)
+static void r3d_apply_texture_filtering(Texture2D* texture)
 {
     if (R3D.state.loading.textureFilter > TEXTURE_FILTER_BILINEAR) {
         GenTextureMipmaps(texture);


### PR DESCRIPTION
Raylib's `SetTextureFilter` is very specific with what it sets depending on the filtering mode used and does not set `GL_TEXTURE_MIN_FILTER` and `GL_TEXTURE_MAG_FILTER` when setting any anisotropic filtering mode. Calling `SetTextureFilter` with `TEXTURE_FILTER_TRILINEAR` will set the values the way you would expect, and then anisotropic filtering can be set after that.

It doesn't read very well and I've actually had code to handle this without using Raylib's functions since before I started using R3D. I might adapt that and replace this later, if that would be wanted.

Current result of R3D_SetTextureFilter(TEXTURE_FILTER_ANISOTROPIC_16X)
<img width="1282" height="752" alt="sa" src="https://github.com/user-attachments/assets/230e67d8-d2b2-44be-ad60-caa8476152a4" />

And with this change
<img width="1282" height="752" alt="sb" src="https://github.com/user-attachments/assets/29fe73e9-e2bf-485e-88f3-bf873a4acd79" />
