### PR TITLE
Review transparency and depth modes

### DIFF
--- a/examples/decal.c
+++ b/examples/decal.c
@@ -125,7 +125,6 @@ const char* Init(void)
 
     decal.material = R3D_GetDefaultMaterial();
     decal.material.albedo.texture = texture;
-    decal.material.blendMode = R3D_BLEND_ALPHA;
 
     /* --- Create a plane along with the transformation matrices to place them to represent a room --- */
 

--- a/examples/transparency.c
+++ b/examples/transparency.c
@@ -1,4 +1,5 @@
 #include "./common.h"
+#include "r3d/r3d_material.h"
 
 /* === Resources === */
 
@@ -23,14 +24,16 @@ const char* Init(void)
     mesh = R3D_GenMeshCube(1, 1, 1);
     cube = R3D_LoadModelFromMesh(&mesh);
 
-    cube.meshes[0].shadowCastMode = R3D_SHADOW_CAST_DISABLED;
+    // NOTE: Alpha transparency mode don't cast shadows
+    cube.materials[0].transparencyMode = R3D_TRANSPARENCY_ALPHA;
+
+    //cube.materials[0].transparencyMode = R3D_TRANSPARENCY_PREPASS;
+    //cube.meshes[0].shadowCastMode = R3D_SHADOW_CAST_DISABLED;
 
     cube.materials[0].albedo.color = (Color){ 100, 100, 255, 100 };
     cube.materials[0].orm.occlusion = 1.0f;
     cube.materials[0].orm.roughness = 0.2f;
     cube.materials[0].orm.metalness = 0.2f;
-
-    cube.materials[0].blendMode = R3D_BLEND_ALPHA;
 
     /* --- Load plane model --- */
 

--- a/include/r3d/r3d_material.h
+++ b/include/r3d/r3d_material.h
@@ -22,51 +22,54 @@
 // ========================================
 
 /**
- * @brief Blend modes for rendering.
+ * @brief Billboard modes.
+ *
+ * This enumeration defines how a 3D object aligns itself relative to the camera.
+ * It provides options to disable billboarding or to enable specific modes of alignment.
+ */
+typedef enum R3D_BillboardMode {
+    R3D_BILLBOARD_DISABLED,         ///< Billboarding is disabled; the object retains its original orientation.
+    R3D_BILLBOARD_FRONT,            ///< Full billboarding; the object fully faces the camera, rotating on all axes.
+    R3D_BILLBOARD_Y_AXIS            /**< Y-axis constrained billboarding; the object rotates only around the Y-axis,
+                                         keeping its "up" orientation fixed. This is suitable for upright objects like characters or signs. */
+} R3D_BillboardMode;
+
+/**
+ * @brief Transparency modes.
+ *
+ * This enumeration defines how a material handles transparency during rendering.
+ * It controls whether transparency is disabled, rendered using a depth pre-pass,
+ * or rendered with standard alpha blending.
+ */
+typedef enum R3D_TransparencyMode {
+    R3D_TRANSPARENCY_DISABLED,      ///< No transparency, supports alpha cutoff.
+    R3D_TRANSPARENCY_PREPASS,       ///< Supports transparency with shadows. Writes shadows for alpha > 0.1 and depth for alpha > 0.99.
+    R3D_TRANSPARENCY_ALPHA,         ///< Standard transparency without shadows or depth writes.
+} R3D_TransparencyMode;
+
+/**
+ * @brief Blend modes.
  *
  * Defines common blending modes used in 3D rendering to combine source and destination colors.
  * @note The blend mode is applied only if you are in forward rendering mode or auto-detect mode.
  */
 typedef enum R3D_BlendMode {
-    R3D_BLEND_OPAQUE,               ///< No blending, the source color fully replaces the destination color.
-    R3D_BLEND_ALPHA,                ///< Alpha blending: source color is blended with the destination based on alpha value.
+    R3D_BLEND_MIX,                  ///< Default mode: the result will be opaque or alpha blended depending on the transparency mode.
     R3D_BLEND_ADDITIVE,             ///< Additive blending: source color is added to the destination, making bright effects.
     R3D_BLEND_MULTIPLY,             ///< Multiply blending: source color is multiplied with the destination, darkening the image.
     R3D_BLEND_PREMULTIPLIED_ALPHA   ///< Premultiplied alpha blending: source color is blended with the destination assuming the source color is already multiplied by its alpha.
 } R3D_BlendMode;
 
 /**
- * @brief Defines the depth mode used to render the mesh.
- */
-typedef enum R3D_DepthMode {
-    R3D_DEPTH_READ_WRITE,       ///< Enable depth testing and writing to the depth buffer.
-    R3D_DEPTH_READ_ONLY,        ///< Enable depth testing but disable writing to the depth buffer.
-    R3D_DEPTH_DISABLED          ///< Disable depth testing and writing to the depth buffer.
-} R3D_DepthMode;
-
-/**
- * @brief Face culling modes for a mesh.
+ * @brief Face culling modes.
  *
  * Specifies which faces of a geometry are discarded during rendering based on their winding order.
  */
 typedef enum R3D_CullMode {
-    R3D_CULL_NONE,   ///< No culling; all faces are rendered.
-    R3D_CULL_BACK,   ///< Cull back-facing polygons (faces with clockwise winding order).
-    R3D_CULL_FRONT   ///< Cull front-facing polygons (faces with counter-clockwise winding order).
+    R3D_CULL_NONE,              ///< No culling; all faces are rendered.
+    R3D_CULL_BACK,              ///< Cull back-facing polygons (faces with clockwise winding order).
+    R3D_CULL_FRONT              ///< Cull front-facing polygons (faces with counter-clockwise winding order).
 } R3D_CullMode;
