### PR TITLE
Color and energy control for ambient light

### DIFF
--- a/examples/basic.c
+++ b/examples/basic.c
@@ -25,6 +25,8 @@ const char* Init(void)
 
     /* --- Setup the scene lighting --- */
 
+    R3D_SetAmbientColor((Color) { 10, 10, 10, 255 });
+
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
     {
         R3D_LightLookAt(light, (Vector3) { 0, 10, 5 }, (Vector3) { 0 });

--- a/examples/directional.c
+++ b/examples/directional.c
@@ -39,6 +39,8 @@ const char* Init(void)
 
     /* --- Setup the scene lighting --- */
 
+    R3D_SetAmbientColor((Color) { 10, 10, 10, 255 });
+
     R3D_SetSceneBounds(
         (BoundingBox) {
             .min = { -100, -1, -100 },

--- a/examples/transparency.c
+++ b/examples/transparency.c
@@ -62,6 +62,8 @@ const char* Init(void)
 
     /* --- Configure lighting --- */
 
+    R3D_SetAmbientColor((Color) { 10, 10, 10, 255 });
+
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
     {
         R3D_LightLookAt(light, (Vector3) { 0, 10, 5 }, (Vector3) { 0 });

--- a/include/r3d.h
+++ b/include/r3d.h
@@ -2164,6 +2164,16 @@ R3DAPI void R3D_SetBackgroundColor(Color color);
 R3DAPI void R3D_SetAmbientColor(Color color);
 
 /**
+ * @brief Sets the energy level for ambient light when no skybox is enabled.
+ *
+ * This function defines the ambient light energy to be used when no skybox is active.
+ * Applied multiplicatively to the base ambient color.
+ *
+ * @param energy The energy to set for ambient light.
+ */
+R3DAPI void R3D_SetAmbientEnergy(float energy);
+
+/**
  * @brief Enables a skybox for the scene.
  *
  * This function enables a skybox in the scene, replacing the default background with

--- a/shaders/raster/forward.frag
+++ b/shaders/raster/forward.frag
@@ -64,7 +64,7 @@ uniform float uOcclusion;
 uniform float uRoughness;
 uniform float uMetalness;
 
-uniform vec3 uAmbientColor;
+uniform vec3 uAmbientLight;
 uniform vec3 uEmissionColor;
 
 uniform samplerCube uCubeIrradiance;
@@ -314,7 +314,7 @@ void main()
 
     /* Compute ambient - (IBL diffuse) */
 
-    vec3 ambient = uAmbientColor;
+    vec3 ambient = uAmbientLight;
 
     if (uHasSkybox)
     {
@@ -332,7 +332,7 @@ void main()
         //       but it's to at least simulate some specularity, otherwise the 
         //       result would look poor for metals...
         ambient = (1.0 - F0) * (1.0 - metalness) * ambient;
-        ambient += F0 * uAmbientColor;
+        ambient += F0 * uAmbientLight;
     }
 
     /* Compute ambient occlusion map */

--- a/shaders/screen/ambient.frag
+++ b/shaders/screen/ambient.frag
@@ -138,7 +138,7 @@ noperspective in vec2 vTexCoord;
 uniform sampler2D uTexAlbedo;
 uniform sampler2D uTexSSAO;
 uniform sampler2D uTexORM;
-uniform vec3 uAmbientColor;
+uniform vec3 uAmbientLight;
 uniform float uSSAOPower;
 
 /* === Fragments === */
@@ -177,8 +177,8 @@ void main()
 
     vec3 F0 = PBR_ComputeF0(metalness, 0.5, albedo);
     vec3 kD = (1.0 - F0) * (1.0 - metalness);
-    vec3 ambient = kD * uAmbientColor;
-    ambient += F0 * uAmbientColor;
+    vec3 ambient = kD * uAmbientLight;
+    ambient += F0 * uAmbientLight;
     ambient *= occlusion;
 
     /* --- Output --- */

--- a/src/details/r3d_shaders.h
+++ b/src/details/r3d_shaders.h
@@ -184,7 +184,7 @@ typedef struct {
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
     r3d_shader_uniform_float_t uMetalness;
-    r3d_shader_uniform_vec3_t uAmbientColor;
+    r3d_shader_uniform_vec3_t uAmbientLight;
     r3d_shader_uniform_vec3_t uEmissionColor;
     r3d_shader_uniform_samplerCube_t uCubeIrradiance;
     r3d_shader_uniform_samplerCube_t uCubePrefilter;
@@ -257,7 +257,7 @@ typedef struct {
     r3d_shader_uniform_sampler2D_t uTexSSAO;
     r3d_shader_uniform_sampler2D_t uTexORM;
     r3d_shader_uniform_float_t uSSAOPower;
-    r3d_shader_uniform_vec3_t uAmbientColor;
+    r3d_shader_uniform_vec3_t uAmbientLight;
 } r3d_shader_screen_ambient_t;
 
 typedef struct {

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -117,7 +117,7 @@ void R3D_Init(int resWidth, int resHeight, unsigned int flags)
     // Environment data
     R3D.env.backgroundColor = (Vector3) { 0.2f, 0.2f, 0.2f };
     R3D.env.ambientColor = (Color){ 0, 0, 0, 255 };
-    R3D.env.ambientEnergy = 3.0f;
+    R3D.env.ambientEnergy = 1.0f;
     R3D.env.ambientLight = (Vector3){ 0.0f, 0.0f, 0.0f };
     R3D.env.quatSky = QuaternionIdentity();
     R3D.env.useSky = false;

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -116,7 +116,9 @@ void R3D_Init(int resWidth, int resHeight, unsigned int flags)
 
     // Environment data
     R3D.env.backgroundColor = (Vector3) { 0.2f, 0.2f, 0.2f };
-    R3D.env.ambientColor = (Vector3) { 0.2f, 0.2f, 0.2f };
+    R3D.env.ambientColor = (Color){ 0, 0, 0, 255 };
+    R3D.env.ambientEnergy = 3.0f;
+    R3D.env.ambientLight = (Vector3){ 0.0f, 0.0f, 0.0f };
     R3D.env.quatSky = QuaternionIdentity();
     R3D.env.useSky = false;
     R3D.env.skyBackgroundIntensity = 1.0f;
@@ -1451,7 +1453,7 @@ void r3d_pass_deferred_ambient(void)
                     r3d_shader_bind_sampler2D(screen.ambient, uTexSSAO, R3D.texture.white);
                 }
 
-                r3d_shader_set_vec3(screen.ambient, uAmbientColor, R3D.env.ambientColor);
+                r3d_shader_set_vec3(screen.ambient, uAmbientLight, R3D.env.ambientLight);
                 r3d_shader_set_float(screen.ambient, uSSAOPower, R3D.env.ssaoPower);
 
                 r3d_primitive_bind_and_draw_screen();
@@ -1907,7 +1909,7 @@ void r3d_pass_scene_forward(void)
                 r3d_shader_set_float(raster.forward, uSkyboxReflectIntensity, R3D.env.skyReflectIntensity);
             }
             else {
-                r3d_shader_set_vec3(raster.forward, uAmbientColor, R3D.env.ambientColor);
+                r3d_shader_set_vec3(raster.forward, uAmbientLight, R3D.env.ambientLight);
                 r3d_shader_set_int(raster.forward, uHasSkybox, false);
             }
 

--- a/src/r3d_environment.c
+++ b/src/r3d_environment.c
@@ -31,9 +31,18 @@ void R3D_SetBackgroundColor(Color color)
 
 void R3D_SetAmbientColor(Color color)
 {
-	R3D.env.ambientColor.x = (float)color.r / 255;
-	R3D.env.ambientColor.y = (float)color.g / 255;
-	R3D.env.ambientColor.z = (float)color.b / 255;
+	R3D.env.ambientColor = color;
+	R3D.env.ambientLight.x = (float)color.r / 255 * R3D.env.ambientEnergy;
+	R3D.env.ambientLight.y = (float)color.g / 255 * R3D.env.ambientEnergy;
+	R3D.env.ambientLight.z = (float)color.b / 255 * R3D.env.ambientEnergy;
+}
+
+void R3D_SetAmbientEnergy(float energy)
+{
+	R3D.env.ambientEnergy = energy;
+	R3D.env.ambientLight.x = (float)R3D.env.ambientColor.r / 255 * energy;
+	R3D.env.ambientLight.y = (float)R3D.env.ambientColor.g / 255 * energy;
+	R3D.env.ambientLight.z = (float)R3D.env.ambientColor.b / 255 * energy;
 }
 
 void R3D_EnableSkybox(R3D_Skybox skybox)

--- a/src/r3d_state.c
+++ b/src/r3d_state.c
@@ -1288,7 +1288,7 @@ void r3d_shader_load_raster_forward(void)
     r3d_shader_get_location(raster.forward, uOcclusion);
     r3d_shader_get_location(raster.forward, uRoughness);
     r3d_shader_get_location(raster.forward, uMetalness);
-    r3d_shader_get_location(raster.forward, uAmbientColor);
+    r3d_shader_get_location(raster.forward, uAmbientLight);
     r3d_shader_get_location(raster.forward, uEmissionColor);
     r3d_shader_get_location(raster.forward, uCubeIrradiance);
     r3d_shader_get_location(raster.forward, uCubePrefilter);
@@ -1510,7 +1510,7 @@ void r3d_shader_load_screen_ambient(void)
     r3d_shader_get_location(screen.ambient, uTexAlbedo);
     r3d_shader_get_location(screen.ambient, uTexSSAO);
     r3d_shader_get_location(screen.ambient, uTexORM);
-    r3d_shader_get_location(screen.ambient, uAmbientColor);
+    r3d_shader_get_location(screen.ambient, uAmbientLight);
     r3d_shader_get_location(screen.ambient, uSSAOPower);
 
     r3d_shader_enable(screen.ambient);

--- a/src/r3d_state.h
+++ b/src/r3d_state.h
@@ -206,7 +206,10 @@ extern struct R3D_State {
     struct {
 
         Vector3 backgroundColor;        // Used as default albedo color when skybox is disabled (raster pass)
-        Vector3 ambientColor;           // Used as default ambient light when skybox is disabled (light pass)
+
+        Color ambientColor;             // Base color of ambient light used when skybox is disabled (light pass)
+        float ambientEnergy;            // Multiplicative energy for ambient light when skybox is disabled (light pass)
+        Vector3 ambientLight;           // Total ambient light contribution when skybox is disabled (light pass)
                                         
         Quaternion quatSky;             // Rotation of the skybox (raster / light passes)
         R3D_Skybox sky;                 // Skybox textures (raster / light passes)


### PR DESCRIPTION
Breaks standard ambient light into a color and energy value to give more control, along with treating it more as an actual light source.

I did set the default ambient lighting to zero. I don't think having added ambient light by default makes any more sense than adding a default light of any type. I did review the examples to make sure this wasn't causing any problems there.

I can see users getting a black screen and not understanding that it's due to there being no default lighting as a reasonable argument for having some default ambient light, but if nothing else I think the previous value was too high.