### PR TITLE
Add sRGB texture loading

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## **v0.7**
 
-* [ ] **Add support for sRGB textures**
+* [x] **Add support for sRGB textures**
   Provide a parameter (enabled by default) for loading textures,
   albedo being the most important, in sRGB.
 

--- a/examples/animation.c
+++ b/examples/animation.c
@@ -1,3 +1,4 @@
+#include "r3d/r3d_lighting.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 
@@ -18,11 +19,11 @@ int main(void)
     R3D_ENVIRONMENT_SET(ssao.enabled, true);
     R3D_ENVIRONMENT_SET(bloom.intensity, 0.03f);
     R3D_ENVIRONMENT_SET(bloom.mode, R3D_BLOOM_ADDITIVE);
-    R3D_ENVIRONMENT_SET(tonemap.mode, R3D_TONEMAP_ACES);
+    R3D_ENVIRONMENT_SET(tonemap.mode, R3D_TONEMAP_AGX);
 
     // Set background and ambient colors
-    R3D_ENVIRONMENT_SET(background.color, BLACK);
-    R3D_ENVIRONMENT_SET(ambient.color, (Color){10, 10, 10, 255});
+    R3D_ENVIRONMENT_SET(background.color, (Color){12, 10, 15, 255});
+    R3D_ENVIRONMENT_SET(ambient.color, (Color){12, 10, 15, 255});
 
     // Create ground plane
     R3D_Mesh plane = R3D_GenMeshPlane(32, 32, 1, 1);
@@ -61,11 +62,13 @@ int main(void)
     lights[0] = R3D_CreateLight(R3D_LIGHT_OMNI);
     R3D_SetLightPosition(lights[0], (Vector3){-10.0f, 25.0f, 0.0f});
     R3D_EnableShadow(lights[0], 4096);
+    R3D_SetLightEnergy(lights[0], 1.25f);
     R3D_SetLightActive(lights[0], true);
 
     lights[1] = R3D_CreateLight(R3D_LIGHT_OMNI);
     R3D_SetLightPosition(lights[1], (Vector3){10.0f, 25.0f, 0.0f});
     R3D_EnableShadow(lights[1], 4096);
+    R3D_SetLightEnergy(lights[1], 1.25f);
     R3D_SetLightActive(lights[1], true);
 
     // Setup camera

--- a/examples/emission.c
+++ b/examples/emission.c
@@ -18,10 +18,7 @@ int main(void)
     R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
 
     // Configure post-processing (Tonemap + Bloom)
-    R3D_ENVIRONMENT_SET(tonemap.mode, R3D_TONEMAP_ACES);
-    R3D_ENVIRONMENT_SET(tonemap.exposure, 0.5f);
-    R3D_ENVIRONMENT_SET(tonemap.white, 4.0f);
-
+    R3D_ENVIRONMENT_SET(tonemap.mode, R3D_TONEMAP_AGX);
     R3D_ENVIRONMENT_SET(bloom.mode, R3D_BLOOM_ADDITIVE);
     R3D_ENVIRONMENT_SET(bloom.softThreshold, 0.2f);
     R3D_ENVIRONMENT_SET(bloom.threshold, 0.6f);

--- a/examples/pbr_car.c
+++ b/examples/pbr_car.c
@@ -1,3 +1,4 @@
+#include "r3d/r3d_environment.h"
 #include "r3d/r3d_lighting.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
@@ -26,7 +27,7 @@ int main(void)
     R3D_ENVIRONMENT_SET(ssao.radius, 2.0f);
     R3D_ENVIRONMENT_SET(bloom.intensity, 0.1f);
     R3D_ENVIRONMENT_SET(bloom.mode, R3D_BLOOM_MIX);
-    R3D_ENVIRONMENT_SET(tonemap.mode, R3D_TONEMAP_ACES);
+    R3D_ENVIRONMENT_SET(tonemap.mode, R3D_TONEMAP_FILMIC);
 
     // Load model
     R3D_Model model = R3D_LoadModel(RESOURCES_PATH "pbr/car.glb");