-
-/**
- * @brief Defines billboard modes for 3D objects.
- *
- * This enumeration defines how a 3D object aligns itself relative to the camera.
- * It provides options to disable billboarding or to enable specific modes of alignment.
- */
-typedef enum R3D_BillboardMode {
-    R3D_BILLBOARD_DISABLED,     ///< Billboarding is disabled; the object retains its original orientation.
-    R3D_BILLBOARD_FRONT,        ///< Full billboarding; the object fully faces the camera, rotating on all axes.
-    R3D_BILLBOARD_Y_AXIS        /**< Y-axis constrained billboarding; the object rotates only around the Y-axis,
-                                     keeping its "up" orientation fixed. This is suitable for upright objects like characters or signs. */
-} R3D_BillboardMode;
 
 // ========================================
 // STRUCTS TYPES
@@ -102,23 +105,22 @@ typedef struct R3D_Material {
         float metalness;        ///< Metalness multiplier.
     } orm;
 
-    R3D_BlendMode blendMode;              ///< Blend mode used for rendering.
-    R3D_DepthMode depthMode;              ///< Depth mode used for rendering (ignored for shadows and decals; disable shadows at mesh level to avoid shadow map writes).
-    R3D_CullMode cullMode;                ///< Face culling mode used for rendering.
+    R3D_TransparencyMode transparencyMode;  ///< Transparency mode applied to the object.
+    R3D_BillboardMode billboardMode;        ///< Billboard mode applied to the object.
+    R3D_BlendMode blendMode;                ///< Blend mode used for rendering.
+    R3D_CullMode cullMode;                  ///< Face culling mode used for rendering.
 
-    R3D_BillboardMode billboardMode;      ///< Billboard mode applied to the object.
+    Vector2 uvOffset;                       /**< UV offset applied to the texture coordinates.
+                                             *  For models, this can be set manually.
+                                             *  For sprites, this value is overridden automatically.
+                                             */
 
-    Vector2 uvOffset;                     /**< UV offset applied to the texture coordinates.
-                                           *  For models, this can be set manually.
-                                           *  For sprites, this value is overridden automatically.
-                                           */
+    Vector2 uvScale;                        /**< UV scale factor applied to the texture coordinates.
+                                             *  For models, this can be set manually.
+                                             *  For sprites, this value is overridden automatically.
+                                             */
 
