### PR TITLE
Added BLEND_PREMULTIPLIED_ALPHA and DEPTH_MODE

### DIFF
--- a/include/r3d.h
+++ b/include/r3d.h
@@ -113,10 +113,11 @@ typedef unsigned int R3D_Layer;
  * @note The blend mode is applied only if you are in forward rendering mode or auto-detect mode.
  */
 typedef enum R3D_BlendMode {
-    R3D_BLEND_OPAQUE,          ///< No blending, the source color fully replaces the destination color.
-    R3D_BLEND_ALPHA,           ///< Alpha blending: source color is blended with the destination based on alpha value.
-    R3D_BLEND_ADDITIVE,        ///< Additive blending: source color is added to the destination, making bright effects.
-    R3D_BLEND_MULTIPLY         ///< Multiply blending: source color is multiplied with the destination, darkening the image.
+    R3D_BLEND_OPAQUE,               ///< No blending, the source color fully replaces the destination color.
+    R3D_BLEND_ALPHA,                ///< Alpha blending: source color is blended with the destination based on alpha value.
+    R3D_BLEND_ADDITIVE,             ///< Additive blending: source color is added to the destination, making bright effects.
+    R3D_BLEND_MULTIPLY,             ///< Multiply blending: source color is multiplied with the destination, darkening the image.
+    R3D_BLEND_PREMULTIPLIED_ALPHA   ///< Premultiplied alpha blending: source color is blended with the destination assuming the source color is already multiplied by its alpha.
 } R3D_BlendMode;
 
 /**
@@ -148,6 +149,12 @@ typedef enum R3D_ShadowCastMode {
     R3D_SHADOW_CAST_ONLY_BACK_SIDE,     ///< The object only casts shadows with only back faces, culling front faces.
     R3D_SHADOW_CAST_DISABLED            ///< The object does not cast shadows at all.
 } R3D_ShadowCastMode;
+
+typedef enum R3D_DepthMode {
+    R3D_DEPTH_READ_WRITE,       ///< Enable depth testing and writing to the depth buffer.
+    R3D_DEPTH_READ_ONLY,        ///< Enable depth testing but disable writing to the depth buffer.
+    R3D_DEPTH_DISABLED          ///< Disable depth testing and writing to the depth buffer.
+} R3D_DepthMode;
 
 /**
  * @brief Defines billboard modes for 3D objects.
@@ -282,6 +289,7 @@ typedef struct R3D_Mesh {
     int boneCount;                        /**< Number of bones (and matrices) that affect the mesh. */
 
     R3D_ShadowCastMode shadowCastMode;    /**< Shadow casting mode for the mesh. */
+    R3D_DepthMode depthMode;              /**< Depth testing mode for the mesh. */
 
     BoundingBox aabb;                     /**< Axis-Aligned Bounding Box in local space. */
 

--- a/src/details/r3d_drawcall.h
+++ b/src/details/r3d_drawcall.h
@@ -41,6 +41,7 @@ typedef struct {
     Matrix transform;
     R3D_Material material;
     R3D_ShadowCastMode shadowCastMode;
+    R3D_DepthMode depthMode;
 
     r3d_drawcall_geometry_e geometryType;
     r3d_drawcall_render_mode_e renderMode;


### PR DESCRIPTION
- Added BLEND_PREMULTIPLIED_ALPHA when drawing multiple alpha model that need it.
- Added R3D_DepthMode to control depth per mesh, default enabled on test and mask.

Did add these since a model of mine require it, maybe that will be useful for some people too :)

- Example disabled (or before implementation even with alpha or additive enabled):
<img width="881" height="668" alt="Capture d&#39;écran 2025-11-12 200011" src="https://github.com/user-attachments/assets/640903e9-f62f-4985-999a-761afc493d5e" />
<img width="1916" height="1111" alt="Capture d&#39;écran 2025-11-12 200023" src="https://github.com/user-attachments/assets/019b3c73-3d7b-42c9-a7a1-861878cf7cb6" />
<img width="871" height="567" alt="Capture d&#39;écran 2025-11-12 200031" src="https://github.com/user-attachments/assets/79770092-4948-421a-aed0-d4f67c08f565" />
- Enabled:
<img width="1917" height="1045" alt="Capture d&#39;écran 2025-11-12 195948" src="https://github.com/user-attachments/assets/b24f7415-884c-4492-adb3-773de5ce4710" />
<img width="1917" height="907" alt="Capture d&#39;écran 2025-11-12 195942" src="https://github.com/user-attachments/assets/d476fb9b-72f7-4caa-827c-b0f8418c1e2f" />