@@ -48,6 +49,7 @@ int main(void)
     R3D_SetShadowDepthBias(light, 0.003f);
     R3D_EnableShadow(light, 4096);
     R3D_SetLightActive(light, true);
+    R3D_SetLightEnergy(light, 2.0f);
     R3D_SetLightRange(light, 10);
 
     // Setup camera

--- a/examples/pbr_musket.c
+++ b/examples/pbr_musket.c
@@ -1,3 +1,4 @@
+#include "r3d/r3d_environment.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 
@@ -15,12 +16,11 @@ int main(void)
     R3D_Init(GetScreenWidth(), GetScreenHeight(), R3D_FLAG_FXAA);
 
     // Tonemapping
-    R3D_ENVIRONMENT_SET(tonemap.mode, R3D_TONEMAP_ACES);
+    R3D_ENVIRONMENT_SET(tonemap.mode, R3D_TONEMAP_FILMIC);
     R3D_ENVIRONMENT_SET(tonemap.exposure, 0.75f);
-    R3D_ENVIRONMENT_SET(tonemap.white, 1.25f);
 
     // Set texture filter for mipmaps
-    R3D_SetTextureFilter(TEXTURE_FILTER_TRILINEAR);
+    R3D_SetTextureFilter(TEXTURE_FILTER_ANISOTROPIC_4X);
 
     // Load model
     R3D_Model model = R3D_LoadModel(RESOURCES_PATH "pbr/musket.glb");

--- a/examples/sponza.c
+++ b/examples/sponza.c
@@ -22,6 +22,7 @@ int main(void)
     R3D_ENVIRONMENT_SET(ambient.color, DARKGRAY);
 
     // Load Sponza model
+    R3D_SetTextureFilter(TEXTURE_FILTER_ANISOTROPIC_8X);
     R3D_Model sponza = R3D_LoadModel(RESOURCES_PATH "sponza.glb");
 
     // Load skybox (disabled by default)

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -73,6 +73,17 @@ typedef uint32_t R3D_Layer;
 
 #define R3D_LAYER_ALL   0xFFFFFFFF
 
+/**
+ * @brief Specifies the color space of a texture.
+ *
+ * This enum defines how a texture's colors are interpreted during rendering.
+ * It is used with color textures such as albedo and emission.
+ */
+typedef enum {
+    R3D_COLORSPACE_LINEAR,  ///< Linear color space, no gamma correction applied.
+    R3D_COLORSPACE_SRGB     ///< sRGB color space, gamma correction applied on load.
+} R3D_ColorSpace;
+
 // ========================================
 // PUBLIC API
 // ========================================
@@ -168,6 +179,19 @@ R3DAPI void R3D_UpdateResolution(int width, int height);
  * @param filter The texture filtering mode to be applied by default.
  */
 R3DAPI void R3D_SetTextureFilter(TextureFilter filter);
+
+/**
+ * @brief Sets the color space for color textures such as albedo and emission.
+ *
+ * This function specifies whether textures representing visible colors
+ * should be interpreted as linear or sRGB. The chosen color space
+ * is applied automatically when loading the texture.
+ *
+ * The default texture color space is `R3D_COLORSPACE_SRGB`.
+ *
+ * @param space The color space to use (linear or sRGB).
+ */
+R3DAPI void R3D_SetTextureColorSpace(R3D_ColorSpace space);
 
 /**
  * @brief Get the currently active global rendering layers.

--- a/src/importer/r3d_importer.h
+++ b/src/importer/r3d_importer.h
@@ -87,7 +87,7 @@ int r3d_importer_get_bone_index(const r3d_importer_t* importer, const char* name
  * This will spawn worker threads to load images in parallel, then
  * progressively upload them to GPU as they become ready
  */