-    Vector2 uvScale;                      /**< UV scale factor applied to the texture coordinates.
-                                           *  For models, this can be set manually.
-                                           *  For sprites, this value is overridden automatically.
-                                           */
-
-    float alphaCutoff;          ///< Alpha threshold below which fragments are discarded.
+    float alphaCutoff;          ///< Alpha threshold below which fragments are discarded during opaque rendering.
 
 } R3D_Material;
 

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -209,17 +209,10 @@ float ShadowOmni(int i, float cNdotL, mat2 diskRot)
 
 void main()
 {
-    /* Sample albedo texture */
+    /* Sample material maps */
 
     vec4 albedo = vColor * texture(uTexAlbedo, vTexCoord);
-    if (albedo.a < uAlphaCutoff) discard;
-
-    /* Sample emission texture */
-
     vec3 emission = uEmissionEnergy * (uEmissionColor * texture(uTexEmission, vTexCoord).rgb);
-
-    /* Sample ORM texture and extract values */
-
     vec3 orm = texture(uTexORM, vTexCoord).rgb;
 
     float occlusion = uOcclusion * orm.x;

--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -31,7 +31,7 @@ struct r3d_draw R3D_MOD_DRAW;
     ((call)->material.transparencyMode == R3D_TRANSPARENCY_PREPASS)
 
 #define IS_CALL_FORWARD(call)                                           \
-    ((call)->material.transparencyMode != R3D_TRANSPARENCY_DISABLED ||  \
+    ((call)->material.transparencyMode == R3D_TRANSPARENCY_ALPHA ||     \
      (call)->material.blendMode != R3D_BLEND_MIX)
 
 // ========================================
@@ -286,14 +286,19 @@ void r3d_draw_apply_cull_mode(R3D_CullMode mode)
     }
 }
 
-void r3d_draw_apply_blend_mode(R3D_BlendMode blend)
+void r3d_draw_apply_blend_mode(R3D_BlendMode blend, R3D_TransparencyMode transparency)
 {
     switch (blend) {
     case R3D_BLEND_MIX:
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         break;
     case R3D_BLEND_ADDITIVE:
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+        if (transparency == R3D_TRANSPARENCY_DISABLED) {
+            glBlendFunc(GL_ONE, GL_ONE);
+        }
+        else {
+            glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+        }
         break;
     case R3D_BLEND_MULTIPLY:
         glBlendFunc(GL_DST_COLOR, GL_ZERO);

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -210,7 +210,7 @@ void r3d_draw_apply_cull_mode(R3D_CullMode mode);
  * Assumes GL_BLEND is already enabled and only sets the blend equations.
  * The MIX blend mode always uses standard alpha blending.
  */
-void r3d_draw_apply_blend_mode(R3D_BlendMode blend);
+void r3d_draw_apply_blend_mode(R3D_BlendMode blend, R3D_TransparencyMode transparency);
 
 /*
  * Configure face culling for shadow rendering depending on shadow casting mode.

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -134,7 +134,14 @@ static int get_or_create_fbo(const r3d_target_t* targets, int count)
     }
 
     fbo->count = count;
-    glDrawBuffers(locCount, glColor);
+
+    if (locCount > 0) {
+        glDrawBuffers(locCount, glColor);
+    }
+    else {
+        glDrawBuffer(GL_NONE);
+        glReadBuffer(GL_NONE);
+    }
 
     GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     if (status != GL_FRAMEBUFFER_COMPLETE) {

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -654,7 +654,7 @@ void raster_decal(const r3d_draw_call_t* call, const Matrix* matVP)
 
     /* --- Applying material parameters that are independent of shaders --- */
 
-    r3d_draw_apply_blend_mode(call->material.blendMode);
+    r3d_draw_apply_blend_mode(call->material.blendMode, call->material.transparencyMode);
 
     /* --- Disable face culling to avoid issues when camera is inside the decal bounding mesh --- */
     // TODO: Implement check for if camera is inside the mesh and apply the appropriate face culling / depth testing
@@ -825,7 +825,7 @@ void raster_forward(const r3d_draw_call_t* call, const Matrix* matVP)
 
     /* --- Applying material parameters that are independent of shaders --- */
 
-    r3d_draw_apply_blend_mode(call->material.blendMode);
+    r3d_draw_apply_blend_mode(call->material.blendMode, call->material.transparencyMode);
     r3d_draw_apply_cull_mode(call->material.cullMode);
 
     /* --- Rendering the object corresponding to the draw call --- */

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -23,7 +23,6 @@
 #include "./modules/r3d_shader.h"
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_cache.h"
-#include "r3d/r3d_core.h"
 #include "./modules/r3d_draw.h"
 
 // ========================================
@@ -44,24 +43,7 @@
 // INTERNAL FUNCTIONS
 // ========================================
 
-static void upload_bone_matrices(const r3d_draw_call_t* call, int bindingSlot)
-{
-    const R3D_Skeleton* skeleton = NULL;
-    const Matrix* currentPose = NULL;
-
-    if (call->player != NULL) {
-        skeleton = &call->player->skeleton;
-        currentPose = call->player->currentPose;
-    }
-    else {
-        skeleton = &call->skeleton;
-        currentPose = call->skeleton.bindPose;
-    }
-
-    static Matrix bones[R3D_STORAGE_MAX_BONE_MATRICES];
-    r3d_matrix_multiply_batch(bones, skeleton->boneOffsets, currentPose, skeleton->boneCount);
-    r3d_storage_use(R3D_STORAGE_BONE_MATRICES, bindingSlot, bones, skeleton->boneCount);
-}
+static void upload_bone_matrices(const r3d_draw_call_t* call, int bindingSlot);
 
 static void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* matVP);
 static void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* matVP);
