### PR TITLE
SSIL history blending

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/prepare/bilateral_blur.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssao.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssil.frag"
+    "${R3D_ROOT_PATH}/shaders/prepare/ssil_convergence.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssr.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/bloom_down.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/bloom_up.frag"

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -80,6 +80,7 @@
             .hitThickness = 0.5f,                       \
             .aoPower = 1.0f,                            \
             .energy = 1.0f,                             \
+            .convergence = 0.5f,                        \
             .enabled = false,                           \
         },                                              \
         .bloom = {                                      \
@@ -227,6 +228,14 @@ typedef struct R3D_EnvSSIL {
     float hitThickness;     ///< Thickness threshold for occluders (default: 0.5)
     float aoPower;          ///< Exponential falloff for visibility factor (too high = more noise) (default: 1.0)
     float energy;           ///< Multiplier for indirect light intensity (default: 1.0)
+    float convergence;      /**< Temporal convergence factor (0 disables it, default 0.5).
+                              *  Smooths sudden light flashes by blending with previous frames.
+                              *  Higher values produce smoother results but may cause ghosting.
+                              *  Tip: The faster the screen changes, the higher the convergence can be acceptable.
+                              *  Requires an additional history buffer (so require more memory). 
+                              *  If multiple SSIL passes are done in the same frame, the history may be inconsistent, 
+                              *  in that case, enable SSIL/convergence for only one pass per frame.
+                              */
     bool enabled;           ///< Enable/disable SSIL effect (default: false)
 } R3D_EnvSSIL;
 

--- a/shaders/prepare/ssil_convergence.frag
+++ b/shaders/prepare/ssil_convergence.frag
@@ -1,0 +1,32 @@
+/* ssil_convergence.frag -- SSIL history blending fragment shader
+ *
+ * Copyright (c) 2025 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+/* === Varyings == */
+
+noperspective in vec2 vTexCoord;
+
+/* === Uniforms === */
+
+uniform sampler2D uTexCurrent;
+uniform sampler2D uTexHistory;
+uniform float uConvergence;
+
+/* === Fragments === */
+
+layout(location = 0) out vec4 FragColor;
+
+/* === Program === */
+
+void main()
+{
+    vec4 current = texture(uTexCurrent, vTexCoord);
+    vec4 history = texture(uTexHistory, vTexCoord);
+    FragColor = mix(current, history, uConvergence);
+}

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -23,6 +23,7 @@
 #include <shaders/bilateral_blur.frag.h>
 #include <shaders/ssao.frag.h>
 #include <shaders/ssil.frag.h>
+#include <shaders/ssil_convergence.frag.h>
 #include <shaders/ssr.frag.h>
 #include <shaders/bloom_down.frag.h>
 #include <shaders/bloom_up.frag.h>
@@ -304,6 +305,20 @@ void r3d_shader_load_prepare_ssil_blur(void)
     SET_SAMPLER_2D(prepare.ssilBlur, uTexSource, 0);
     SET_SAMPLER_2D(prepare.ssilBlur, uTexNormal, 1);
     SET_SAMPLER_2D(prepare.ssilBlur, uTexDepth, 2);
+}
+
+void r3d_shader_load_prepare_ssil_convergence(void)
+{
+    LOAD_SHADER(prepare.ssilConvergence, SCREEN_VERT, SSIL_CONVERGENCE_FRAG);
+
+    GET_LOCATION(prepare.ssilConvergence, uTexCurrent);
+    GET_LOCATION(prepare.ssilConvergence, uTexHistory);
+    GET_LOCATION(prepare.ssilConvergence, uConvergence);
+
+    USE_SHADER(prepare.ssilConvergence);
+
+    SET_SAMPLER_2D(prepare.ssilConvergence, uTexCurrent, 0);
+    SET_SAMPLER_2D(prepare.ssilConvergence, uTexHistory, 1);
 }
 
 void r3d_shader_load_prepare_ssr(void)

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -223,6 +223,13 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
+    r3d_shader_uniform_sampler2D_t uTexCurrent;
+    r3d_shader_uniform_sampler2D_t uTexHistory;
+    r3d_shader_uniform_float_t uConvergence;
+} r3d_shader_prepare_ssil_convergence_t;
+
+typedef struct {
+    unsigned int id;
     r3d_shader_uniform_sampler2D_t uTexColor;
     r3d_shader_uniform_sampler2D_t uTexAlbedo;
     r3d_shader_uniform_sampler2D_t uTexNormal;
@@ -552,6 +559,7 @@ extern struct r3d_shader {
         r3d_shader_prepare_ssao_blur_t ssaoBlur;
         r3d_shader_prepare_ssil_t ssil;
         r3d_shader_prepare_ssil_blur_t ssilBlur;
+        r3d_shader_prepare_ssil_convergence_t ssilConvergence;
         r3d_shader_prepare_ssr_t ssr;
         r3d_shader_prepare_bloom_down_t bloomDown;
         r3d_shader_prepare_bloom_up_t bloomUp;
@@ -600,6 +608,7 @@ void r3d_shader_load_prepare_ssao(void);
 void r3d_shader_load_prepare_ssao_blur(void);
 void r3d_shader_load_prepare_ssil(void);
 void r3d_shader_load_prepare_ssil_blur(void);
+void r3d_shader_load_prepare_ssil_convergence(void);
 void r3d_shader_load_prepare_ssr(void);
 void r3d_shader_load_prepare_bloom_down(void);
 void r3d_shader_load_prepare_bloom_up(void);
@@ -631,6 +640,7 @@ static const struct r3d_shader_loader {
         r3d_shader_loader_func ssaoBlur;
         r3d_shader_loader_func ssil;
         r3d_shader_loader_func ssilBlur;
+        r3d_shader_loader_func ssilConvergence;
         r3d_shader_loader_func ssr;
         r3d_shader_loader_func bloomDown;
         r3d_shader_loader_func bloomUp;
@@ -674,6 +684,7 @@ static const struct r3d_shader_loader {
         .ssaoBlur = r3d_shader_load_prepare_ssao_blur,
         .ssil = r3d_shader_load_prepare_ssil,
         .ssilBlur = r3d_shader_load_prepare_ssil_blur,
+        .ssilConvergence = r3d_shader_load_prepare_ssil_convergence,
         .ssr = r3d_shader_load_prepare_ssr,
         .bloomDown = r3d_shader_load_prepare_bloom_down,
         .bloomUp = r3d_shader_load_prepare_bloom_up,

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -49,6 +49,8 @@ static const target_config_t TARGET_CONFIG[] = {
     [R3D_TARGET_SSAO_1]     = { GL_R8,                GL_RED,             GL_UNSIGNED_BYTE,  0.5f, GL_LINEAR,               GL_LINEAR,  false },
     [R3D_TARGET_SSIL_0]     = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     0.5f, GL_LINEAR,               GL_LINEAR,  false },
     [R3D_TARGET_SSIL_1]     = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     0.5f, GL_LINEAR,               GL_LINEAR,  false },
+    [R3D_TARGET_SSIL_2]     = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     0.5f, GL_LINEAR,               GL_LINEAR,  false },
+    [R3D_TARGET_SSIL_3]     = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     0.5f, GL_LINEAR,               GL_LINEAR,  false },
     [R3D_TARGET_SSR]        = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     0.5f, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR,  true },
     [R3D_TARGET_BLOOM]      = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     1.0f, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR,  true  },
     [R3D_TARGET_SCENE_0]    = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     1.0f, GL_NEAREST,              GL_NEAREST, false },