-r3d_importer_texture_cache_t* r3d_importer_load_texture_cache(const r3d_importer_t* importer, TextureFilter filter);
+r3d_importer_texture_cache_t* r3d_importer_load_texture_cache(const r3d_importer_t* importer, R3D_ColorSpace colorSpace, TextureFilter filter);
 
 /**
  * Destroy the texture cache and free all unused resources

--- a/src/importer/r3d_importer_texture.c
+++ b/src/importer/r3d_importer_texture.c
@@ -28,6 +28,8 @@
 #include <tinycthread.h>
 #include <stdatomic.h>
 #include <stdlib.h>
+#include <rlgl.h>
+#include <glad.h>
 
 #include "../details/r3d_image.h"
 
@@ -118,10 +120,197 @@ static bool ring_pop(loader_context_t* ctx, int* jobIndex)
 }
 
 // ========================================
-// TEXTURE WRAP CONVERSION
+// TEXTURE LOADING FUNCTIONS
 // ========================================
 
-static int get_wrap_mode(enum aiTextureMapMode wrap)
+static bool has_gl_ext(const char* name)
+{
+    GLint n = 0;
+    glGetIntegerv(GL_NUM_EXTENSIONS, &n);
+
+    for (GLint i = 0; i < n; i++) {
+        const char* ext = (const char*)glGetStringi(GL_EXTENSIONS, i);
+        if (strcmp(ext, name) == 0) return true;
+    }
+
+    return false;
+}
+
+static bool has_gl_anisotropy(float* max)
+{
+    static bool hasAniso = false;
+    static float maxAniso = 1.0f;
+
+    if (!hasAniso) {
+        hasAniso = has_gl_ext("GL_EXT_texture_filter_anisotropic");
+        if (hasAniso) {
+            glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAniso);
+            glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, fminf(8.0f, maxAniso));
+        }
+    }
+
+    if (max) *max = maxAniso;
+
+    return hasAniso;
+}
+
+void get_gl_texture_format(int format, bool srgb, GLenum* glInternalFormat, GLenum* glFormat, GLenum* glType)
+{
+    // TODO: Add checks for support of compressed formats (consider WebGL 2 for later)
+
+    *glInternalFormat = 0;
+    *glFormat = 0;
+    *glType = 0;
+
+    switch (format) {
+    case RL_PIXELFORMAT_UNCOMPRESSED_GRAYSCALE: *glInternalFormat = GL_R8; *glFormat = GL_RED; *glType = GL_UNSIGNED_BYTE; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_GRAY_ALPHA: *glInternalFormat = GL_RG8; *glFormat = GL_RG; *glType = GL_UNSIGNED_BYTE; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R5G6B5: *glInternalFormat = GL_RGB565; *glFormat = GL_RGB; *glType = GL_UNSIGNED_SHORT_5_6_5; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R8G8B8: *glInternalFormat = GL_RGB8; *glFormat = GL_RGB; *glType = GL_UNSIGNED_BYTE; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R5G5B5A1: *glInternalFormat = GL_RGB5_A1; *glFormat = GL_RGBA; *glType = GL_UNSIGNED_SHORT_5_5_5_1; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R4G4B4A4: *glInternalFormat = GL_RGBA4; *glFormat = GL_RGBA; *glType = GL_UNSIGNED_SHORT_4_4_4_4; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R8G8B8A8: *glInternalFormat = GL_RGBA8; *glFormat = GL_RGBA; *glType = GL_UNSIGNED_BYTE; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R32: *glInternalFormat = GL_R32F; *glFormat = GL_RED; *glType = GL_FLOAT; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R32G32B32: *glInternalFormat = GL_RGB32F; *glFormat = GL_RGB; *glType = GL_FLOAT; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R32G32B32A32: *glInternalFormat = GL_RGBA32F; *glFormat = GL_RGBA; *glType = GL_FLOAT; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R16: *glInternalFormat = GL_R16F; *glFormat = GL_RED; *glType = GL_HALF_FLOAT; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R16G16B16: *glInternalFormat = GL_RGB16F; *glFormat = GL_RGB; *glType = GL_HALF_FLOAT; break;
+    case RL_PIXELFORMAT_UNCOMPRESSED_R16G16B16A16: *glInternalFormat = GL_RGBA16F; *glFormat = GL_RGBA; *glType = GL_HALF_FLOAT; break;
+    case RL_PIXELFORMAT_COMPRESSED_DXT1_RGB: *glInternalFormat = GL_COMPRESSED_RGB_S3TC_DXT1_EXT; break;
+    case RL_PIXELFORMAT_COMPRESSED_DXT1_RGBA: *glInternalFormat = GL_COMPRESSED_RGBA_S3TC_DXT1_EXT; break;
+    case RL_PIXELFORMAT_COMPRESSED_DXT3_RGBA: *glInternalFormat = GL_COMPRESSED_RGBA_S3TC_DXT3_EXT; break;
+    case RL_PIXELFORMAT_COMPRESSED_DXT5_RGBA: *glInternalFormat = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT; break;
+    default: TRACELOG(RL_LOG_WARNING, "R3D: Current format not supported (%i)", format); break;
+    }
+
+    if (srgb) {
+        switch (*glInternalFormat) {
+        case GL_RGBA8: *glInternalFormat = GL_SRGB8_ALPHA8; break;
+        case GL_RGB8: *glInternalFormat = GL_SRGB8; break;
+        }
+    }
+}
+
+static void upload_mipmap(const uint8_t *data, int width, int height, int level, 
+                          int format, bool srgb)
+{
+    GLenum glInternalFormat, glFormat, glType;
+    get_gl_texture_format(format, srgb, &glInternalFormat, &glFormat, &glType);
+    
+    if (glInternalFormat == 0) return;
+    
+    if (format < RL_PIXELFORMAT_COMPRESSED_DXT1_RGB) {
+        glTexImage2D(GL_TEXTURE_2D, level, glInternalFormat, width, height, 
+                     0, glFormat, glType, data);
+    } else {
+        int size = GetPixelDataSize(width, height, format);
+        glCompressedTexImage2D(GL_TEXTURE_2D, level, glInternalFormat, 
+                              width, height, 0, size, data);
+    }
+}
+
+static void set_texture_swizzle(int format)
+{
+    static const GLint grayscale[] = {GL_RED, GL_RED, GL_RED, GL_ONE};
+    static const GLint gray_alpha[] = {GL_RED, GL_RED, GL_RED, GL_GREEN};
+    
+    const GLint *mask = NULL;
+    if (format == RL_PIXELFORMAT_UNCOMPRESSED_GRAYSCALE) mask = grayscale;
+    else if (format == RL_PIXELFORMAT_UNCOMPRESSED_GRAY_ALPHA) mask = gray_alpha;
+    
+    if (mask) {
+        glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, mask);
+    }
+}
+
+static void set_texture_wrap(TextureWrap wrap)
+{
+    static const GLenum wrap_modes[] = {
+        [TEXTURE_WRAP_REPEAT] = GL_REPEAT,
+        [TEXTURE_WRAP_CLAMP] = GL_CLAMP_TO_EDGE,
+        [TEXTURE_WRAP_MIRROR_REPEAT] = GL_MIRRORED_REPEAT,
+        [TEXTURE_WRAP_MIRROR_CLAMP] = GL_MIRROR_CLAMP_TO_EDGE
+    };
+    
+    if (wrap < sizeof(wrap_modes) / sizeof(wrap_modes[0]) && wrap_modes[wrap]) {
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap_modes[wrap]);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap_modes[wrap]);
+    }
+}
+
+static void set_texture_filter(TextureFilter filter)
+{
+    typedef struct {
+        GLenum mag, min;
+        float aniso;
+    } FilterMode;
+    
+    static const FilterMode modes[] = {
+        [TEXTURE_FILTER_POINT] = {GL_NEAREST, GL_NEAREST, 0},
+        [TEXTURE_FILTER_BILINEAR] = {GL_LINEAR, GL_LINEAR, 0},
+        [TEXTURE_FILTER_TRILINEAR] = {GL_LINEAR, GL_LINEAR_MIPMAP_LINEAR, 0},
+        [TEXTURE_FILTER_ANISOTROPIC_4X] = {GL_LINEAR, GL_LINEAR_MIPMAP_LINEAR, 4.0f},
+        [TEXTURE_FILTER_ANISOTROPIC_8X] = {GL_LINEAR, GL_LINEAR_MIPMAP_LINEAR, 8.0f},
+        [TEXTURE_FILTER_ANISOTROPIC_16X] = {GL_LINEAR, GL_LINEAR_MIPMAP_LINEAR, 16.0f}
+    };
+    
+    if (filter < sizeof(modes) / sizeof(modes[0]) && modes[filter].mag) {
+        const FilterMode *m = &modes[filter];
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, m->mag);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m->min);
+        if (m->aniso > 0) {
+            float maxAniso = 1.0f;
+            if (has_gl_anisotropy(&maxAniso)) {
+                glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, fminf(m->aniso, maxAniso));
+            }
+        }
+    }
+}
+
+static Texture2D load_texture(const Image* image, TextureWrap wrap, 
+                               TextureFilter filter, bool srgb)
+{
+    GLuint id = 0;
+    glGenTextures(1, &id);
+    glBindTexture(GL_TEXTURE_2D, id);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+    const uint8_t *dataPtr = image->data;
+    int mipW = image->width, mipH = image->height;
+
+    for (int i = 0; i < image->mipmaps; i++) {
+        upload_mipmap(dataPtr, mipW, mipH, i, image->format, srgb);
+        if (i == 0) set_texture_swizzle(image->format);
+
+        int mipSize = GetPixelDataSize(mipW, mipH, image->format);
+        if (dataPtr) dataPtr += mipSize;
+
+        mipW = (mipW > 1) ? mipW / 2 : 1;
+        mipH = (mipH > 1) ? mipH / 2 : 1;
+    }
+
+    if (image->mipmaps == 1 && filter >= TEXTURE_FILTER_TRILINEAR) {
+        glGenerateMipmap(GL_TEXTURE_2D);
+    }
+
+    set_texture_wrap(wrap);
+    set_texture_filter(filter);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    return (Texture2D) {
+        .id = id,
+        .width = image->width,
+        .height = image->height,
+        .mipmaps = image->mipmaps,
+        .format = image->format
+    };
+}
+
+// ========================================
+// ASSIMP HELPER FUNCTIONS
+// ========================================
+
+static TextureWrap get_wrap_mode(enum aiTextureMapMode wrap)
 {
     switch (wrap) {
     case aiTextureMapMode_Wrap:
@@ -136,7 +325,7 @@ static int get_wrap_mode(enum aiTextureMapMode wrap)
 }
 
 // ========================================
-// IMAGE LOADING HELPERS
+// IMAGE LOADING FUNCTIONS
 // ========================================
 
 static bool load_image_base(
@@ -391,8 +580,6 @@ r3d_importer_texture_cache_t* r3d_importer_load_texture_cache(const r3d_importer
 
     // Progressive upload loop on main thread
     int uploadedCount = 0;
-    bool generateMipmaps = (filter >= TEXTURE_FILTER_TRILINEAR);
-
     while (uploadedCount < ctx.totalJobs) {
         int jobIndex;
 
@@ -406,15 +593,7 @@ r3d_importer_texture_cache_t* r3d_importer_load_texture_cache(const r3d_importer
             // Upload texture to GPU
             if (img->image.data) {
                 Texture2D* texture = &cache->materials[materialIdx].textures[mapIdx];
-                *texture = LoadTextureFromImage(img->image);
-
-                if (texture->id != 0) {
-                    if (generateMipmaps) {
-                        GenTextureMipmaps(texture);
-                    }
-                    SetTextureWrap(*texture, get_wrap_mode(img->wrap[0]));
-                    SetTextureFilter(*texture, filter);
-                }
+                *texture = load_texture(&img->image, get_wrap_mode(img->wrap[0]), filter, mapIdx == R3D_MAP_ALBEDO);
 
                 // Free image data
                 if (img->owned) {

--- a/src/importer/r3d_importer_texture.c
+++ b/src/importer/r3d_importer_texture.c
@@ -187,6 +187,25 @@ void get_gl_texture_format(int format, bool srgb, GLenum* glInternalFormat, GLen
         switch (*glInternalFormat) {
         case GL_RGBA8: *glInternalFormat = GL_SRGB8_ALPHA8; break;
         case GL_RGB8: *glInternalFormat = GL_SRGB8; break;
+        // NOT SUPPORTED FOR NOW
+        case GL_COMPRESSED_RGBA_BPTC_UNORM: *glInternalFormat = GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM; break;
+        case GL_COMPRESSED_RGBA_ASTC_4x4_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_5x4_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_5x5_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_6x5_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_6x6_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_8x5_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_8x6_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_8x8_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_10x5_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_10x6_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_10x8_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_10x10_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_12x10_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR; break;
+        case GL_COMPRESSED_RGBA_ASTC_12x12_KHR: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR; break;
+        case GL_COMPRESSED_RGB8_ETC2: *glInternalFormat = GL_COMPRESSED_SRGB8_ETC2; break;
+        case GL_COMPRESSED_RGBA8_ETC2_EAC: *glInternalFormat = GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC; break;
+        case GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2: *glInternalFormat = GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2; break;
         }
     }
 }

--- a/src/modules/r3d_cache.c
+++ b/src/modules/r3d_cache.c
@@ -53,6 +53,7 @@ bool r3d_cache_init(R3D_Flags flags)
 
     R3D_MOD_CACHE.environment = R3D_ENVIRONMENT_BASE;
 
+    R3D_MOD_CACHE.textureColorSpace = R3D_COLORSPACE_SRGB;
     R3D_MOD_CACHE.textureFilter = TEXTURE_FILTER_TRILINEAR;
     R3D_MOD_CACHE.layers = R3D_LAYER_ALL;
     R3D_MOD_CACHE.state = flags;

--- a/src/modules/r3d_cache.h
+++ b/src/modules/r3d_cache.h
@@ -84,6 +84,7 @@ extern struct r3d_cache {
     GLuint uniformBuffers[R3D_CACHE_UNIFORM_COUNT]; //< Current view state uniform buffer
     R3D_Environment environment;                    //< Current environment settings
     r3d_view_state_t viewState;                     //< Current view state
+    R3D_ColorSpace textureColorSpace;               //< Default texture color space for model loading
     TextureFilter textureFilter;                    //< Default texture filter for model loading
     Matrix matCubeViews[6];                         //< Pre-computed view matrices for cubemap faces
     R3D_Layer layers;                               //< Active rendering layers

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -87,6 +87,11 @@ void R3D_SetTextureFilter(TextureFilter filter)
     R3D_CACHE_SET(textureFilter, filter);
 }
 
+void R3D_SetTextureColorSpace(R3D_ColorSpace space)
+{
+    R3D_CACHE_SET(textureColorSpace, space);
+}
+
 R3D_Layer R3D_GetActiveLayers(void)
 {
     return R3D_CACHE_GET(layers);

--- a/src/r3d_model.c
+++ b/src/r3d_model.c
@@ -20,7 +20,10 @@
 
 static bool import_model(r3d_importer_t* importer, R3D_Model* model)
 {
-    r3d_importer_texture_cache_t* textureCache = r3d_importer_load_texture_cache(importer, R3D_CACHE_GET(textureFilter));
+    r3d_importer_texture_cache_t* textureCache = r3d_importer_load_texture_cache(
+        importer, R3D_CACHE_GET(textureColorSpace), R3D_CACHE_GET(textureFilter)
+    );
+
     if (textureCache == NULL) {
         r3d_importer_destroy(importer);
         return false;


### PR DESCRIPTION
This addresses the first point on the roadmap for version 0.7

The main goal is to support sRGB textures, which will therefore be enabled by default for 8-bit albedo maps. I'll also be looking into compressed formats.

A parameter to disable this will be available, similar to the default texture filtering option.

Along the way, the necessary changes will give us full control over how textures are loaded and configured during loading.

One of the first benefits is that anisotropic filtering is now handled correctly (for some reason, raylib struggles with it and it seems to work randomly).

However this also means we'll have to manage more things ourselves, especially regarding compressed formats, something that will need careful thought given the potential future support for WebGL 2.

Anyway, here's an example of the current Sponza scene versus what it should actually look like

## Current

<img width="800" height="450" alt="screenshot000" src="https://github.com/user-attachments/assets/bdb275da-5d5b-4bbb-81af-f6aa94bf2306" />

## Now (what it should look like)

<img width="800" height="450" alt="screenshot000" src="https://github.com/user-attachments/assets/7e12101d-941d-4f0b-9aee-d0cb91273204" />