@@ -79,6 +61,7 @@ static void pass_deferred_ambient(r3d_target_t ssaoSource);
 static void pass_deferred_lights(r3d_target_t ssaoSource);
 static void pass_deferred_compose(r3d_target_t sceneTarget);
 
+static void pass_scene_prepass(void);
 static void pass_scene_forward(r3d_target_t sceneTarget);
 static void pass_scene_background(r3d_target_t sceneTarget);
 
@@ -166,13 +149,12 @@ void R3D_End(void)
     }
 
     if (R3D_CACHE_FLAGS_HAS(state, R3D_FLAG_OPAQUE_SORTING)) {
-        r3d_draw_sort_list(R3D_DRAW_DEFERRED, R3D_CACHE_GET(viewport.viewPosition), R3D_DRAW_SORT_BACK_TO_FRONT);
-        r3d_draw_sort_list(R3D_DRAW_DEFERRED_INST, R3D_CACHE_GET(viewport.viewPosition), R3D_DRAW_SORT_BACK_TO_FRONT);
+        r3d_draw_sort_list(R3D_DRAW_DEFERRED, R3D_CACHE_GET(viewport.viewPosition), R3D_DRAW_SORT_FRONT_TO_BACK);
     }
 
     if (R3D_CACHE_FLAGS_HAS(state, R3D_FLAG_TRANSPARENT_SORTING)) {
-        r3d_draw_sort_list(R3D_DRAW_FORWARD, R3D_CACHE_GET(viewport.viewPosition), R3D_DRAW_SORT_FRONT_TO_BACK);
-        r3d_draw_sort_list(R3D_DRAW_FORWARD_INST, R3D_CACHE_GET(viewport.viewPosition), R3D_DRAW_SORT_FRONT_TO_BACK);
+        r3d_draw_sort_list(R3D_DRAW_PREPASS, R3D_CACHE_GET(viewport.viewPosition), R3D_DRAW_SORT_BACK_TO_FRONT);
+        r3d_draw_sort_list(R3D_DRAW_FORWARD, R3D_CACHE_GET(viewport.viewPosition), R3D_DRAW_SORT_BACK_TO_FRONT);
     }
 
     /* --- Opaque and decal rendering with deferred lighting and composition --- */
@@ -204,7 +186,8 @@ void R3D_End(void)
 
     pass_scene_background(sceneTarget);
 