@@ -284,14 +286,6 @@ r3d_target_t r3d_target_swap_ssao(r3d_target_t ssao)
     return R3D_TARGET_SSAO_0;
 }
 
-r3d_target_t r3d_target_swap_ssil(r3d_target_t ssil)
-{
-    if (ssil == R3D_TARGET_SSIL_0) {
-        return R3D_TARGET_SSIL_1;
-    }
-    return R3D_TARGET_SSIL_0;
-}
-
 r3d_target_t r3d_target_swap_scene(r3d_target_t scene)
 {
     if (scene == R3D_TARGET_SCENE_0) {
@@ -370,11 +364,15 @@ void r3d_target_gen_mipmap(r3d_target_t target)
 
 GLuint r3d_target_get(r3d_target_t target)
 {
-    if (target <= R3D_TARGET_INVALID || target >= R3D_TARGET_COUNT) {
-        return 0;
-    }
-
+    assert(target > R3D_TARGET_INVALID && target < R3D_TARGET_COUNT);
     assert(R3D_MOD_TARGET.targetLoaded[target]);
+    return R3D_MOD_TARGET.targets[target];
+}
+
+GLuint r3d_target_get_or_null(r3d_target_t target)
+{
+    if (target <= R3D_TARGET_INVALID || target >= R3D_TARGET_COUNT) return 0;
+    if (!R3D_MOD_TARGET.targetLoaded[target]) return 0;
     return R3D_MOD_TARGET.targets[target];
 }
 

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -33,6 +33,8 @@ typedef enum {
     R3D_TARGET_SSAO_1,          //< Half - Mip 1 - R[8]
     R3D_TARGET_SSIL_0,          //< Half - Mip 1 - RGBA[16|16|16|16]
     R3D_TARGET_SSIL_1,          //< Half - Mip 1 - RGBA[16|16|16|16]
+    R3D_TARGET_SSIL_2,          //< Half - Mip 1 - RGBA[16|16|16|16]
+    R3D_TARGET_SSIL_3,          //< Half - Mip 1 - RGBA[16|16|16|16]
     R3D_TARGET_SSR,             //< Half - Mip N - RGBA[16|16|16|16]
     R3D_TARGET_BLOOM,           //< Full - Mip N - RGB[16|16|16]
     R3D_TARGET_SCENE_0,         //< Full - Mip 1 - RGB[16|16|16]
@@ -96,15 +98,6 @@ typedef enum {
 #define R3D_TARGET_BIND_AND_SWAP_SSAO(target) do {                      \
     R3D_TARGET_BIND(target);                                            \
     target = r3d_target_swap_ssao(target);                              \
-} while(0)
-
-/*
- * Binds the target, then swaps to the alternate SSIL target.
- * Modifies the target parameter to point to the other buffer.
- */
-#define R3D_TARGET_BIND_AND_SWAP_SSIL(target) do {                      \
-    R3D_TARGET_BIND(target);                                            \
-    target = r3d_target_swap_ssil(target);                              \
 } while(0)
 
 /*
@@ -215,11 +208,6 @@ r3d_target_t r3d_target_swap_ssao(r3d_target_t ssao);
 /*
  * Returns target '1' if target '0' is provided, otherwise returns target '0'.
  */
-r3d_target_t r3d_target_swap_ssil(r3d_target_t ssil);
-
-/*
- * Returns target '1' if target '0' is provided, otherwise returns target '0'.
- */
 r3d_target_t r3d_target_swap_scene(r3d_target_t scene);
 
 /*
@@ -253,11 +241,16 @@ void r3d_target_gen_mipmap(r3d_target_t target);
 
 /*
  * Returns the texture ID corresponding to the requested target.
- * Returns 0 if the target enum is invalid.
- * Asserts that the requested target has been created.
+ * Asserts that the requested target has been created and if the target enum is valid.
  * If not created yet, it means we never bound this target, so it would be empty.
  */
 GLuint r3d_target_get(r3d_target_t target);
+
+/*
+ * Returns the texture ID corresponding to the requested target.
+ * Or returns 0 if the target has not been created or if the enum is invalid.
+ */
+GLuint r3d_target_get_or_null(r3d_target_t target);
 
 /*
  * Blits mip 0 of the specified target to the screen or RenderTexture2D


### PR DESCRIPTION
Just a small PR that adds a history system and blending with the current frame for SSIL.
This helps reduce lighting "pops" when a hot spot leaves and re-enters the screen.

It adds the `convergence` parameter to the `R3D_EnvSSIL` struct, which expects a value between 0 and 1.

If the parameter is set to 0, the history management is disabled. If this is done before the first pass, the two additional buffers used for history and blending will never be allocated.

The default convergence value is 0.5, which should be enough for outdoor scenes. For indoor scenes, such as corridors in Sponza in another measure, it's a bit trickier, a higher convergence closer to 0.9 works better but it can introduce ghosting.

Ideally, we would have a velocity buffer to adapt the convergence factor, and even full reprojection with depth history, but that's rather complicated to implement due to the API and the current `Begin/End`, because if you render several scenes in the same frame, it messes everything up.

One idea would be to have an implicit default viewport for simple `Begin/End` and allow creation of additional viewports (which manages its own history and velocity buffers), and then recommend avoiding rendering to the same viewport multiple times per frame, at least when reprojection is involved.

Anyway, this opens up a lot of potential topics (TAA, motion blur, and other cool stuff), but now isn't really the time…

In any case, this small change is more than welcome for SSIL!