### PR TITLE
remove incorrect albedo in ambient light

### DIFF
--- a/shaders/screen/ambient.frag
+++ b/shaders/screen/ambient.frag
@@ -179,7 +179,7 @@ void main()
     vec3 kD = (1.0 - F0) * (1.0 - metalness);
     vec3 ambient = kD * uAmbientColor;
     ambient += F0 * uAmbientColor;
-    ambient *= albedo * occlusion;
+    ambient *= occlusion;
 
     /* --- Output --- */
 


### PR DESCRIPTION
The ambient light calculated here goes into the diffuse render target which is used in the scene shader where albedo is applied. Applying it in the shader means that the albedo was affecting ambient light twice.