-    if (R3D_DRAW_HAS_FORWARD) {
+    if (R3D_DRAW_HAS_FORWARD || R3D_DRAW_HAS_PREPASS) {
+        if (R3D_DRAW_HAS_PREPASS) pass_scene_prepass();
         pass_scene_forward(sceneTarget);
     }
 
@@ -253,12 +236,7 @@ void R3D_DrawMesh(const R3D_Mesh* mesh, const R3D_Material* material, Matrix tra
     drawCall.transform = transform;
     drawCall.material = material ? *material : R3D_GetDefaultMaterial();
 
-    if (drawCall.material.blendMode == R3D_BLEND_OPAQUE) {
-        r3d_draw_push(&drawCall, R3D_DRAW_DEFERRED);
-    }
-    else {
-        r3d_draw_push(&drawCall, R3D_DRAW_FORWARD);
-    }
+    r3d_draw_push(&drawCall, false);
 }
 
 void R3D_DrawMeshInstanced(const R3D_Mesh* mesh, const R3D_Material* material, const Matrix* instanceTransforms, int instanceCount)
@@ -303,12 +281,7 @@ void R3D_DrawMeshInstancedPro(const R3D_Mesh* mesh, const R3D_Material* material
     drawCall.instanced.colors = instanceColors;
     drawCall.instanced.count = instanceCount;
 
-    if (drawCall.material.blendMode == R3D_BLEND_OPAQUE) {
-        r3d_draw_push(&drawCall, R3D_DRAW_DEFERRED_INST);
-    }
-    else {
-        r3d_draw_push(&drawCall, R3D_DRAW_FORWARD_INST);
-    }
+    r3d_draw_push(&drawCall, false);
 }
 
 void R3D_DrawModel(const R3D_Model* model, Vector3 position, float scale)
@@ -354,12 +327,7 @@ void R3D_DrawModelPro(const R3D_Model* model, Matrix transform)
         drawCall.skeleton = model->skeleton;
         drawCall.material = material ? *material : R3D_GetDefaultMaterial();
 
-        if (drawCall.material.blendMode == R3D_BLEND_OPAQUE) {
-            r3d_draw_push(&drawCall, R3D_DRAW_DEFERRED);
-        }
-        else {
-            r3d_draw_push(&drawCall, R3D_DRAW_FORWARD);
-        }
+        r3d_draw_push(&drawCall, false);
     }
 }
 
@@ -417,12 +385,7 @@ void R3D_DrawModelInstancedPro(const R3D_Model* model,
         drawCall.instanced.colors = instanceColors;
         drawCall.instanced.count = instanceCount;
 
-        if (drawCall.material.blendMode == R3D_BLEND_OPAQUE) {
-            r3d_draw_push(&drawCall, R3D_DRAW_DEFERRED_INST);
-        }
-        else {
-            r3d_draw_push(&drawCall, R3D_DRAW_FORWARD_INST);
-        }
+        r3d_draw_push(&drawCall, false);
     }
 }
 
@@ -437,7 +400,7 @@ void R3D_DrawDecal(const R3D_Decal* decal, Matrix transform)
     drawCall.mesh.aabb.min = (Vector3) {-0.5f, -0.5f, -0.5f};
     drawCall.mesh.aabb.max = (Vector3) {+0.5f, +0.5f, +0.5f};
 
-    r3d_draw_push(&drawCall, R3D_DRAW_DECAL);
+    r3d_draw_push(&drawCall, true);
 }
 
 void R3D_DrawDecalInstanced(const R3D_Decal* decal, const Matrix* instanceTransforms, int instanceCount)
@@ -463,7 +426,7 @@ void R3D_DrawDecalInstanced(const R3D_Decal* decal, const Matrix* instanceTransf
     drawCall.instanced.colors = NULL;
     drawCall.instanced.count = instanceCount;
 
-    r3d_draw_push(&drawCall, R3D_DRAW_DECAL_INST);
+    r3d_draw_push(&drawCall, true);
 }
 
 void R3D_DrawParticleSystem(const R3D_ParticleSystem* system, const R3D_Mesh* mesh, const R3D_Material* material)
@@ -488,6 +451,25 @@ void R3D_DrawParticleSystemEx(const R3D_ParticleSystem* system, const R3D_Mesh* 
 // ========================================
 // INTERNAL FUNCTIONS
 // ========================================
+
+static void upload_bone_matrices(const r3d_draw_call_t* call, int bindingSlot)
+{
+    const R3D_Skeleton* skeleton = NULL;
+    const Matrix* currentPose = NULL;
+
+    if (call->player != NULL) {
+        skeleton = &call->player->skeleton;
+        currentPose = call->player->currentPose;
+    }
+    else {
+        skeleton = &call->skeleton;
+        currentPose = call->skeleton.bindPose;
+    }
+
+    static Matrix bones[R3D_STORAGE_MAX_BONE_MATRICES];
+    r3d_matrix_multiply_batch(bones, skeleton->boneOffsets, currentPose, skeleton->boneCount);
+    r3d_storage_use(R3D_STORAGE_BONE_MATRICES, bindingSlot, bones, skeleton->boneCount);
+}
 
 void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* matVP)
 {
@@ -522,7 +504,13 @@ void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* matVP)
 
     R3D_SHADER_BIND_SAMPLER_2D(scene.depth, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
     R3D_SHADER_SET_FLOAT(scene.depth, uAlpha, ((float)call->material.albedo.color.a / 255));
-    R3D_SHADER_SET_FLOAT(scene.depth, uAlphaCutoff, call->material.alphaCutoff);
+
+    if (call->material.transparencyMode == R3D_TRANSPARENCY_PREPASS) {
+        R3D_SHADER_SET_FLOAT(scene.depth, uAlphaCutoff, shadow ? 0.1f : 0.99f);
+    }
+    else {
+        R3D_SHADER_SET_FLOAT(scene.depth, uAlphaCutoff, call->material.alphaCutoff);
+    }
 
     /* --- Applying material parameters that are independent of shaders --- */
 
@@ -582,7 +570,13 @@ void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* m
 
     R3D_SHADER_BIND_SAMPLER_2D(scene.depthCube, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
     R3D_SHADER_SET_FLOAT(scene.depthCube, uAlpha, ((float)call->material.albedo.color.a / 255));
-    R3D_SHADER_SET_FLOAT(scene.depthCube, uAlphaCutoff, call->material.alphaCutoff);
+
+    if (call->material.transparencyMode == R3D_TRANSPARENCY_PREPASS) {
+        R3D_SHADER_SET_FLOAT(scene.depthCube, uAlphaCutoff, shadow ? 0.1f : 0.99f);
+    }
+    else {
+        R3D_SHADER_SET_FLOAT(scene.depthCube, uAlphaCutoff, call->material.alphaCutoff);
+    }
 
     /* --- Applying material parameters that are independent of shaders --- */
 
@@ -753,7 +747,6 @@ void raster_geometry(const r3d_draw_call_t* call, const Matrix* matVP)
     /* --- Applying material parameters that are independent of shaders --- */
 
     r3d_draw_apply_cull_mode(call->material.cullMode);
-    r3d_draw_apply_depth_mode(call->material.depthMode);
 
     /* --- Rendering the object corresponding to the draw call --- */
 
@@ -832,9 +825,8 @@ void raster_forward(const r3d_draw_call_t* call, const Matrix* matVP)
 
     /* --- Applying material parameters that are independent of shaders --- */
 
-    r3d_draw_apply_cull_mode(call->material.cullMode);
     r3d_draw_apply_blend_mode(call->material.blendMode);
-    r3d_draw_apply_depth_mode(call->material.depthMode);
+    r3d_draw_apply_cull_mode(call->material.cullMode);
 
     /* --- Rendering the object corresponding to the draw call --- */
 
@@ -860,7 +852,6 @@ void pass_scene_shadow(void)
     glEnable(GL_DEPTH_TEST);
     glDepthFunc(GL_LEQUAL);
     glDepthMask(GL_TRUE);
-    glDisable(GL_BLEND);
 
     R3D_LIGHT_FOR_EACH_VISIBLE(light)
     {
@@ -880,7 +871,7 @@ void pass_scene_shadow(void)
                 glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_CUBE_MAP_POSITIVE_X + iFace, light->shadowMap.tex, 0);
                 glClear(GL_DEPTH_BUFFER_BIT);
 
-                R3D_DRAW_FOR_EACH(call, R3D_DRAW_DEFERRED, R3D_DRAW_DEFERRED_INST, R3D_DRAW_FORWARD, R3D_DRAW_FORWARD_INST) {
+                R3D_DRAW_FOR_EACH(call, R3D_DRAW_DEFERRED_INST, R3D_DRAW_DEFERRED, R3D_DRAW_PREPASS_INST, R3D_DRAW_PREPASS) {
                     if (call->mesh.shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
                         raster_depth_cube(call, true, &light->matVP[iFace]);
                     }
@@ -894,7 +885,7 @@ void pass_scene_shadow(void)
             glClear(GL_DEPTH_BUFFER_BIT);
             R3D_SHADER_USE(scene.depth);
 
-            R3D_DRAW_FOR_EACH(call, R3D_DRAW_DEFERRED, R3D_DRAW_DEFERRED_INST, R3D_DRAW_FORWARD, R3D_DRAW_FORWARD_INST) {
+            R3D_DRAW_FOR_EACH(call, R3D_DRAW_DEFERRED_INST, R3D_DRAW_DEFERRED, R3D_DRAW_PREPASS_INST, R3D_DRAW_PREPASS) {
                 if (call->mesh.shadowCastMode != R3D_SHADOW_CAST_DISABLED) {
                     raster_depth(call, true, &light->matVP[0]);
                 }
@@ -911,10 +902,12 @@ void pass_scene_geometry(void)
     R3D_TARGET_BIND(R3D_TARGET_GBUFFER);
     R3D_SHADER_USE(scene.geometry);
 
+    glEnable(GL_DEPTH_TEST);
     glDepthFunc(GL_LEQUAL);
+    glDepthMask(GL_TRUE);
     glDisable(GL_BLEND);
 
-    R3D_DRAW_FOR_EACH(call, R3D_DRAW_DEFERRED, R3D_DRAW_DEFERRED_INST) {
+    R3D_DRAW_FOR_EACH(call, R3D_DRAW_DEFERRED_INST, R3D_DRAW_DEFERRED) {
         raster_geometry(call, &R3D_CACHE_GET(viewport.viewProj));
     }
 
@@ -927,12 +920,14 @@ void pass_scene_decals(void)
     R3D_TARGET_BIND(R3D_TARGET_GBUFFER);
     R3D_SHADER_USE(scene.decal);
 
+    glEnable(GL_DEPTH_TEST);
     glDepthFunc(GL_LEQUAL);
     glDepthMask(GL_FALSE);
+    glEnable(GL_BLEND);
 
     R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexDepth, r3d_target_get(R3D_TARGET_DEPTH));
 
-    R3D_DRAW_FOR_EACH(call, R3D_DRAW_DECAL, R3D_DRAW_DECAL_INST) {
+    R3D_DRAW_FOR_EACH(call, R3D_DRAW_DECAL_INST, R3D_DRAW_DECAL) {
         raster_decal(call, &R3D_CACHE_GET(viewport.viewProj));
     }
 
@@ -1226,6 +1221,23 @@ void pass_deferred_compose(r3d_target_t sceneTarget)
     R3D_SHADER_UNBIND_SAMPLER_2D(deferred.compose, uTexSpecular);
 }
 
+void pass_scene_prepass(void)
+{
+    R3D_TARGET_BIND(R3D_TARGET_DEPTH);
+    R3D_SHADER_USE(scene.depth);
+
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_LEQUAL);
+    glDepthMask(GL_TRUE);
+
+    R3D_DRAW_FOR_EACH(call, R3D_DRAW_PREPASS_INST, R3D_DRAW_PREPASS) {
+        raster_depth(call, false, &R3D_CACHE_GET(viewport.viewProj));
+    }
+
+    // NOTE: The storage texture of the matrices may have been bind during drawcalls
+    R3D_SHADER_UNBIND_SAMPLER_1D(scene.forward, uTexBoneMatrices);
+}
+
 static void pass_scene_forward_send_lights(const r3d_draw_call_t* call)
 {
     int iLight = 0;
@@ -1299,7 +1311,10 @@ void pass_scene_forward(r3d_target_t sceneTarget)
     R3D_TARGET_BIND(sceneTarget, R3D_TARGET_ALBEDO, R3D_TARGET_NORMAL, R3D_TARGET_ORM, R3D_TARGET_DEPTH);
     R3D_SHADER_USE(scene.forward);
 
+    glEnable(GL_DEPTH_TEST);
     glDepthFunc(GL_LEQUAL);
+    glDepthMask(GL_FALSE);
+    glEnable(GL_BLEND);
 
     if (R3D_CACHE_GET(environment.background.sky.cubemap.id) != 0) {
         R3D_SHADER_BIND_SAMPLER_CUBE(scene.forward, uCubeIrradiance, R3D_CACHE_GET(environment.background.sky.irradiance.id));
@@ -1319,7 +1334,7 @@ void pass_scene_forward(r3d_target_t sceneTarget)
 
     R3D_SHADER_SET_VEC3(scene.forward, uViewPosition, R3D_CACHE_GET(viewport.viewPosition));
 
-    R3D_DRAW_FOR_EACH(call, R3D_DRAW_FORWARD, R3D_DRAW_FORWARD_INST) {
+    R3D_DRAW_FOR_EACH(call, R3D_DRAW_PREPASS_INST, R3D_DRAW_PREPASS, R3D_DRAW_FORWARD_INST, R3D_DRAW_FORWARD) {
         pass_scene_forward_send_lights(call);
         raster_forward(call, &R3D_CACHE_GET(viewport.viewProj));
     }

--- a/src/r3d_material.c
+++ b/src/r3d_material.c
@@ -40,11 +40,12 @@ R3D_Material R3D_GetDefaultMaterial(void)
     material.orm.metalness = 0.0f;
 
     // Misc
-    material.blendMode = R3D_BLEND_OPAQUE;
-    material.cullMode = R3D_CULL_BACK;
+    material.transparencyMode = R3D_TRANSPARENCY_DISABLED;
     material.billboardMode = R3D_BILLBOARD_DISABLED;
-    material.uvOffset = (Vector2) { 0.0f, 0.0f };
-    material.uvScale = (Vector2) { 1.0f, 1.0f };
+    material.blendMode = R3D_BLEND_MIX;
+    material.cullMode = R3D_CULL_BACK;
+    material.uvOffset = (Vector2) {0.0f, 0.0f};
+    material.uvScale = (Vector2) {1.0f, 1.0f};
     material.alphaCutoff = 0.01f;
 
     return material;


### PR DESCRIPTION
### Transparency refactor

The `R3D_DepthMode` enum has been removed.

Depth writing is now automatically handled based on the selected transparency mode, instead of being explicitly controlled by the user.

Three transparency modes are now available:

- `R3D_TRANSPARENCY_DISABLED`
- `R3D_TRANSPARENCY_PREPASS`
- `R3D_TRANSPARENCY_ALPHA`

**Mode behavior:**

- `R3D_TRANSPARENCY_DISABLED`
  Opaque rendering path with support for material alpha cutoff (performed in the deferred pass).

- `R3D_TRANSPARENCY_PREPASS`
  Transparency with partial depth correctness using a depth prepass.
  Fragments with alpha > 0.99 write to the scene depth buffer, while fragments with alpha > 0.1 write to shadow maps.

- `R3D_TRANSPARENCY_ALPHA`
  Standard alpha blending with no depth writes, neither to the scene depth buffer nor to shadow maps.

```c
typedef enum R3D_TransparencyMode {
    R3D_TRANSPARENCY_DISABLED,      ///< No transparency, supports alpha cutoff.
    R3D_TRANSPARENCY_PREPASS,       ///< Supports transparency with shadows. Writes shadows for alpha > 0.1 and depth for alpha > 0.99.
    R3D_TRANSPARENCY_ALPHA,         ///< Standard transparency without shadows or depth writes.
} R3D_TransparencyMode;
```

---

### Blend mode changes

The blend modes have been slightly adjusted.
`R3D_BLEND_OPAQUE` and `R3D_BLEND_ALPHA` have been merged into a single mode `R3D_BLEND_MIX`
Whether rendering is fully opaque or alpha-blended is now determined by the selected transparency mode.

**Rendering paths:**

- `R3D_BLEND_MIX` with transparency disabled is rendered through the **deferred** pipeline.
- `R3D_BLEND_MIX` with transparency enabled (prepass or alpha) is rendered through the **forward** pipeline.

All other blend modes remain unchanged and are always rendered through the forward pipeline when:

- the blend mode is not `MIX`, and/or
- transparency is enabled.

**Special case for additive blending:**

When additive blending is used without transparency, rendering still goes through the forward path, but uses:

```
GL_ONE, GL_ONE
```

instead of:

```
GL_SRC_ALPHA, GL_ONE
```

---

### Depth control

The ability to explicitly enable or disable depth test/write, previously handled by `R3D_DepthMode`, has been removed.
This functionality may be reintroduced in the form of an enum allowing direct control over the depth function instead.