### PR TITLE
[BREAKING] API Refactor

### DIFF
--- a/examples/animation.c
+++ b/examples/animation.c
@@ -54,9 +54,9 @@ int main(void)
 
     // Load animations
     R3D_AnimationLib dancerAnims = R3D_LoadAnimationLib(RESOURCES_PATH "dancer.glb");
-    dancer.player = R3D_LoadAnimationPlayer(&dancer.skeleton, &dancerAnims);
-    dancer.player->states[0].weight = 1.0f;
-    dancer.player->states[0].loop = true;
+    R3D_AnimationPlayer dancerPlayer = R3D_LoadAnimationPlayer(dancer.skeleton, dancerAnims);
+    dancerPlayer.states[0].weight = 1.0f;
+    dancerPlayer.states[0].loop = true;
 
     // Setup lights with shadows
     R3D_Light lights[2];
@@ -89,7 +89,7 @@ int main(void)
         float delta = GetFrameTime();
 
         UpdateCamera(&camera, CAMERA_FREE);
-        R3D_UpdateAnimationPlayer(dancer.player, delta);
+        R3D_UpdateAnimationPlayer(&dancerPlayer, delta);
 
         // Animate lights
         R3D_SetLightColor(lights[0], ColorFromHSV(90.0f * GetTime() + 90.0f, 1.0f, 1.0f));
@@ -99,9 +99,9 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             R3D_Begin(camera);
-                R3D_DrawMesh(&plane, &planeMat, MatrixIdentity());
-                R3D_DrawModel(&dancer, (Vector3){0, 0, 1.5f}, 1.0f);
-                R3D_DrawModelInstanced(&dancer, &instances, 4);
+                R3D_DrawMesh(plane, planeMat, Vector3Zero(), 1.0f);
+                R3D_DrawAnimatedModel(dancer, dancerPlayer, (Vector3){0, 0, 1.5f}, 1.0f);
+                R3D_DrawAnimatedModelInstanced(dancer, dancerPlayer, instances, 4);
             R3D_End();
 
             DrawText("Model made by zhuoyi0904", 10, GetScreenHeight() - 26, 16, LIME);
@@ -110,9 +110,11 @@ int main(void)
     }
 
     // Cleanup
-    R3D_UnloadMesh(&plane);
-    R3D_UnloadMaterial(&planeMat);
-    R3D_UnloadModel(&dancer, true);
+    R3D_UnloadAnimationPlayer(dancerPlayer);
+    R3D_UnloadAnimationLib(dancerAnims);
+    R3D_UnloadModel(dancer, true);
+    R3D_UnloadMaterial(planeMat);
+    R3D_UnloadMesh(plane);
     R3D_Close();
 
     CloseWindow();

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -41,17 +41,18 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             R3D_Begin(camera);
-                R3D_DrawMesh(&plane, &material, MatrixTranslate(0, -0.5f, 0));
-                R3D_DrawMesh(&sphere, &material, MatrixIdentity());
+                R3D_DrawMesh(plane, material, (Vector3) {0, -0.5f, 0}, 1.0f);
+                R3D_DrawMesh(sphere, material, Vector3Zero(), 1.0f);
             R3D_End();
 
         EndDrawing();
     }
 
     // Cleanup
-    R3D_UnloadMesh(&plane);
-    R3D_UnloadMesh(&sphere);
+    R3D_UnloadMesh(sphere);
+    R3D_UnloadMesh(plane);
     R3D_Close();
+
     CloseWindow();
 
     return 0;

--- a/examples/billboards.c
+++ b/examples/billboards.c
@@ -35,8 +35,7 @@ int main(void)
     R3D_InstanceBuffer instances = R3D_LoadInstanceBuffer(64, R3D_INSTANCE_POSITION | R3D_INSTANCE_SCALE);
     Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION);
     Vector3* scales = R3D_MapInstances(instances, R3D_INSTANCE_SCALE);
-    for (int i = 0; i < 64; i++)
-    {
+    for (int i = 0; i < 64; i++) {
         float scaleFactor = GetRandomValue(25, 50) / 10.0f;
         scales[i] = (Vector3) {scaleFactor, scaleFactor, 1.0f};
         positions[i] = (Vector3) {
@@ -75,18 +74,18 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             R3D_Begin(camera);
-                R3D_DrawMesh(&meshGround, &matGround, MatrixIdentity());
-                R3D_DrawMeshInstanced(&meshBillboard, &matBillboard, &instances, 64);
+                R3D_DrawMesh(meshGround, matGround, Vector3Zero(), 1.0f);
+                R3D_DrawMeshInstanced(meshBillboard, matBillboard, instances, 64);
             R3D_End();
 
         EndDrawing();
     }
 
     // Cleanup
-    R3D_UnloadMaterial(&matBillboard);
-    R3D_UnloadMesh(&meshBillboard);
-    R3D_UnloadMesh(&meshGround);
+    R3D_UnloadMesh(meshBillboard);
+    R3D_UnloadMesh(meshGround);
     R3D_Close();
+
     CloseWindow();
 
     return 0;

--- a/examples/bloom.c
+++ b/examples/bloom.c
@@ -76,7 +76,7 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             R3D_Begin(camera);
-                R3D_DrawMesh(&cube, &material, MatrixIdentity());
+                R3D_DrawMesh(cube, material, Vector3Zero(), 1.0f);
             R3D_End();
 
             // Draw bloom info
@@ -88,7 +88,7 @@ int main(void)
         EndDrawing();
     }
 
-    R3D_UnloadMesh(&cube);
+    R3D_UnloadMesh(cube);
     R3D_Close();
 
     CloseWindow();

--- a/examples/decal.c
+++ b/examples/decal.c
@@ -105,14 +105,14 @@ int main(void)
             R3D_Begin(camera);
 
             for (int i = 0; i < 6; i++) {
-                R3D_DrawMesh(&meshPlane, &materialWalls, matRoom[i]);
+                R3D_DrawMeshPro(meshPlane, materialWalls, matRoom[i]);
             }
 
             if (decalCount > 0) {
-                R3D_DrawDecalInstanced(&decal, &instances, decalCount);
+                R3D_DrawDecalInstanced(decal, instances, decalCount);
             }
 
-            R3D_DrawDecal(&decal, MatrixTransform(targetPosition, decalRotation, decalScale));
+            R3D_DrawDecal(decal, MatrixTransform(targetPosition, decalRotation, decalScale));
 
         R3D_End();
 
@@ -126,7 +126,7 @@ int main(void)
     }
 
     // Cleanup
-    R3D_UnloadMesh(&meshPlane);
+    R3D_UnloadMesh(meshPlane);
     R3D_Close();
 
     CloseWindow();

--- a/examples/directional.c
+++ b/examples/directional.c
@@ -66,8 +66,8 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             R3D_Begin(camera);
-                R3D_DrawMesh(&plane, &material, MatrixTranslate(0, -0.5f, 0));
-                R3D_DrawMeshInstanced(&sphere, &material, &instances, INSTANCE_COUNT);
+                R3D_DrawMesh(plane, material, (Vector3) {0, -0.5f, 0}, 1.0f);
+                R3D_DrawMeshInstanced(sphere, material, instances, INSTANCE_COUNT);
             R3D_End();
 
             DrawFPS(10, 10);
@@ -77,9 +77,9 @@ int main(void)
 
     // Cleanup
     R3D_UnloadInstanceBuffer(instances);
-    R3D_UnloadMaterial(&material);
-    R3D_UnloadMesh(&sphere);
-    R3D_UnloadMesh(&plane);
+    R3D_UnloadMaterial(material);
+    R3D_UnloadMesh(sphere);
+    R3D_UnloadMesh(plane);
     R3D_Close();
 
     CloseWindow();

--- a/examples/dof.c
+++ b/examples/dof.c
@@ -91,7 +91,7 @@ int main(void)
 
             // Render scene
             R3D_Begin(camDefault);
-                R3D_DrawMeshInstanced(&meshSphere, &matDefault, &instances, INSTANCE_COUNT);
+                R3D_DrawMeshInstanced(meshSphere, matDefault, instances, INSTANCE_COUNT);
             R3D_End();
 
             // Display DoF values
@@ -115,7 +115,7 @@ int main(void)
 
     // Cleanup
     R3D_UnloadInstanceBuffer(instances);
-    R3D_UnloadMesh(&meshSphere);
+    R3D_UnloadMesh(meshSphere);
     R3D_Close();
 
     CloseWindow();

--- a/examples/emission.c
+++ b/examples/emission.c
@@ -76,8 +76,8 @@ int main(void)
 
             // Render scene
             R3D_Begin(camera);
-                R3D_DrawMesh(&plane, &material, MatrixIdentity());
-                R3D_DrawModelEx(&model, (Vector3){0}, (Vector3){0, 1, 0}, rotModel, (Vector3){1, 1, 1});
+                R3D_DrawMesh(plane, material, Vector3Zero(), 1.0f);
+                R3D_DrawModelEx(model, Vector3Zero(), QuaternionFromEuler(0.0f, rotModel, .0f), Vector3One());
             R3D_End();
 
             // UI
@@ -88,8 +88,8 @@ int main(void)
     }
 
     // Cleanup
-    R3D_UnloadModel(&model, true);
-    R3D_UnloadMesh(&plane);
+    R3D_UnloadModel(model, true);
+    R3D_UnloadMesh(plane);
     R3D_Close();
 
     CloseWindow();

--- a/examples/instanced.c
+++ b/examples/instanced.c
@@ -75,7 +75,7 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             R3D_Begin(camera);
-                R3D_DrawMeshInstanced(&mesh, &material, &instances, INSTANCE_COUNT);
+                R3D_DrawMeshInstanced(mesh, material, instances, INSTANCE_COUNT);
             R3D_End();
 
             DrawFPS(10, 10);
@@ -83,8 +83,8 @@ int main(void)
     }
 
     // Cleanup
-    R3D_UnloadMesh(&mesh);
-    R3D_UnloadMaterial(&material);
+    R3D_UnloadMaterial(material);
+    R3D_UnloadMesh(mesh);
     R3D_Close();
 
     CloseWindow();

--- a/examples/lights.c
+++ b/examples/lights.c
@@ -62,8 +62,8 @@ int main(void)
 
         // Draw scene
         R3D_Begin(camera);
-            R3D_DrawMesh(&plane, &material, MatrixTranslate(0, -0.5f, 0));
-            R3D_DrawMeshInstanced(&sphere, &material, &instances, GRID_SIZE*GRID_SIZE);
+            R3D_DrawMesh(plane, material, (Vector3) {0, -0.5f, 0}, 1.0f);
+            R3D_DrawMeshInstanced(sphere, material, instances, GRID_SIZE*GRID_SIZE);
         R3D_End();
 
         // Optionally show lights shapes
@@ -82,8 +82,8 @@ int main(void)
 
     // Cleanup
     R3D_UnloadInstanceBuffer(instances);
-    R3D_UnloadMesh(&sphere);
-    R3D_UnloadMesh(&plane);
+    R3D_UnloadMesh(sphere);
+    R3D_UnloadMesh(plane);
     R3D_Close();
 
     CloseWindow();

--- a/examples/particles.c
+++ b/examples/particles.c
@@ -96,15 +96,15 @@ int main(void)
 
         BeginDrawing();
             R3D_Begin(camera);
-                R3D_DrawMeshInstanced(&mesh, &material, &instances, particleCount);
+                R3D_DrawMeshInstanced(mesh, material, instances, particleCount);
             R3D_End();
             DrawFPS(10, 10);
         EndDrawing();
     }
 
     R3D_UnloadInstanceBuffer(instances);
-    R3D_UnloadMaterial(&material);
-    R3D_UnloadMesh(&mesh);
+    R3D_UnloadMaterial(material);
+    R3D_UnloadMesh(mesh);
     R3D_Close();
 
     CloseWindow();

--- a/examples/pbr_car.c
+++ b/examples/pbr_car.c
@@ -83,8 +83,8 @@ int main(void)
 
             // Draw scene
             R3D_Begin(camera);
-                R3D_DrawMesh(&ground, &groundMat, MatrixIdentity());
-                R3D_DrawModel(&model, (Vector3){0,0,0}, 1.0f);
+                R3D_DrawMesh(ground, groundMat, Vector3Zero(), 1.0f);
+                R3D_DrawModel(model, Vector3Zero(), 1.0f);
             R3D_End();
 
             DrawText("Model made by MaximePages", 10, GetScreenHeight()-26, 16, LIME);
@@ -93,7 +93,7 @@ int main(void)
     }
 
     // Cleanup
-    R3D_UnloadModel(&model, true);
+    R3D_UnloadModel(model, true);
     R3D_UnloadSkybox(skybox);
     R3D_Close();
 

--- a/examples/pbr_musket.c
+++ b/examples/pbr_musket.c
@@ -1,4 +1,3 @@
-#include "r3d/r3d_environment.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 
@@ -65,7 +64,7 @@ int main(void)
             R3D_Begin(camera);
                 Matrix scale = MatrixScale(modelScale, modelScale, modelScale);
                 Matrix transform = MatrixMultiply(modelMatrix, scale);
-                R3D_DrawModelPro(&model, transform);
+                R3D_DrawModelPro(model, transform);
             R3D_End();
 
             DrawText("Model made by TommyLingL", 10, GetScreenHeight()-26, 16, LIME);
@@ -74,7 +73,7 @@ int main(void)
     }
 
     // Cleanup
-    R3D_UnloadModel(&model, true);
+    R3D_UnloadModel(model, true);
     R3D_UnloadSkybox(skybox);
     R3D_Close();
 

--- a/examples/resize.c
+++ b/examples/resize.c
@@ -56,7 +56,7 @@ int main(void)
             // Draw spheres
             R3D_Begin(camera);
                 for (int i = 0; i < 5; i++) {
-                    R3D_DrawMesh(&sphere, &materials[i], MatrixTranslate((float)i - 2, 0, 0));
+                    R3D_DrawMesh(sphere, materials[i], (Vector3) {(float)i - 2, 0, 0}, 1.0f);
                 }
             R3D_End();
 
@@ -70,8 +70,9 @@ int main(void)
     }
 
     // Cleanup
-    R3D_UnloadMesh(&sphere);
+    R3D_UnloadMesh(sphere);
     R3D_Close();
+
     CloseWindow();
 
     return 0;

--- a/examples/skybox.c
+++ b/examples/skybox.c
@@ -56,7 +56,7 @@ int main(void)
         R3D_Begin(camera);
             for (int x = 0; x < 7; x++) {
                 for (int y = 0; y < 7; y++) {
-                    R3D_DrawMesh(&sphere, &materials[y * 7 + x], MatrixTranslate((float)x - 3, (float)y - 3, 0.0f));
+                    R3D_DrawMesh(sphere, materials[y * 7 + x], (Vector3) {(float)x - 3, (float)y - 3, 0.0f}, 1.0f);
                 }
             }
         R3D_End();
@@ -65,8 +65,8 @@ int main(void)
     }
 
     // Cleanup
-    R3D_UnloadMesh(&sphere);
     R3D_UnloadSkybox(skybox);
+    R3D_UnloadMesh(sphere);
     R3D_Close();
 
     CloseWindow();

--- a/examples/sponza.c
+++ b/examples/sponza.c
@@ -1,4 +1,5 @@
 #include <r3d/r3d.h>
+#include <raymath.h>
 
 #ifndef RESOURCES_PATH
 #	define RESOURCES_PATH "./"
@@ -104,7 +105,7 @@ int main(void)
 
             // Draw Sponza model
             R3D_Begin(camera);
-                R3D_DrawModel(&sponza, (Vector3){0,0,0}, 1.0f);
+                R3D_DrawModel(sponza, Vector3Zero(), 1.0f);
             R3D_End();
 
             // Draw lights
@@ -132,7 +133,7 @@ int main(void)
     }
 
     // Cleanup
-    R3D_UnloadModel(&sponza, true);
+    R3D_UnloadModel(sponza, true);
     R3D_UnloadSkybox(skybox);
     R3D_Close();
 

--- a/examples/sprite.c
+++ b/examples/sprite.c
@@ -71,17 +71,17 @@ int main(void)
 
             // Draw scene
             R3D_Begin(camera);
-                R3D_DrawMesh(&meshGround, &matGround, MatrixTranslate(0, -0.5f, 0));
-                R3D_DrawMesh(&meshSprite, &matSprite, MatrixTranslate(birdPos.x, birdPos.y, 0));
+                R3D_DrawMesh(meshGround, matGround, (Vector3) {0, -0.5f, 0}, 1.0f);
+                R3D_DrawMesh(meshSprite, matSprite, (Vector3) {birdPos.x, birdPos.y, 0}, 1.0f);
             R3D_End();
 
         EndDrawing();
     }
 
     // Cleanup
-    R3D_UnloadMaterial(&matSprite);
-    R3D_UnloadMesh(&meshSprite);
-    R3D_UnloadMesh(&meshGround);
+    R3D_UnloadMaterial(matSprite);
+    R3D_UnloadMesh(meshSprite);
+    R3D_UnloadMesh(meshGround);
     R3D_Close();
 
     CloseWindow();

--- a/examples/transparency.c
+++ b/examples/transparency.c
@@ -1,4 +1,5 @@
 #include <r3d/r3d.h>
+#include <raymath.h>
 
 int main(void)
 {
@@ -11,7 +12,7 @@ int main(void)
 
     // Create cube model
     R3D_Mesh mesh = R3D_GenMeshCube(1, 1, 1);
-    R3D_Model cube = R3D_LoadModelFromMesh(&mesh);
+    R3D_Model cube = R3D_LoadModelFromMesh(mesh);
     cube.materials[0].transparencyMode = R3D_TRANSPARENCY_ALPHA;
     cube.materials[0].albedo.color = (Color){100, 100, 255, 100};
     cube.materials[0].orm.occlusion = 1.0f;
@@ -20,14 +21,14 @@ int main(void)
 
     // Create plane model
     mesh = R3D_GenMeshPlane(1000, 1000, 1, 1);
-    R3D_Model plane = R3D_LoadModelFromMesh(&mesh);
+    R3D_Model plane = R3D_LoadModelFromMesh(mesh);
     plane.materials[0].orm.occlusion = 1.0f;
     plane.materials[0].orm.roughness = 1.0f;
     plane.materials[0].orm.metalness = 0.0f;
 
     // Create sphere model
     mesh = R3D_GenMeshSphere(0.5f, 64, 64);
-    R3D_Model sphere = R3D_LoadModelFromMesh(&mesh);
+    R3D_Model sphere = R3D_LoadModelFromMesh(mesh);
     sphere.materials[0].orm.occlusion = 1.0f;
     sphere.materials[0].orm.roughness = 0.25f;
     sphere.materials[0].orm.metalness = 0.75f;
@@ -56,18 +57,18 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             R3D_Begin(camera);
-                R3D_DrawModel(&plane, (Vector3){0, -0.5f, 0}, 1.0f);
-                R3D_DrawModel(&sphere, (Vector3){0, 0, 0}, 1.0f);
-                R3D_DrawModel(&cube, (Vector3){0, 0, 0}, 1.0f);
+                R3D_DrawModel(plane, (Vector3){0, -0.5f, 0}, 1.0f);
+                R3D_DrawModel(sphere, Vector3Zero(), 1.0f);
+                R3D_DrawModel(cube, Vector3Zero(), 1.0f);
             R3D_End();
 
         EndDrawing();
     }
 
     // Cleanup
-    R3D_UnloadModel(&plane, false);
-    R3D_UnloadModel(&sphere, false);
-    R3D_UnloadModel(&cube, false);
+    R3D_UnloadModel(sphere, false);
+    R3D_UnloadModel(plane, false);
+    R3D_UnloadModel(cube, false);
     R3D_Close();
 
     CloseWindow();

--- a/include/r3d/r3d_animation.h
+++ b/include/r3d/r3d_animation.h
@@ -138,48 +138,56 @@ R3DAPI R3D_AnimationLib R3D_LoadAnimationLib(const char* filePath);
 R3DAPI R3D_AnimationLib R3D_LoadAnimationLibFromMemory(const void* data, unsigned int size, const char* hint);
 
 /**
- * @brief Frees memory allocated for model animations.
- * @param animLib Pointer to the animation library to free.
+ * @brief Releases all resources associated with an animation library.
+ * @param animLib Animation library to unload.
  */
-R3DAPI void R3D_UnloadAnimationLib(R3D_AnimationLib* animLib);
+R3DAPI void R3D_UnloadAnimationLib(R3D_AnimationLib animLib);
 
 /**
- * @brief Retrieves the index of a named animation within an animation library.
- * @param animLib Pointer to the animation library.
- * @param name Name of the animation to look for (case-sensitive).
- * @return Zero-based index of the matching animation, or -1 if not found.
+ * @brief Returns the index of an animation by name.
+ * @param animLib Animation library to search.
+ * @param name Name of the animation (case-sensitive).
+ * @return Zero-based index if found, or -1 if not found.
  */
-R3DAPI int R3D_GetAnimationIndex(const R3D_AnimationLib* animLib, const char* name);
+R3DAPI int R3D_GetAnimationIndex(R3D_AnimationLib animLib, const char* name);
 
 /**
- * @brief Finds a named animation in an array of animations.
- * @param animLib Pointer to the animation library.
- * @param name Name of the animation to find (case-sensitive).
- * @return Pointer to the matching animation, or NULL if not found.
+ * @brief Retrieves an animation by name.
+ * @param animLib Animation library to search.
+ * @param name Name of the animation (case-sensitive).
+ * @return Pointer to the animation, or NULL if not found.
  */
-R3DAPI R3D_Animation* R3D_GetAnimation(const R3D_AnimationLib* animLib, const char* name);
+R3DAPI R3D_Animation* R3D_GetAnimation(R3D_AnimationLib animLib, const char* name);
 
 // ----------------------------------------
 // ANIMATION: Animation Player Functions
 // ----------------------------------------
 
 /**
- * @brief Creates a new animation player for a skeleton and animation library.
+ * @brief Creates an animation player for a skeleton and animation library.
  *
- * Allocates internal structures for managing animation states and poses.
+ * Allocates the internal data required to manage animation state and poses.
  *
- * @param skeleton Pointer to the target skeleton.
- * @param animLib Pointer to the animation library containing available animations.
- * @return Pointer to a newly created animation player, or NULL on failure.
+ * @param skeleton Skeleton used by the player.
+ * @param animLib Animation library providing available animations.
+ * @return Newly created animation player, or zeroed struct on failure.
  */
-R3DAPI R3D_AnimationPlayer* R3D_LoadAnimationPlayer(const R3D_Skeleton* skeleton, const R3D_AnimationLib* animLib);
+R3DAPI R3D_AnimationPlayer R3D_LoadAnimationPlayer(R3D_Skeleton skeleton, R3D_AnimationLib animLib);
 
 /**
- * @brief Destroys an animation player and frees its allocated resources.
+ * @brief Releases all resources used by an animation player.
  *
- * @param player Pointer to the animation player to destroy.
+ * @param player Animation player to unload.
  */
-R3DAPI void R3D_UnloadAnimationPlayer(R3D_AnimationPlayer* player);
+R3DAPI void R3D_UnloadAnimationPlayer(R3D_AnimationPlayer player);
+
+/**
+ * @brief Determines whether an animation player is valid.
+ *
+ * @param player Animation player to check.
+ * @return true if the player is valid, false otherwise.
+ */
+R3DAPI bool R3D_IsAnimationPlayerValid(R3D_AnimationPlayer player);
 
 /**
  * @brief Advances the animation player's time for all active animation states.

--- a/include/r3d/r3d_draw.h
+++ b/include/r3d/r3d_draw.h
@@ -9,6 +9,7 @@
 #ifndef R3D_DRAW_H
 #define R3D_DRAW_H
 
+#include "./r3d_animation.h"
 #include "./r3d_instance.h"
 #include "./r3d_platform.h"
 #include "./r3d_model.h"
@@ -29,164 +30,160 @@ extern "C" {
 #endif
 
 /**
- * @brief Begins a rendering session for a 3D camera.
- * 
- * This function starts a rendering session, preparing the engine to handle subsequent 
- * draw calls using the provided camera settings. Rendering output will be directed 
- * to the default screen framebuffer.
- * 
- * @param camera The camera to use for rendering the scene.
+ * @brief Begins a rendering session using the given camera.
+ *
+ * Rendering output is directed to the default framebuffer.
+ *
+ * @param camera Camera used to render the scene.
  */
 R3DAPI void R3D_Begin(Camera3D camera);
 
 /**
- * @brief Begins a rendering session for a 3D camera with an optional custom render target.
- * 
- * This function starts a rendering session, preparing the engine to handle subsequent 
- * draw calls using the provided camera settings. If a render target is provided, rendering 
- * output will be directed to it. If the target is `NULL`, rendering will be performed 
- * directly to the screen framebuffer (same behavior as R3D_Begin).
- * 
- * @param camera The camera to use for rendering the scene.
- * @param target Optional pointer to a RenderTexture to render into. Can be NULL to render 
- *               directly to the screen.
+ * @brief Begins a rendering session with a custom render target.
+ *
+ * If the render target is invalid (ID = 0), rendering goes to the screen.
+ *
+ * @param target Render texture to render into.
+ * @param camera Camera used to render the scene.
  */
-R3DAPI void R3D_BeginEx(Camera3D camera, const RenderTexture* target);
+R3DAPI void R3D_BeginEx(RenderTexture target, Camera3D camera);
 
 /**
  * @brief Ends the current rendering session.
- * 
- * This function signals the end of a rendering session, at which point the engine 
- * will process all necessary render passes and output the final result to the main 
- * or custom framebuffer.
+ *
+ * This function is the one that actually performs the full
+ * rendering of the described scene. It carries out culling,
+ * sorting, shadow rendering, scene rendering, and screen /
+ * post-processing effects.
  */
 R3DAPI void R3D_End(void);
 
 /**
- * @brief Draws a mesh with a specified material and transformation.
- * 
- * This function renders a mesh with the provided material and transformation matrix.
- * 
- * @param mesh A pointer to the mesh to render. Cannot be NULL.
- * @param material A pointer to the material to apply to the mesh. Can be NULL, default material will be used.
- * @param transform The transformation matrix to apply to the mesh.
+ * @brief Queues a mesh draw command.
+ *
+ * Draws the mesh at the given position and uniform scale.
+ * The command is executed during R3D_End().
  */
-R3DAPI void R3D_DrawMesh(const R3D_Mesh* mesh, const R3D_Material* material, Matrix transform);
+R3DAPI void R3D_DrawMesh(R3D_Mesh mesh, R3D_Material material, Vector3 position, float scale);
 
 /**
- * @brief Draws a mesh with instancing support.
- * 
- * This function renders a mesh multiple times for each instance.
- * 
- * @param mesh A pointer to the mesh to render. Cannot be NULL.
- * @param material A pointer to the material to apply to the mesh. Can be NULL, default material will be used.
- * @param instances A pointer tot the instance buffer to use. Cannot be NULL.
- * @param count The number of instances to render. Clamped between 1 and instance buffer capacity.
+ * @brief Queues a mesh draw command with rotation and non-uniform scale.
+ *
+ * Executed during R3D_End().
  */
-R3DAPI void R3D_DrawMeshInstanced(const R3D_Mesh* mesh, const R3D_Material* material, const R3D_InstanceBuffer* instances, int count);
+R3DAPI void R3D_DrawMeshEx(R3D_Mesh mesh, R3D_Material material, Vector3 position, Quaternion rotation, Vector3 scale);
 
 /**
- * @brief Draws a mesh with instancing support.
+ * @brief Queues a mesh draw command using a full transform matrix.
  *
- * This function renders a mesh multiple times for each instance.
- * Allows to provide a bounding box and global transformation of all instances.
- *
- * @param mesh A pointer to the mesh to render. Cannot be NULL.
- * @param material A pointer to the material to apply to the mesh. Can be NULL, default material will be used.
- * @param globalAaabb Bounding box for frustum culling. Ignored if zeroed.
- * @param globalTransform Global transformation matrix for all instances.
- * @param instances A pointer tot the instance buffer to use. Cannot be NULL.
- * @param count The number of instances to render. Clamped between 1 and instance buffer capacity.
+ * Executed during R3D_End().
  */
-R3DAPI void R3D_DrawMeshInstancedEx(const R3D_Mesh* mesh, const R3D_Material* material,
-                                    BoundingBox globalAabb, Matrix globalTransform,
-                                    const R3D_InstanceBuffer* instances, int count);
+R3DAPI void R3D_DrawMeshPro(R3D_Mesh mesh, R3D_Material material, Matrix transform);
 
 /**
- * @brief Draws a model at a specified position and scale.
+ * @brief Queues an instanced mesh draw command.
  *
- * This function renders a model at the given position with the specified scale factor.
- *
- * @param model A pointer to the model to render.
- * @param position The position to place the model at.
- * @param scale The scale factor to apply to the model.
+ * Draws multiple instances using the provided instance buffer.
+ * Executed during R3D_End().
  */
-R3DAPI void R3D_DrawModel(const R3D_Model* model, Vector3 position, float scale);
+R3DAPI void R3D_DrawMeshInstanced(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int count);
 
 /**
- * @brief Draws a model with advanced transformation options.
+ * @brief Queues an instanced mesh draw command with an additional transform.
  *
- * This function renders a model with a specified position, rotation axis, rotation 
- * angle, and scale. It provides more control over how the model is transformed before 
- * rendering.
- *
- * @param model A pointer to the model to render.
- * @param position The position to place the model at.
- * @param rotationAxis The axis of rotation for the model.
- * @param rotationAngle The angle to rotate the model.
- * @param scale The scale factor to apply to the model.
+ * The transform is applied to all instances. Executed during R3D_End().
  */
-R3DAPI void R3D_DrawModelEx(const R3D_Model* model, Vector3 position, Vector3 rotationAxis, float rotationAngle, Vector3 scale);
+R3DAPI void R3D_DrawMeshInstancedEx(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int count, Matrix transform);
 
 /**
- * @brief Draws a model using a transformation matrix.
+ * @brief Queues a model draw command.
  *
- * This function renders a model using a custom transformation matrix, allowing full control 
- * over the model's position, rotation, scale, and skew. It is intended for advanced rendering 
- * scenarios where a single matrix defines the complete transformation.
- *
- * @param model A pointer to the model to render.
- * @param transform A transformation matrix that defines how to position, rotate, and scale the model.
+ * Draws the model at the given position and uniform scale.
+ * Executed during R3D_End().
  */
-R3DAPI void R3D_DrawModelPro(const R3D_Model* model, Matrix transform);
+R3DAPI void R3D_DrawModel(R3D_Model model, Vector3 position, float scale);
 
 /**
- * @brief Draws a model with instancing support.
+ * @brief Queues a model draw command with rotation and non-uniform scale.
  *
- * This function renders a model multiple times for each instance.
- * 
- * @param model A pointer to the model to render. Cannot be NULL.
- * @param instances A pointer tot the instance buffer to use. Cannot be NULL.
- * @param count The number of instances to render. Clamped between 1 and instance buffer capacity.
+ * Executed during R3D_End().
  */
-R3DAPI void R3D_DrawModelInstanced(const R3D_Model* model, const R3D_InstanceBuffer* instances, int count);
+R3DAPI void R3D_DrawModelEx(R3D_Model model, Vector3 position, Quaternion rotation, Vector3 scale);
 
 /**
- * @brief Draws a model with instancing support.
+ * @brief Queues a model draw command using a full transform matrix.
  *
- * This function renders a model multiple times for each instance.
- * Allows to provide a bounding box and global transformation of all instances.
- *
- * @param model A pointer to the model to render. Cannot be NULL.
- * @param globalAaabb Bounding box for frustum culling. Ignored if zeroed.
- * @param globalTransform Global transformation matrix for all instances.
- * @param instances A pointer tot the instance buffer to use. Cannot be NULL.
- * @param count The number of instances to render. Clamped between 1 and instance buffer capacity.
+ * Executed during R3D_End().
  */
-R3DAPI void R3D_DrawModelInstancedEx(const R3D_Model* model,
-                                     BoundingBox globalAabb, Matrix globalTransform,
-                                     const R3D_InstanceBuffer* instances, int count);
+R3DAPI void R3D_DrawModelPro(R3D_Model model, Matrix transform);
 
 /**
- * @brief Draws a decal using a transformation matrix.
+ * @brief Queues an instanced model draw command.
  *
- * This function renders a decal in 3D space at the given position.
- *
- * @param decal A pointer to the decal to render.
- * @param transform A transformation matrix that defines how to position, rotate, and scale the decal.
+ * Draws multiple instances using the provided instance buffer.
+ * Executed during R3D_End().
  */
-R3DAPI void R3D_DrawDecal(const R3D_Decal* decal, Matrix transform);
+R3DAPI void R3D_DrawModelInstanced(R3D_Model model, R3D_InstanceBuffer instances, int count);
 
 /**
- * @brief Draws a decal with instancing support.
+ * @brief Queues an instanced model draw command with an additional transform.
  *
- * This function renders a decal multiple times for each instance.
- *
- * @param decal A pointer to the decal to render. Cannot be NULL.
- * @param instances A pointer tot the instance buffer to use. Cannot be NULL.
- * @param count The number of instances to render. Clamped between 1 and instance buffer capacity.
+ * The transform is applied to all instances. Executed during R3D_End().
  */
-R3DAPI void R3D_DrawDecalInstanced(const R3D_Decal* decal, const R3D_InstanceBuffer* instances, int count);
+R3DAPI void R3D_DrawModelInstancedEx(R3D_Model model, R3D_InstanceBuffer instances, int count, Matrix transform);
+
+/**
+ * @brief Queues an animated model draw command.
+ *
+ * Uses the provided animation player to compute the pose.
+ * Executed during R3D_End().
+ */
+R3DAPI void R3D_DrawAnimatedModel(R3D_Model model, R3D_AnimationPlayer player, Vector3 position, float scale);
+
+/**
+ * @brief Queues an animated model draw command with rotation and non-uniform scale.
+ *
+ * Executed during R3D_End().
+ */
+R3DAPI void R3D_DrawAnimatedModelEx(R3D_Model model, R3D_AnimationPlayer player, Vector3 position, Quaternion rotation, Vector3 scale);
+
+/**
+ * @brief Queues an animated model draw command using a full transform matrix.
+ *
+ * Executed during R3D_End().
+ */
+R3DAPI void R3D_DrawAnimatedModelPro(R3D_Model model, R3D_AnimationPlayer player, Matrix transform);
+
+/**
+ * @brief Queues an instanced animated model draw command.
+ *
+ * Draws multiple animated instances using the provided instance buffer.
+ * Executed during R3D_End().
+ */
+R3DAPI void R3D_DrawAnimatedModelInstanced(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int count);
+
+/**
+ * @brief Queues an instanced animated model draw command with an additional transform.
+ *
+ * The transform is applied to all instances. Executed during R3D_End().
+ */
+R3DAPI void R3D_DrawAnimatedModelInstancedEx(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int count, Matrix transform);
+
+/**
+ * @brief Queues a decal draw command.
+ *
+ * The decal is transformed by the given matrix.
+ * Executed during R3D_End().
+ */
+R3DAPI void R3D_DrawDecal(R3D_Decal decal, Matrix transform);
+
+/**
+ * @brief Queues an instanced decal draw command.
+ *
+ * Draws multiple decals using the provided instance buffer.
+ * Executed during R3D_End().
+ */
+R3DAPI void R3D_DrawDecalInstanced(R3D_Decal decal, R3D_InstanceBuffer instances, int count);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -352,7 +352,7 @@ typedef struct R3D_Environment {
  *
  * Example: `float intensity = R3D_ENVIRONMENT_GET(bloom.intensity);`
  */
-#define R3D_ENVIRONMENT_GET(member)         (R3D_GetEnvironment()->member)
+#define R3D_ENVIRONMENT_GET(member) (R3D_GetEnvironment()->member)
 
 /**
  * @brief Quick write access to environment members.
@@ -362,7 +362,7 @@ typedef struct R3D_Environment {
  *
  * Example: `R3D_ENVIRONMENT_SET(bloom.intensity, 0.05f);`
  */
-#define R3D_ENVIRONMENT_SET(member, ...)    ((R3D_GetEnvironment()->member) = (__VA_ARGS__))
+#define R3D_ENVIRONMENT_SET(member, ...) ((R3D_GetEnvironment()->member) = (__VA_ARGS__))
 
 // ========================================
 // PUBLIC API

--- a/include/r3d/r3d_material.h
+++ b/include/r3d/r3d_material.h
@@ -18,6 +18,46 @@
  */
 
 // ========================================
+// CONSTANTS
+// ========================================
+
+/**
+ * @brief Default environment configuration.
+ *
+ * Initializes an R3D_Environment structure with sensible default values for all
+ * rendering parameters. Use this as a starting point for custom configurations.
+ */
+#define R3D_MATERIAL_BASE                               \
+    R3D_LITERAL(R3D_Material) {                         \
+        .albedo = {                                     \
+            .texture = {0},                             \
+            .color = {255, 255, 255, 255},              \
+        },                                              \
+        .emission = {                                   \
+            .texture = {0},                             \
+            .color = {255, 255, 255, 255},              \
+            .energy = 0.0f,                             \
+        },                                              \
+        .normal = {                                     \
+            .texture = {0},                             \
+            .scale = 1.0f,                              \
+        },                                              \
+        .orm = {                                        \
+            .texture = {0},                             \
+            .occlusion = 1.0f,                          \
+            .roughness = 1.0f,                          \
+            .metalness = 0.0f,                          \
+        },                                              \
+        .transparencyMode = R3D_TRANSPARENCY_DISABLED,  \
+        .billboardMode = R3D_BILLBOARD_DISABLED,        \
+        .blendMode = R3D_BLEND_MIX,                     \
+        .cullMode = R3D_CULL_BACK,                      \
+        .uvOffset = {0.0f, 0.0f},                       \
+        .uvScale = {1.0f, 1.0f},                        \
+        .alphaCutoff = 0.01f,                           \
+    }
+
+// ========================================
 // ENUMS TYPES
 // ========================================
 
@@ -75,6 +115,29 @@ typedef enum R3D_CullMode {
 // STRUCTS TYPES
 // ========================================
 
+typedef struct R3D_MapAlbedo {
+    Texture2D texture;      ///< Albedo (base color) texture. (default: WHITE)
+    Color color;            ///< Albedo color multiplier. (defulat: WHITE)
+} R3D_MapAlbedo;
+
+typedef struct R3D_MapEmission {
+    Texture2D texture;      ///< Emission texture. (default: WHITE)
+    Color color;            ///< Emission color. (default: WHITE)
+    float energy;           ///< Emission energy multiplier. (default: 0.0f)
+} R3D_MapEmission;
+
+typedef struct R3D_MapNormal {
+    Texture2D texture;      ///< Normal map texture. (default: Front Facing)
+    float scale;            ///< Normal scale. (default: 1.0f)
+} R3D_MapNormal;
+
+typedef struct R3D_MapORM {
+    Texture2D texture;      ///< Combined Occlusion-Roughness-Metalness texture. (default: WHITE)
+    float occlusion;        ///< Occlusion multiplier. (default: 1.0f)
+    float roughness;        ///< Roughness multiplier. (default: 1.0f)
+    float metalness;        ///< Metalness multiplier. (default: 0.0f)
+} R3D_MapORM;
+
 /**
  * @brief Represents a material with textures, parameters, and rendering modes.
  *
@@ -82,45 +145,29 @@ typedef enum R3D_CullMode {
  */
 typedef struct R3D_Material {
 
-    struct R3D_MapAlbedo {
-        Texture2D texture;      ///< Albedo (base color) texture.
-        Color color;            ///< Albedo color multiplier.
-    } albedo;
+    R3D_MapAlbedo albedo;
+    R3D_MapEmission emission;
+    R3D_MapNormal normal;
+    R3D_MapORM orm;
 
-    struct R3D_MapEmission {
-        Texture2D texture;      ///< Emission texture.
-        Color color;            ///< Emission color.
-        float energy;           ///< Emission energy multiplier.
-    } emission;
-
-    struct R3D_MapNormal {
-        Texture2D texture;      ///< Normal map texture.
-        float scale;            ///< Normal scale.
-    } normal;
-
-    struct R3D_MapORM {
-        Texture2D texture;      ///< Combined Occlusion-Roughness-Metalness texture.
-        float occlusion;        ///< Occlusion multiplier.
-        float roughness;        ///< Roughness multiplier.
-        float metalness;        ///< Metalness multiplier.
-    } orm;
-
-    R3D_TransparencyMode transparencyMode;  ///< Transparency mode applied to the object.
-    R3D_BillboardMode billboardMode;        ///< Billboard mode applied to the object.
-    R3D_BlendMode blendMode;                ///< Blend mode used for rendering.
-    R3D_CullMode cullMode;                  ///< Face culling mode used for rendering.
+    R3D_TransparencyMode transparencyMode;  ///< Transparency mode applied to the object. (default: DISABLED)
+    R3D_BillboardMode billboardMode;        ///< Billboard mode applied to the object. (default: DISABLED)
+    R3D_BlendMode blendMode;                ///< Blend mode used for rendering. (default: MIX)
+    R3D_CullMode cullMode;                  ///< Face culling mode used for rendering. (default: BACK)
 
     Vector2 uvOffset;                       /**< UV offset applied to the texture coordinates.
                                              *  For models, this can be set manually.
                                              *  For sprites, this value is overridden automatically.
+                                             *  (default: {0.0f, 0.0f})
                                              */
 
     Vector2 uvScale;                        /**< UV scale factor applied to the texture coordinates.
                                              *  For models, this can be set manually.
                                              *  For sprites, this value is overridden automatically.
+                                             *  (default: {1.0f, 1.0f})
                                              */
 
-    float alphaCutoff;          ///< Alpha threshold below which fragments are discarded during opaque rendering.
+    float alphaCutoff;          ///< Alpha threshold below which fragments are discarded during opaque rendering. (default: 0.01f)
 
 } R3D_Material;
 
@@ -135,12 +182,22 @@ extern "C" {
 /**
  * @brief Get the default material configuration.
  *
- * Returns a default material with standard properties and default textures.
- * This material can be used as a fallback or starting point for custom materials.
+ * Returns `R3D_MATERIAL_BASE` by default,
+ * or the material defined via `R3D_SetDefaultMaterial()`.
  *
  * @return Default material structure with standard properties.
  */
 R3DAPI R3D_Material R3D_GetDefaultMaterial(void);
+
+/**
+ * @brief Set the default material configuration.
+ *
+ * Allows you to override the default material.
+ * The default material will be used as the basis for loading 3D models.
+ *
+ * @param material Default material to define.
+ */
+R3DAPI void R3D_SetDefaultMaterial(R3D_Material material);
 
 /**
  * @brief Unload a material and its associated textures.
@@ -154,7 +211,7 @@ R3DAPI R3D_Material R3D_GetDefaultMaterial(void);
  *
  * @param material Pointer to the material structure to be unloaded.
  */
-R3DAPI void R3D_UnloadMaterial(const R3D_Material* material);
+R3DAPI void R3D_UnloadMaterial(R3D_Material material);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/r3d/r3d_material.h
+++ b/include/r3d/r3d_material.h
@@ -115,59 +115,70 @@ typedef enum R3D_CullMode {
 // STRUCTS TYPES
 // ========================================
 
+/**
+ * @brief Albedo (base color) map.
+ *
+ * Provides the base color texture and a color multiplier.
+ */
 typedef struct R3D_MapAlbedo {
-    Texture2D texture;      ///< Albedo (base color) texture. (default: WHITE)
-    Color color;            ///< Albedo color multiplier. (defulat: WHITE)
+    Texture2D texture;  ///< Base color texture (default: WHITE)
+    Color color;        ///< Color multiplier (default: WHITE)
 } R3D_MapAlbedo;
 
+/**
+ * @brief Emission map.
+ *
+ * Provides emission texture, color, and energy multiplier.
+ */
 typedef struct R3D_MapEmission {
-    Texture2D texture;      ///< Emission texture. (default: WHITE)
-    Color color;            ///< Emission color. (default: WHITE)
-    float energy;           ///< Emission energy multiplier. (default: 0.0f)
+    Texture2D texture;  ///< Emission texture (default: WHITE)
+    Color color;        ///< Emission color (default: WHITE)
+    float energy;       ///< Emission strength (default: 0.0f)
 } R3D_MapEmission;
 
+/**
+ * @brief Normal map.
+ *
+ * Provides normal map texture and scale factor.
+ */
 typedef struct R3D_MapNormal {
-    Texture2D texture;      ///< Normal map texture. (default: Front Facing)
-    float scale;            ///< Normal scale. (default: 1.0f)
+    Texture2D texture;  ///< Normal map texture (default: Front Facing)
+    float scale;        ///< Normal scale (default: 1.0f)
 } R3D_MapNormal;
 
+/**
+ * @brief Combined Occlusion-Roughness-Metalness (ORM) map.
+ *
+ * Provides texture and individual multipliers for occlusion, roughness, and metalness.
+ */
 typedef struct R3D_MapORM {
-    Texture2D texture;      ///< Combined Occlusion-Roughness-Metalness texture. (default: WHITE)
-    float occlusion;        ///< Occlusion multiplier. (default: 1.0f)
-    float roughness;        ///< Roughness multiplier. (default: 1.0f)
-    float metalness;        ///< Metalness multiplier. (default: 0.0f)
+    Texture2D texture;  ///< ORM texture (default: WHITE)
+    float occlusion;    ///< Occlusion multiplier (default: 1.0f)
+    float roughness;    ///< Roughness multiplier (default: 1.0f)
+    float metalness;    ///< Metalness multiplier (default: 0.0f)
 } R3D_MapORM;
 
 /**
- * @brief Represents a material with textures, parameters, and rendering modes.
+ * @brief Material definition.
  *
- * Combines multiple texture maps and settings used during shading.
+ * Combines multiple texture maps and rendering parameters for shading.
  */
 typedef struct R3D_Material {
 
-    R3D_MapAlbedo albedo;
-    R3D_MapEmission emission;
-    R3D_MapNormal normal;
-    R3D_MapORM orm;
+    R3D_MapAlbedo albedo;       ///< Albedo map
+    R3D_MapEmission emission;   ///< Emission map
+    R3D_MapNormal normal;       ///< Normal map
+    R3D_MapORM orm;             ///< Occlusion-Roughness-Metalness map
 
-    R3D_TransparencyMode transparencyMode;  ///< Transparency mode applied to the object. (default: DISABLED)
-    R3D_BillboardMode billboardMode;        ///< Billboard mode applied to the object. (default: DISABLED)
-    R3D_BlendMode blendMode;                ///< Blend mode used for rendering. (default: MIX)
-    R3D_CullMode cullMode;                  ///< Face culling mode used for rendering. (default: BACK)
+    R3D_TransparencyMode transparencyMode;  ///< Transparency mode (default: DISABLED)
+    R3D_BillboardMode billboardMode;        ///< Billboard mode (default: DISABLED)
+    R3D_BlendMode blendMode;                ///< Blend mode (default: MIX)
+    R3D_CullMode cullMode;                  ///< Face culling mode (default: BACK)
 
-    Vector2 uvOffset;                       /**< UV offset applied to the texture coordinates.
-                                             *  For models, this can be set manually.
-                                             *  For sprites, this value is overridden automatically.
-                                             *  (default: {0.0f, 0.0f})
-                                             */
+    Vector2 uvOffset;    ///< UV offset (default: {0.0f, 0.0f})
+    Vector2 uvScale;     ///< UV scale (default: {1.0f, 1.0f})
 
-    Vector2 uvScale;                        /**< UV scale factor applied to the texture coordinates.
-                                             *  For models, this can be set manually.
-                                             *  For sprites, this value is overridden automatically.
-                                             *  (default: {1.0f, 1.0f})
-                                             */
-
-    float alphaCutoff;          ///< Alpha threshold below which fragments are discarded during opaque rendering. (default: 0.01f)
+    float alphaCutoff;   ///< Alpha cutoff threshold (default: 0.01f)
 
 } R3D_Material;
 

--- a/include/r3d/r3d_mesh.h
+++ b/include/r3d/r3d_mesh.h
@@ -96,29 +96,29 @@ extern "C" {
 /**
  * @brief Creates a 3D mesh from CPU-side mesh data.
  * @param type Primitive type used to interpret vertex data.
- * @param data Pointer to the R3D_MeshData containing vertices and indices (cannot be NULL).
+ * @param data R3D_MeshData containing vertices and indices (cannot be NULL).
  * @param aabb Optional pointer to a bounding box. If NULL, it will be computed automatically.
  * @param usage Hint on how the mesh will be used.
  * @return Created R3D_Mesh.
  * @note The function copies all vertex and index data into GPU buffers.
  */
-R3DAPI R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, const R3D_MeshData* data, const BoundingBox* aabb, R3D_MeshUsage usage);
+R3DAPI R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, R3D_MeshData data, const BoundingBox* aabb, R3D_MeshUsage usage);
 
 /**
  * @brief Destroys a 3D mesh and frees its resources.
- * @param mesh Pointer to the R3D_Mesh to destroy.
+ * @param mesh R3D_Mesh to destroy.
  */
-R3DAPI void R3D_UnloadMesh(R3D_Mesh* mesh);
+R3DAPI void R3D_UnloadMesh(R3D_Mesh mesh);
 
 /**
  * @brief Check if a mesh is valid for rendering.
  * 
  * Returns true if the mesh has a valid VAO and VBO.
  *
- * @param mesh Pointer to the mesh to check.
+ * @param mesh The mesh to check.
  * @return true if valid, false otherwise.
  */
-R3DAPI bool R3D_IsMeshValid(const R3D_Mesh* mesh);
+R3DAPI bool R3D_IsMeshValid(R3D_Mesh mesh);
 
 /**
  * @brief Generate a quad mesh with orientation.
@@ -250,12 +250,12 @@ R3DAPI R3D_Mesh R3D_GenMeshCubicmap(Image cubicmap, Vector3 cubeSize);
  * If `aabb` is provided, it will be used as the mesh's bounding box; if null,
  * the bounding box is automatically recalculated from the vertex data.
  *
- * @param mesh Pointer to the mesh structure to upload or update.
- * @param data Pointer to the mesh data (vertices and indices) to upload.
+ * @param mesh Pointer to the mesh structure to update.
+ * @param data Mesh data (vertices and indices) to upload.
  * @param aabb Optional bounding box; if null, it is recalculated automatically.
  * @return Returns true if the update is successful, false otherwise.
  */
-R3DAPI bool R3D_UpdateMesh(R3D_Mesh* mesh, const R3D_MeshData* data, const BoundingBox* aabb);
+R3DAPI bool R3D_UpdateMesh(R3D_Mesh* mesh, R3D_MeshData data, const BoundingBox* aabb);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -77,7 +77,7 @@ R3DAPI R3D_MeshData R3D_CreateMeshData(int vertexCount, int indexCount);
  * @brief Releases memory used by a mesh data container.
  * @param meshData Pointer to the R3D_MeshData to destroy.
  */
-R3DAPI void R3D_UnloadMeshData(R3D_MeshData* meshData);
+R3DAPI void R3D_UnloadMeshData(R3D_MeshData meshData);
 
 /**
  * @brief Check if mesh data is valid.
@@ -88,7 +88,7 @@ R3DAPI void R3D_UnloadMeshData(R3D_MeshData* meshData);
  * @param meshData Pointer to the mesh data to check.
  * @return true if valid, false otherwise.
  */
-R3DAPI bool R3D_IsMeshDataValid(const R3D_MeshData* meshData);
+R3DAPI bool R3D_IsMeshDataValid(R3D_MeshData meshData);
 
 /**
  * @brief Generate a quad mesh with specified dimensions, resolution, and orientation.
@@ -270,7 +270,7 @@ R3DAPI R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize);
  * @param meshData Source mesh data to duplicate.
  * @return A new R3D_MeshData containing a copy of the source data.
  */
-R3DAPI R3D_MeshData R3D_DuplicateMeshData(const R3D_MeshData* meshData);
+R3DAPI R3D_MeshData R3D_DuplicateMeshData(R3D_MeshData meshData);
 
 /**
  * @brief Merges two mesh data containers into a single one.
@@ -278,7 +278,7 @@ R3DAPI R3D_MeshData R3D_DuplicateMeshData(const R3D_MeshData* meshData);
  * @param b Second mesh data.
  * @return A new R3D_MeshData containing the merged geometry.
  */
-R3DAPI R3D_MeshData R3D_MergeMeshData(const R3D_MeshData* a, const R3D_MeshData* b);
+R3DAPI R3D_MeshData R3D_MergeMeshData(R3D_MeshData a, R3D_MeshData b);
 
 /**
  * @brief Translates all vertices by a given offset.
@@ -338,7 +338,7 @@ R3DAPI void R3D_GenMeshDataTangents(R3D_MeshData* meshData);
  * @param meshData Mesh data to analyze.
  * @return The computed bounding box.
  */
-R3DAPI BoundingBox R3D_CalculateMeshDataBoundingBox(const R3D_MeshData* meshData);
+R3DAPI BoundingBox R3D_CalculateMeshDataBoundingBox(R3D_MeshData meshData);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -75,7 +75,7 @@ R3DAPI R3D_MeshData R3D_CreateMeshData(int vertexCount, int indexCount);
 
 /**
  * @brief Releases memory used by a mesh data container.
- * @param meshData Pointer to the R3D_MeshData to destroy.
+ * @param meshData R3D_MeshData to destroy.
  */
 R3DAPI void R3D_UnloadMeshData(R3D_MeshData meshData);
 
@@ -85,7 +85,7 @@ R3DAPI void R3D_UnloadMeshData(R3D_MeshData meshData);
  * Returns true if the mesh data contains at least one vertex buffer
  * with a positive number of vertices.
  *
- * @param meshData Pointer to the mesh data to check.
+ * @param meshData Mesh data to check.
  * @return true if valid, false otherwise.
  */
 R3DAPI bool R3D_IsMeshDataValid(R3D_MeshData meshData);

--- a/include/r3d/r3d_model.h
+++ b/include/r3d/r3d_model.h
@@ -9,7 +9,6 @@
 #ifndef R3D_MODEL_H
 #define R3D_MODEL_H
 
-#include "./r3d_animation.h"
 #include "./r3d_material.h"
 #include "./r3d_skeleton.h"
 #include "./r3d_platform.h"
@@ -40,8 +39,6 @@ typedef struct R3D_Model {
 
     BoundingBox aabb;                   ///< Axis-Aligned Bounding Box encompassing the whole model.
     R3D_Skeleton skeleton;              ///< Skeleton hierarchy and bind pose used for skinning (NULL if non-skinned).
-
-    R3D_AnimationPlayer* player;        ///< Animation player controlling the skeleton. If NULL the model uses its bind pose.
 
 } R3D_Model;
 
@@ -91,11 +88,11 @@ R3DAPI R3D_Model R3D_LoadModelFromMemory(const void* data, unsigned int size, co
  * @warning The model's bounding box calculation assumes that the mesh's
  * bounding boxes has already been computed.
  *
- * @param mesh Pointer to the mesh to be wrapped in a model structure.
+ * @param mesh The mesh to be wrapped in a model structure.
  *
  * @return Model structure containing the specified mesh.
  */
-R3DAPI R3D_Model R3D_LoadModelFromMesh(const R3D_Mesh* mesh);
+R3DAPI R3D_Model R3D_LoadModelFromMesh(R3D_Mesh mesh);
 
 /**
  * @brief Unload a model and optionally its materials.
@@ -103,11 +100,11 @@ R3DAPI R3D_Model R3D_LoadModelFromMesh(const R3D_Mesh* mesh);
  * Frees all memory associated with a model, including its meshes.
  * Materials can be optionally unloaded as well.
  *
- * @param model Pointer to the model structure to be unloaded.
+ * @param model The model to be unloaded.
  * @param unloadMaterials If true, also unloads all materials associated with the model.
  * Set to false if textures are still being used elsewhere to avoid freeing shared resources.
  */
-R3DAPI void R3D_UnloadModel(R3D_Model* model, bool unloadMaterials);
+R3DAPI void R3D_UnloadModel(R3D_Model model, bool unloadMaterials);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/r3d/r3d_skeleton.h
+++ b/include/r3d/r3d_skeleton.h
@@ -87,19 +87,19 @@ R3DAPI R3D_Skeleton R3D_LoadSkeletonFromData(const void* data, unsigned int size
 /**
  * @brief Frees the memory allocated for a skeleton.
  *
- * @param skeleton Pointer to the R3D_Skeleton to destroy.
+ * @param skeleton R3D_Skeleton to destroy.
  */
-R3DAPI void R3D_UnloadSkeleton(R3D_Skeleton* skeleton);
+R3DAPI void R3D_UnloadSkeleton(R3D_Skeleton skeleton);
 
 /**
  * @brief Check if a skeleton is valid.
  * 
  * Returns true if atleast the texBindPose is greater than zero.
  *
- * @param skeleton Pointer to the skeleton to check.
+ * @param skeleton The skeleton to check.
  * @return true if valid, false otherwise.
  */
-R3DAPI bool R3D_IsSkeletonValid(const R3D_Skeleton* skeleton);
+R3DAPI bool R3D_IsSkeletonValid(R3D_Skeleton skeleton);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/importer/r3d_importer.h
+++ b/src/importer/r3d_importer.h
@@ -12,6 +12,7 @@
 #include <raylib.h>
 #include <uthash.h>
 
+#include <r3d/r3d_animation.h>
 #include <r3d/r3d_material.h>
 #include <r3d/r3d_skeleton.h>
 #include <r3d/r3d_model.h>

--- a/src/importer/r3d_importer_mesh.c
+++ b/src/importer/r3d_importer_mesh.c
@@ -13,7 +13,6 @@
 #include <raylib.h>
 
 #include <assimp/mesh.h>
-#include <string.h>
 #include <float.h>
 
 #include "../details/r3d_math.h"
@@ -275,13 +274,13 @@ static bool load_mesh_internal(
 
     // Process bone data
     if (!process_bones(aiMesh, &data, vertexCount)) {
-        R3D_UnloadMeshData(&data);
+        R3D_UnloadMeshData(data);
         return false;
     }
 
     // Upload the mesh
-    *outMesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    *outMesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return true;
 }
@@ -345,7 +344,7 @@ bool r3d_importer_load_meshes(const r3d_importer_t* importer, R3D_Model* model)
     // Load all meshes recursively
     if (!load_recursive(importer, model, r3d_importer_get_root(importer), &R3D_MATRIX_IDENTITY)) {
         for (int i = 0; i < model->meshCount; i++) {
-            R3D_UnloadMesh(&model->meshes[i]);
+            R3D_UnloadMesh(model->meshes[i]);
         }
         RL_FREE(model->meshMaterials);
         RL_FREE(model->meshes);

--- a/src/modules/r3d_cache.c
+++ b/src/modules/r3d_cache.c
@@ -9,6 +9,7 @@
 #include "./r3d_cache.h"
 
 #include <r3d/r3d_environment.h>
+#include <r3d/r3d_material.h>
 #include <stdalign.h>
 #include <raymath.h>
 #include <stddef.h>
@@ -52,6 +53,7 @@ bool r3d_cache_init(R3D_Flags flags)
     R3D_MOD_CACHE.matCubeViews[5] = MatrixLookAt((Vector3) {0}, (Vector3) { 0.0f,  0.0f, -1.0f}, (Vector3) {0.0f, -1.0f,  0.0f});
 
     R3D_MOD_CACHE.environment = R3D_ENVIRONMENT_BASE;
+    R3D_MOD_CACHE.material = R3D_MATERIAL_BASE;
 
     R3D_MOD_CACHE.textureColorSpace = R3D_COLORSPACE_SRGB;
     R3D_MOD_CACHE.textureFilter = TEXTURE_FILTER_TRILINEAR;

--- a/src/modules/r3d_cache.h
+++ b/src/modules/r3d_cache.h
@@ -10,6 +10,7 @@
 #define R3D_MODULE_CACHE_H
 
 #include <r3d/r3d_environment.h>
+#include <r3d/r3d_material.h>
 #include <r3d/r3d_core.h>
 #include <glad.h>
 
@@ -83,6 +84,7 @@ typedef struct {
 extern struct r3d_cache {
     GLuint uniformBuffers[R3D_CACHE_UNIFORM_COUNT]; //< Current view state uniform buffer
     R3D_Environment environment;                    //< Current environment settings
+    R3D_Material material;                          //< Default material to use
     r3d_view_state_t viewState;                     //< Current view state
     R3D_ColorSpace textureColorSpace;               //< Default texture color space for model loading
     TextureFilter textureFilter;                    //< Default texture filter for model loading

--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -156,11 +156,6 @@ static int compare_front_to_back(const void* a, const void* b)
 // INTERNAL DRAW FUNCTIONS
 // ========================================
 
-static inline const BoundingBox* get_group_aabb(const r3d_draw_group_t* group)
-{
-    return r3d_draw_has_instances(group) ? &group->instanced.allAabb : &group->aabb;
-}
-
 static GLenum get_opengl_primitive(R3D_PrimitiveType primitive)
 {
     switch (primitive) {
@@ -305,7 +300,7 @@ void r3d_draw_compute_visible_groups(const r3d_frustum_t* frustum)
     for (int i = 0; i < R3D_MOD_DRAW.numGroups; i++)
     {
         const r3d_draw_group_t* group = &R3D_MOD_DRAW.groups[i];
-        const BoundingBox* aabb = get_group_aabb(group);
+        const BoundingBox* aabb = &group->aabb;
 
         if (memcmp(aabb, &(BoundingBox){0}, sizeof(BoundingBox)) == 0) {
             R3D_MOD_DRAW.visibleGroups[i] = true;
@@ -331,7 +326,7 @@ bool r3d_draw_call_is_visible(const r3d_draw_call_t* call, const r3d_frustum_t* 
     }
 
     const r3d_draw_group_t* group = &R3D_MOD_DRAW.groups[groupIndex];
-    const BoundingBox* aabb = get_group_aabb(group);
+    const BoundingBox* aabb = &group->aabb;
 
     // If the AABB is 'zero', the object is considered visible
     if (memcmp(aabb, &(BoundingBox){0}, sizeof(BoundingBox)) == 0) {
@@ -481,7 +476,7 @@ void r3d_draw_instanced(const r3d_draw_call_t* call)
     GLenum primitive = get_opengl_primitive(call->mesh.primitiveType);
 
     const r3d_draw_group_t* group = r3d_draw_get_call_group(call);
-    const R3D_InstanceBuffer* instances = &group->instanced.buffer;
+    const R3D_InstanceBuffer* instances = &group->instances;
 
     glBindVertexArray(call->mesh.vao);
 
@@ -522,9 +517,9 @@ void r3d_draw_instanced(const r3d_draw_call_t* call)
     }
 
     if (call->mesh.ebo == 0) {
-        glDrawArraysInstanced(primitive, 0, call->mesh.vertexCount, group->instanced.count);
+        glDrawArraysInstanced(primitive, 0, call->mesh.vertexCount, group->instanceCount);
     }
     else {
-        glDrawElementsInstanced(primitive, call->mesh.indexCount, GL_UNSIGNED_INT, NULL, group->instanced.count);
+        glDrawElementsInstanced(primitive, call->mesh.indexCount, GL_UNSIGNED_INT, NULL, group->instanceCount);
     }
 }

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -65,18 +65,12 @@ typedef enum {
  * All draw calls pushed after a group inherit its transform, skeleton, and instancing data.
  */
 typedef struct {
-
     BoundingBox aabb;                   //< AABB of the model
     Matrix transform;                   //< World transform matrix
     R3D_Skeleton skeleton;              //< Skeleton containing the bind pose (if any)
-    const R3D_AnimationPlayer* player;  //< Animation player (may be NULL)
-
-    struct {
-        R3D_InstanceBuffer buffer;      //< Instance buffer to use
-        BoundingBox allAabb;            //< World-space AABB covering all instances
-        int count;                      //< Number of instances
-    } instanced;
-
+    R3D_AnimationPlayer player;         //< Animation player (may be NULL)
+    R3D_InstanceBuffer instances;       //< Instance buffer to use
+    int instanceCount;                  //< Number of instances
 } r3d_draw_group_t;
 
 /*
@@ -245,7 +239,7 @@ void r3d_draw_instanced(const r3d_draw_call_t* call);
  */
 static inline bool r3d_draw_has_instances(const r3d_draw_group_t* group)
 {
-    return (group->instanced.buffer.capacity > 0) && (group->instanced.count > 0);
+    return (group->instances.capacity > 0) && (group->instanceCount > 0);
 }
 
 /*

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -67,8 +67,7 @@ typedef enum {
 typedef struct {
     BoundingBox aabb;                   //< AABB of the model
     Matrix transform;                   //< World transform matrix
-    R3D_Skeleton skeleton;              //< Skeleton containing the bind pose (if any)
-    R3D_AnimationPlayer player;         //< Animation player (may be NULL)
+    uint32_t texPose;                   //< Texture that contains the bone matrices (can be 0 for non-skinned)
     R3D_InstanceBuffer instances;       //< Instance buffer to use
     int instanceCount;                  //< Number of instances
 } r3d_draw_group_t;

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -207,10 +207,9 @@ void r3d_target_resize(int resW, int resH)
     }
 }
 
-void r3d_target_set_blit_screen(const RenderTexture* screen)
+void r3d_target_set_blit_screen(RenderTexture screen)
 {
-    if (screen != NULL) R3D_MOD_TARGET.screen = *screen;
-    else R3D_MOD_TARGET.screen.id = 0;
+    R3D_MOD_TARGET.screen = screen;
 }
 
 void r3d_target_set_blit_mode(bool keepAspect, bool blitLinear)

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -168,9 +168,9 @@ void r3d_target_resize(int resW, int resH);
 /*
  * Defines the target where the blit is performed.
  * Also uses the associated data to determine the aspect ratio.
- * If NULL, the destination will be the default framebuffer (0).
+ * If ID is zero, the destination will be the default framebuffer (0).
  */
-void r3d_target_set_blit_screen(const RenderTexture* screen);
+void r3d_target_set_blit_screen(RenderTexture screen);
 
 /*
  * Defines the blit configuration for the assigned screen.

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -287,7 +287,7 @@ void R3D_DrawModelPro(R3D_Model model, Matrix transform)
 
     drawGroup.aabb = model.aabb;
     drawGroup.transform = transform;
-    drawGroup.skeleton = model.skeleton;
+    drawGroup.texPose = model.skeleton.texBindPose;
 
     r3d_draw_group_push(&drawGroup);
 
@@ -319,7 +319,7 @@ void R3D_DrawModelInstancedEx(R3D_Model model, R3D_InstanceBuffer instances, int
 
     drawGroup.aabb = model.aabb;
     drawGroup.transform = transform;
-    drawGroup.skeleton = model.skeleton;
+    drawGroup.texPose = model.skeleton.texBindPose;
 
     drawGroup.transform = transform;
     drawGroup.instances = instances;
@@ -362,8 +362,8 @@ void R3D_DrawAnimatedModelPro(R3D_Model model, R3D_AnimationPlayer player, Matri
 
     drawGroup.aabb = model.aabb;
     drawGroup.transform = transform;
-    drawGroup.skeleton = model.skeleton;
-    drawGroup.player = player;
+    drawGroup.texPose = (player.texGlobalPose > 0)
+        ? player.texGlobalPose : model.skeleton.texBindPose;
 
     r3d_draw_group_push(&drawGroup);
 
@@ -395,8 +395,8 @@ void R3D_DrawAnimatedModelInstancedEx(R3D_Model model, R3D_AnimationPlayer playe
 
     drawGroup.aabb = model.aabb;
     drawGroup.transform = transform;
-    drawGroup.skeleton = model.skeleton;
-    drawGroup.player = player;
+    drawGroup.texPose = (player.texGlobalPose > 0)
+        ? player.texGlobalPose : model.skeleton.texBindPose;
 
     drawGroup.transform = transform;
     drawGroup.instances = instances;
@@ -472,9 +472,8 @@ void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* matVP)
 
     /* --- Send skinning related data --- */
 
-    if (group->player.texGlobalPose > 0 || group->skeleton.texBindPose > 0) {
-        GLuint texPose = (group->player.texGlobalPose > 0) ? group->player.texGlobalPose : group->skeleton.texBindPose;
-        R3D_SHADER_BIND_SAMPLER_1D(scene.depth, uTexBoneMatrices, texPose);
+    if (group->texPose > 0) {
+        R3D_SHADER_BIND_SAMPLER_1D(scene.depth, uTexBoneMatrices, group->texPose);
         R3D_SHADER_SET_INT(scene.depth, uSkinning, true);
     }
     else {
@@ -541,9 +540,8 @@ void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* m
 
     /* --- Send skinning related data --- */
 
-    if (group->player.texGlobalPose > 0 || group->skeleton.texBindPose > 0) {
-        GLuint texPose = (group->player.texGlobalPose > 0) ? group->player.texGlobalPose : group->skeleton.texBindPose;
-        R3D_SHADER_BIND_SAMPLER_1D(scene.depthCube, uTexBoneMatrices, texPose);
+    if (group->texPose > 0) {
+        R3D_SHADER_BIND_SAMPLER_1D(scene.depthCube, uTexBoneMatrices, group->texPose);
         R3D_SHADER_SET_INT(scene.depthCube, uSkinning, true);
     }
     else {
@@ -618,9 +616,8 @@ void raster_geometry(const r3d_draw_call_t* call)
 
     /* --- Send skinning related data --- */
 
-    if (group->player.texGlobalPose > 0 || group->skeleton.texBindPose > 0) {
-        GLuint texPose = (group->player.texGlobalPose > 0) ? group->player.texGlobalPose : group->skeleton.texBindPose;
-        R3D_SHADER_BIND_SAMPLER_1D(scene.geometry, uTexBoneMatrices, texPose);
+    if (group->texPose > 0) {
+        R3D_SHADER_BIND_SAMPLER_1D(scene.geometry, uTexBoneMatrices, group->texPose);
         R3D_SHADER_SET_INT(scene.geometry, uSkinning, true);
     }
     else {
@@ -764,9 +761,8 @@ void raster_forward(const r3d_draw_call_t* call)
 
     /* --- Send skinning related data --- */
 
-    if (group->player.texGlobalPose > 0 || group->skeleton.texBindPose > 0) {
-        GLuint texPose = (group->player.texGlobalPose > 0) ? group->player.texGlobalPose : group->skeleton.texBindPose;
-        R3D_SHADER_BIND_SAMPLER_1D(scene.forward, uTexBoneMatrices, texPose);
+    if (group->texPose > 0) {
+        R3D_SHADER_BIND_SAMPLER_1D(scene.forward, uTexBoneMatrices, group->texPose);
         R3D_SHADER_SET_INT(scene.forward, uSkinning, true);
     }
     else {

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -657,7 +657,7 @@ void raster_geometry(const r3d_draw_call_t* call)
 
     R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
     R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uTexNormal, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uTexEmission, R3D_TEXTURE_SELECT(call->material.emission.texture.id, BLACK));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uTexEmission, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
     R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uTexORM, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */
@@ -720,7 +720,7 @@ void raster_decal(const r3d_draw_call_t* call)
 
     R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
     R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexNormal, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexEmission, R3D_TEXTURE_SELECT(call->material.emission.texture.id, BLACK));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexEmission, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
     R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexORM, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */
@@ -803,7 +803,7 @@ void raster_forward(const r3d_draw_call_t* call)
 
     R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
     R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uTexNormal, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uTexEmission, R3D_TEXTURE_SELECT(call->material.emission.texture.id, BLACK));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uTexEmission, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
     R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uTexORM, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */

--- a/src/r3d_material.c
+++ b/src/r3d_material.c
@@ -11,12 +11,7 @@
 #include <glad.h>
 
 #include "./modules/r3d_texture.h"
-
-// ========================================
-// INTERNAL STATE
-// ========================================
-
-static R3D_Material G_DefaultMaterial = R3D_MATERIAL_BASE;
+#include "./modules/r3d_cache.h"
 
 // ========================================
 // PUBLIC API
@@ -24,12 +19,12 @@ static R3D_Material G_DefaultMaterial = R3D_MATERIAL_BASE;
 
 R3D_Material R3D_GetDefaultMaterial(void)
 {
-    return G_DefaultMaterial;
+    return R3D_CACHE_GET(material);
 }
 
 void R3D_SetDefaultMaterial(R3D_Material material)
 {
-    G_DefaultMaterial = material;
+    R3D_CACHE_SET(material, material);
 }
 
 void R3D_UnloadMaterial(R3D_Material material)

--- a/src/r3d_material.c
+++ b/src/r3d_material.c
@@ -13,45 +13,26 @@
 #include "./modules/r3d_texture.h"
 
 // ========================================
+// INTERNAL STATE
+// ========================================
+
+static R3D_Material G_DefaultMaterial = R3D_MATERIAL_BASE;
+
+// ========================================
 // PUBLIC API
 // ========================================
 
 R3D_Material R3D_GetDefaultMaterial(void)
 {
-    R3D_Material material = { 0 };
-
-    // Albedo map
-    material.albedo.texture = R3D_GetWhiteTexture();
-    material.albedo.color = WHITE;
-
-    // Emission map
-    material.emission.texture = R3D_GetWhiteTexture();
-    material.emission.color = WHITE;
-    material.emission.energy = 0.0f;
-
-    // Normal map
-    material.normal.texture = R3D_GetNormalTexture();
-    material.normal.scale = 1.0f;
-
-    // ORM map
-    material.orm.texture = R3D_GetWhiteTexture();
-    material.orm.occlusion = 1.0f;
-    material.orm.roughness = 1.0f;
-    material.orm.metalness = 0.0f;
-
-    // Misc
-    material.transparencyMode = R3D_TRANSPARENCY_DISABLED;
-    material.billboardMode = R3D_BILLBOARD_DISABLED;
-    material.blendMode = R3D_BLEND_MIX;
-    material.cullMode = R3D_CULL_BACK;
-    material.uvOffset = (Vector2) {0.0f, 0.0f};
-    material.uvScale = (Vector2) {1.0f, 1.0f};
-    material.alphaCutoff = 0.01f;
-
-    return material;
+    return G_DefaultMaterial;
 }
 
-void R3D_UnloadMaterial(const R3D_Material* material)
+void R3D_SetDefaultMaterial(R3D_Material material)
+{
+    G_DefaultMaterial = material;
+}
+
+void R3D_UnloadMaterial(R3D_Material material)
 {
 #define UNLOAD_TEXTURE_IF_VALID(id) \
     do { \
@@ -60,10 +41,10 @@ void R3D_UnloadMaterial(const R3D_Material* material)
         } \
     } while (0)
 
-    UNLOAD_TEXTURE_IF_VALID(material->albedo.texture.id);
-    UNLOAD_TEXTURE_IF_VALID(material->emission.texture.id);
-    UNLOAD_TEXTURE_IF_VALID(material->normal.texture.id);
-    UNLOAD_TEXTURE_IF_VALID(material->orm.texture.id);
+    UNLOAD_TEXTURE_IF_VALID(material.albedo.texture.id);
+    UNLOAD_TEXTURE_IF_VALID(material.emission.texture.id);
+    UNLOAD_TEXTURE_IF_VALID(material.normal.texture.id);
+    UNLOAD_TEXTURE_IF_VALID(material.orm.texture.id);
 
 #undef UNLOAD_TEXTURE_IF_VALID
 }

--- a/src/r3d_mesh.c
+++ b/src/r3d_mesh.c
@@ -16,11 +16,11 @@
 // PUBLIC API
 // ========================================
 
-R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, const R3D_MeshData* data, const BoundingBox* aabb, R3D_MeshUsage usage)
+R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, R3D_MeshData data, const BoundingBox* aabb, R3D_MeshUsage usage)
 {
     R3D_Mesh mesh = { 0 };
 
-    if (data == NULL || data->vertexCount <= 0 || !data->vertices) {
+    if (data.vertexCount <= 0 || !data.vertices) {
         TraceLog(LOG_WARNING, "R3D: Invalid mesh data passed to R3D_UpdateMesh");
         return mesh;
     }
@@ -42,7 +42,7 @@ R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, const R3D_MeshData* data, const Bo
     // Creation of the VBO
     glGenBuffers(1, &mesh.vbo);
     glBindBuffer(GL_ARRAY_BUFFER, mesh.vbo);
-    glBufferData(GL_ARRAY_BUFFER, data->vertexCount * sizeof(R3D_Vertex), data->vertices, glUsage);
+    glBufferData(GL_ARRAY_BUFFER, data.vertexCount * sizeof(R3D_Vertex), data.vertices, glUsage);
 
     // position (vec3)
     glEnableVertexAttribArray(0);
@@ -89,10 +89,10 @@ R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, const R3D_MeshData* data, const Bo
     glVertexAttrib4f(13, 1.0f, 1.0f, 1.0f, 1.0f);
 
     // EBO if indices present
-    if (data->indexCount > 0 && data->indices) {
+    if (data.indexCount > 0 && data.indices) {
         glGenBuffers(1, &mesh.ebo);
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.ebo);
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER, data->indexCount * sizeof(uint32_t), data->indices, glUsage);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, data.indexCount * sizeof(uint32_t), data.indices, glUsage);
     }
 
     // Cleaning
@@ -101,8 +101,8 @@ R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, const R3D_MeshData* data, const Bo
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
     // Fill mesh infos
-    mesh.vertexCount = mesh.allocVertexCount = data->vertexCount;
-    mesh.indexCount = mesh.allocIndexCount = data->indexCount;
+    mesh.vertexCount = mesh.allocVertexCount = data.vertexCount;
+    mesh.indexCount = mesh.allocIndexCount = data.indexCount;
     mesh.shadowCastMode = R3D_SHADOW_CAST_ON_AUTO;
     mesh.layerMask = R3D_LAYER_01;
     mesh.primitiveType = type;
@@ -115,16 +115,16 @@ R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, const R3D_MeshData* data, const Bo
     return mesh;
 }
 
-void R3D_UnloadMesh(R3D_Mesh* mesh)
+void R3D_UnloadMesh(R3D_Mesh mesh)
 {
-    if (mesh->vao != 0) glDeleteVertexArrays(1, &mesh->vao);
-    if (mesh->vbo != 0) glDeleteBuffers(1, &mesh->vbo);
-    if (mesh->ebo != 0) glDeleteBuffers(1, &mesh->ebo);
+    if (mesh.vao != 0) glDeleteVertexArrays(1, &mesh.vao);
+    if (mesh.vbo != 0) glDeleteBuffers(1, &mesh.vbo);
+    if (mesh.ebo != 0) glDeleteBuffers(1, &mesh.ebo);
 }
 
-bool R3D_IsMeshValid(const R3D_Mesh* mesh)
+bool R3D_IsMeshValid(R3D_Mesh mesh)
 {
-    return (mesh->vao != 0) && (mesh->vbo != 0);
+    return (mesh.vao != 0) && (mesh.vbo != 0);
 }
 
 R3D_Mesh R3D_GenMeshQuad(float width, float length, int resX, int resZ, Vector3 frontDir)
@@ -132,10 +132,10 @@ R3D_Mesh R3D_GenMeshQuad(float width, float length, int resX, int resZ, Vector3 
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataQuad(width, length, resX, resZ, frontDir);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, NULL, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, NULL, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -145,15 +145,15 @@ R3D_Mesh R3D_GenMeshPlane(float width, float length, int resX, int resZ)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataPlane(width, length, resX, resZ);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {-width * 0.5f, 0.0f, -length * 0.5f},
         { width * 0.5f, 0.0f,  length * 0.5f}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -163,15 +163,15 @@ R3D_Mesh R3D_GenMeshPoly(int sides, float radius)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataPoly(sides, radius);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {-radius, 0.0f, -radius},
         { radius, 0.0f,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -181,15 +181,15 @@ R3D_Mesh R3D_GenMeshCube(float width, float height, float length)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataCube(width, height, length);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {-width * 0.5f, -height * 0.5f, -length * 0.5f},
         { width * 0.5f,  height * 0.5f,  length * 0.5f}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -199,15 +199,15 @@ R3D_Mesh R3D_GenMeshSphere(float radius, int rings, int slices)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataSphere(radius, rings, slices);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {-radius, -radius, -radius},
         { radius,  radius,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -217,15 +217,15 @@ R3D_Mesh R3D_GenMeshHemiSphere(float radius, int rings, int slices)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataHemiSphere(radius, rings, slices);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {-radius,   0.0f, -radius},
         { radius, radius,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -235,15 +235,15 @@ R3D_Mesh R3D_GenMeshCylinder(float radius, float height, int slices)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataCylinder(radius, height, slices);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {-radius,   0.0f, -radius},
         { radius, height,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -253,15 +253,15 @@ R3D_Mesh R3D_GenMeshCone(float radius, float height, int slices)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataCone(radius, height, slices);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {-radius,   0.0f, -radius},
         { radius, height,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -271,15 +271,15 @@ R3D_Mesh R3D_GenMeshTorus(float radius, float size, int radSeg, int sides)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataTorus(radius, size, radSeg, sides);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {-radius - size, -size, -radius - size},
         { radius + size,  size,  radius + size}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -289,15 +289,15 @@ R3D_Mesh R3D_GenMeshKnot(float radius, float size, int radSeg, int sides)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataKnot(radius, size, radSeg, sides);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {-radius - size, -size, -radius - size},
         { radius + size,  size,  radius + size}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -307,15 +307,15 @@ R3D_Mesh R3D_GenMeshHeightmap(Image heightmap, Vector3 size)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataHeightmap(heightmap, size);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {-size.x * 0.5f,   0.0f, -size.z * 0.5f},
         { size.x * 0.5f, size.y,  size.z * 0.5f}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
@@ -325,27 +325,27 @@ R3D_Mesh R3D_GenMeshCubicmap(Image cubicmap, Vector3 cubeSize)
     R3D_Mesh mesh = { 0 };
 
     R3D_MeshData data = R3D_GenMeshDataCubicmap(cubicmap, cubeSize);
-    if (!R3D_IsMeshDataValid(&data)) return mesh;
+    if (!R3D_IsMeshDataValid(data)) return mesh;
 
     BoundingBox aabb = {
         {0.0f, 0.0f, 0.0f},
         {cubicmap.width * cubeSize.x, cubeSize.y, cubicmap.height * cubeSize.z}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, &data, &aabb, R3D_STATIC_MESH);
-    R3D_UnloadMeshData(&data);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
 
     return mesh;
 }
 
-bool R3D_UpdateMesh(R3D_Mesh* mesh, const R3D_MeshData* data, const BoundingBox* aabb)
+bool R3D_UpdateMesh(R3D_Mesh* mesh, R3D_MeshData data, const BoundingBox* aabb)
 {
     if (!mesh || mesh->vao == 0 || mesh->vbo == 0) {
         TraceLog(LOG_WARNING, "R3D: Cannot update mesh; Invalid mesh instance");
         return false;
     }
 
-    if (!data || data->vertexCount <= 0 || !data->vertices) {
+    if (data.vertexCount <= 0 || !data.vertices) {
         TraceLog(LOG_WARNING, "R3D: Invalid mesh data given to R3D_UpdateMesh");
         return false;
     }
@@ -363,23 +363,23 @@ bool R3D_UpdateMesh(R3D_Mesh* mesh, const R3D_MeshData* data, const BoundingBox*
     glBindVertexArray(mesh->vao);
     glBindBuffer(GL_ARRAY_BUFFER, mesh->vbo);
 
-    if (mesh->allocVertexCount < data->vertexCount) {
-        glBufferData(GL_ARRAY_BUFFER, mesh->vertexCount * sizeof(R3D_Vertex), data->vertices, glUsage);
-        mesh->allocVertexCount = data->vertexCount;
+    if (mesh->allocVertexCount < data.vertexCount) {
+        glBufferData(GL_ARRAY_BUFFER, mesh->vertexCount * sizeof(R3D_Vertex), data.vertices, glUsage);
+        mesh->allocVertexCount = data.vertexCount;
     }
     else {
-        glBufferSubData(GL_ARRAY_BUFFER, 0, mesh->vertexCount * sizeof(R3D_Vertex), data->vertices);
+        glBufferSubData(GL_ARRAY_BUFFER, 0, mesh->vertexCount * sizeof(R3D_Vertex), data.vertices);
     }
 
-    if (data->indexCount > 0) {
-        if (mesh->allocIndexCount < data->indexCount) {
+    if (data.indexCount > 0) {
+        if (mesh->allocIndexCount < data.indexCount) {
             if (mesh->ebo == 0) glGenBuffers(1, &mesh->ebo);
             glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh->ebo);
-            glBufferData(GL_ELEMENT_ARRAY_BUFFER, mesh->indexCount * sizeof(uint32_t), data->indices, glUsage);
-            mesh->allocIndexCount = data->indexCount;
+            glBufferData(GL_ELEMENT_ARRAY_BUFFER, mesh->indexCount * sizeof(uint32_t), data.indices, glUsage);
+            mesh->allocIndexCount = data.indexCount;
         }
         else {
-            glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, mesh->indexCount * sizeof(uint32_t), data->indices);
+            glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, mesh->indexCount * sizeof(uint32_t), data.indices);
         }
     }
 
@@ -387,8 +387,8 @@ bool R3D_UpdateMesh(R3D_Mesh* mesh, const R3D_MeshData* data, const BoundingBox*
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
-    mesh->vertexCount = data->vertexCount;
-    mesh->indexCount = data->indexCount;
+    mesh->vertexCount = data.vertexCount;
+    mesh->indexCount = data.indexCount;
 
     return true;
 }

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -12,8 +12,6 @@
 #include <string.h>
 #include <float.h>
 
-#include "./details/r3d_math.h"
-
 // ========================================
 // PUBLIC API
 // ========================================
@@ -50,15 +48,15 @@ R3D_MeshData R3D_CreateMeshData(int vertexCount, int indexCount)
     return meshData;
 }
 
-void R3D_UnloadMeshData(R3D_MeshData* meshData)
+void R3D_UnloadMeshData(R3D_MeshData meshData)
 {
-    RL_FREE(meshData->vertices);
-    RL_FREE(meshData->indices);
+    RL_FREE(meshData.vertices);
+    RL_FREE(meshData.indices);
 }
 
-bool R3D_IsMeshDataValid(const R3D_MeshData* meshData)
+bool R3D_IsMeshDataValid(R3D_MeshData meshData)
 {
-    return (meshData->vertices != NULL) && (meshData->vertexCount > 0);
+    return (meshData.vertices != NULL) && (meshData.vertexCount > 0);
 }
 
 R3D_MeshData R3D_GenMeshDataQuad(float width, float length, int resX, int resZ, Vector3 frontDir)
@@ -1670,40 +1668,40 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
     return meshData;
 }
 
-R3D_MeshData R3D_DuplicateMeshData(const R3D_MeshData* meshData)
+R3D_MeshData R3D_DuplicateMeshData(R3D_MeshData meshData)
 {
     R3D_MeshData duplicate = {0};
 
-    if (meshData == NULL || meshData->vertices == NULL) {
+    if (meshData.vertices == NULL) {
         TraceLog(LOG_ERROR, "R3D: Cannot duplicate null mesh data");
         return duplicate;
     }
 
-    duplicate = R3D_CreateMeshData(meshData->vertexCount, meshData->indexCount);
+    duplicate = R3D_CreateMeshData(meshData.vertexCount, meshData.indexCount);
     if (duplicate.vertices == NULL) {
         return duplicate;
     }
 
-    memcpy(duplicate.vertices, meshData->vertices, meshData->vertexCount * sizeof(*meshData->vertices));
+    memcpy(duplicate.vertices, meshData.vertices, meshData.vertexCount * sizeof(*meshData.vertices));
 
-    if (meshData->indexCount > 0 && meshData->indices != NULL && duplicate.indices != NULL) {
-        memcpy(duplicate.indices, meshData->indices, meshData->indexCount * sizeof(*meshData->indices));
+    if (meshData.indexCount > 0 && meshData.indices != NULL && duplicate.indices != NULL) {
+        memcpy(duplicate.indices, meshData.indices, meshData.indexCount * sizeof(*meshData.indices));
     }
 
     return duplicate;
 }
 
-R3D_MeshData R3D_MergeMeshData(const R3D_MeshData* a, const R3D_MeshData* b)
+R3D_MeshData R3D_MergeMeshData(R3D_MeshData a, R3D_MeshData b)
 {
     R3D_MeshData merged = {0};
 
-    if (a == NULL || b == NULL || a->vertices == NULL || b->vertices == NULL) {
+    if (a.vertices == NULL || b.vertices == NULL) {
         TraceLog(LOG_ERROR, "R3D: Cannot merge null mesh data");
         return merged;
     }
 
-    int totalVertices = a->vertexCount + b->vertexCount;
-    int totalIndices = a->indexCount + b->indexCount;
+    int totalVertices = a.vertexCount + b.vertexCount;
+    int totalIndices = a.indexCount + b.indexCount;
 
     merged = R3D_CreateMeshData(totalVertices, totalIndices);
 
@@ -1711,16 +1709,16 @@ R3D_MeshData R3D_MergeMeshData(const R3D_MeshData* a, const R3D_MeshData* b)
         return merged;
     }
 
-    memcpy(merged.vertices, a->vertices, a->vertexCount * sizeof(*merged.vertices));
-    memcpy(merged.vertices + a->vertexCount, b->vertices, b->vertexCount * sizeof(*merged.vertices));
+    memcpy(merged.vertices, a.vertices, a.vertexCount * sizeof(*merged.vertices));
+    memcpy(merged.vertices + a.vertexCount, b.vertices, b.vertexCount * sizeof(*merged.vertices));
 
-    if (a->indexCount > 0 && a->indices != NULL) {
-        memcpy(merged.indices, a->indices, a->indexCount * sizeof(*merged.indices));
+    if (a.indexCount > 0 && a.indices != NULL) {
+        memcpy(merged.indices, a.indices, a.indexCount * sizeof(*merged.indices));
     }
 
-    if (b->indexCount > 0 && b->indices != NULL) {
-        for (int i = 0; i < b->indexCount; i++) {
-            merged.indices[a->indexCount + i] = b->indices[i] + a->vertexCount;
+    if (b.indexCount > 0 && b.indices != NULL) {
+        for (int i = 0; i < b.indexCount; i++) {
+            merged.indices[a.indexCount + i] = b.indices[i] + a.vertexCount;
         }
     }
 
@@ -1991,19 +1989,19 @@ void R3D_GenMeshDataTangents(R3D_MeshData* meshData)
     RL_FREE(bitangents);
 }
 
-BoundingBox R3D_CalculateMeshDataBoundingBox(const R3D_MeshData* meshData)
+BoundingBox R3D_CalculateMeshDataBoundingBox(R3D_MeshData meshData)
 {
     BoundingBox bounds = {0};
 
-    if (meshData == NULL || meshData->vertices == NULL || meshData->vertexCount == 0) {
+    if (meshData.vertices == NULL || meshData.vertexCount == 0) {
         return bounds;
     }
 
-    bounds.min = meshData->vertices[0].position;
-    bounds.max = meshData->vertices[0].position;
+    bounds.min = meshData.vertices[0].position;
+    bounds.max = meshData.vertices[0].position;
 
-    for (int i = 1; i < meshData->vertexCount; i++) {
-        Vector3 pos = meshData->vertices[i].position;
+    for (int i = 1; i < meshData.vertexCount; i++) {
+        Vector3 pos = meshData.vertices[i].position;
         bounds.min = Vector3Min(bounds.min, pos);
         bounds.max = Vector3Max(bounds.max, pos);
     }

--- a/src/r3d_model.c
+++ b/src/r3d_model.c
@@ -53,15 +53,15 @@ static bool import_model(r3d_importer_t* importer, R3D_Model* model)
 
 R3D_Model R3D_LoadModel(const char* filePath)
 {
-    R3D_Model model = { 0 };
+    R3D_Model model = {0};
 
-    r3d_importer_t importer = { 0 };
+    r3d_importer_t importer = {0};
     if (!r3d_importer_create_from_file(&importer, filePath)) {
         return model;
     }
 
     if (!import_model(&importer, &model)) {
-        R3D_UnloadModel(&model, true);
+        R3D_UnloadModel(model, true);
     }
 
     r3d_importer_destroy(&importer);
@@ -71,15 +71,15 @@ R3D_Model R3D_LoadModel(const char* filePath)
 
 R3D_Model R3D_LoadModelFromMemory(const void* data, unsigned int size, const char* hint)
 {
-    R3D_Model model = { 0 };
+    R3D_Model model = {0};
 
-    r3d_importer_t importer = { 0 };
+    r3d_importer_t importer = {0};
     if (!r3d_importer_create_from_memory(&importer, data, size, hint)) {
         return model;
     }
 
     if (!import_model(&importer, &model)) {
-        R3D_UnloadModel(&model, true);
+        R3D_UnloadModel(model, true);
     }
 
     r3d_importer_destroy(&importer);
@@ -87,16 +87,12 @@ R3D_Model R3D_LoadModelFromMemory(const void* data, unsigned int size, const cha
     return model;
 }
 
-R3D_Model R3D_LoadModelFromMesh(const R3D_Mesh* mesh)
+R3D_Model R3D_LoadModelFromMesh(R3D_Mesh mesh)
 {
-    R3D_Model model = { 0 };
-
-    if (!mesh) {
-        return model;
-    }
+    R3D_Model model = {0};
 
     model.meshes = RL_MALLOC(sizeof(R3D_Mesh));
-    model.meshes[0] = *mesh;
+    model.meshes[0] = mesh;
     model.meshCount = 1;
 
     model.materials = RL_MALLOC(sizeof(R3D_Material));
@@ -106,28 +102,28 @@ R3D_Model R3D_LoadModelFromMesh(const R3D_Mesh* mesh)
     model.meshMaterials = RL_MALLOC(sizeof(int));
     model.meshMaterials[0] = 0;
 
-    model.aabb = mesh->aabb;
+    model.aabb = mesh.aabb;
 
     return model;
 }
 
-void R3D_UnloadModel(R3D_Model* model, bool unloadMaterials)
+void R3D_UnloadModel(R3D_Model model, bool unloadMaterials)
 {
-    R3D_UnloadSkeleton(&model->skeleton);
+    R3D_UnloadSkeleton(model.skeleton);
 
-    if (model->meshes != NULL) {
-        for (int i = 0; i < model->meshCount; i++) {
-            R3D_UnloadMesh(&model->meshes[i]);
+    if (model.meshes != NULL) {
+        for (int i = 0; i < model.meshCount; i++) {
+            R3D_UnloadMesh(model.meshes[i]);
         }
     }
 
-    if (unloadMaterials && model->materials != NULL) {
-        for (int i = 0; i < model->materialCount; i++) {
-            R3D_UnloadMaterial(&model->materials[i]);
+    if (unloadMaterials && model.materials != NULL) {
+        for (int i = 0; i < model.materialCount; i++) {
+            R3D_UnloadMaterial(model.materials[i]);
         }
     }
 
-    RL_FREE(model->meshMaterials);
-    RL_FREE(model->materials);
-    RL_FREE(model->meshes);
+    RL_FREE(model.meshMaterials);
+    RL_FREE(model.materials);
+    RL_FREE(model.meshes);
 }

--- a/src/r3d_skeleton.c
+++ b/src/r3d_skeleton.c
@@ -47,19 +47,19 @@ R3D_Skeleton R3D_LoadSkeletonFromData(const void* data, unsigned int size, const
     return skeleton;
 }
 
-void R3D_UnloadSkeleton(R3D_Skeleton* skeleton)
+void R3D_UnloadSkeleton(R3D_Skeleton skeleton)
 {
-    if (skeleton->texBindPose > 0) {
-        glDeleteTextures(1, &skeleton->texBindPose);
+    if (skeleton.texBindPose > 0) {
+        glDeleteTextures(1, &skeleton.texBindPose);
     }
 
-    RL_FREE(skeleton->bones);
-    RL_FREE(skeleton->boneOffsets);
-    RL_FREE(skeleton->bindLocal);
-    RL_FREE(skeleton->bindPose);
+    RL_FREE(skeleton.bones);
+    RL_FREE(skeleton.boneOffsets);
+    RL_FREE(skeleton.bindLocal);
+    RL_FREE(skeleton.bindPose);
 }
 
-bool R3D_IsSkeletonValid(const R3D_Skeleton* skeleton)
+bool R3D_IsSkeletonValid(R3D_Skeleton skeleton)
 {
-    return (skeleton->texBindPose > 0);
+    return (skeleton.texBindPose > 0);
 }


### PR DESCRIPTION
This PR introduces several breaking changes, mainly to the draw functions.

The goal was to fix some oddities inherited from the very first versions of R3D, mainly regarding pointers.
There has been no need for a long time to pass structures by pointer in draw functions, passing them by value works fine and is even safer.

From now on, simple structures are used as follows:
- By value if the parameter is required and the function does not modify the structure.
- By non-const pointer if the function modifies the structure or related data (even if it does not modify the members directly).
- By const pointer if the value is optional.

This should make the API more consistent, less error-prone, and easier to bind in other languages.

All `Draw` functions have been revised to ensure mesh rendering functions have signatures consistent with model rendering functions.

Also, `R3D_AnimationPlayer` is no longer returned via pointer when loaded.
The `R3D_AnimationPlayer player` member has been removed from `R3D_Model` to avoid awkward dependencies and complicated management.

Now to draw an animated model, use the `R3D_DrawAnimatedModelXXX` functions.
If you draw a skinned model with `R3D_DrawModelXXX` (without an animation player), or call `R3D_DrawAnimatedModelXXX` with an invalid animation player, the model will simply render in its bind pose.

The `globalAabb` parameters have been removed from instanced draw functions, as a "cluster" system is planned to allow more advanced culling strategies.

Also, a new function `R3D_SetDefaultMaterial()` has been added to set the default material, for example when loading 3D models.
Additionally, the `R3D_MATERIAL_BASE` definition has been added, representing the base default material, similar to `R3D_Environment`.

Here is the complete set of new draw functions:
```c
R3DAPI void R3D_DrawMesh(R3D_Mesh mesh, R3D_Material material, Vector3 position, float scale);
R3DAPI void R3D_DrawMeshEx(R3D_Mesh mesh, R3D_Material material, Vector3 position, Quaternion rotation, Vector3 scale);
R3DAPI void R3D_DrawMeshPro(R3D_Mesh mesh, R3D_Material material, Matrix transform);

R3DAPI void R3D_DrawMeshInstanced(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int count);
R3DAPI void R3D_DrawMeshInstancedEx(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int count, Matrix transform);

R3DAPI void R3D_DrawModel(R3D_Model model, Vector3 position, float scale);
R3DAPI void R3D_DrawModelEx(R3D_Model model, Vector3 position, Quaternion rotation, Vector3 scale);
R3DAPI void R3D_DrawModelPro(R3D_Model model, Matrix transform);

R3DAPI void R3D_DrawModelInstanced(R3D_Model model, R3D_InstanceBuffer instances, int count);
R3DAPI void R3D_DrawModelInstancedEx(R3D_Model model, R3D_InstanceBuffer instances, int count, Matrix transform);

R3DAPI void R3D_DrawAnimatedModel(R3D_Model model, R3D_AnimationPlayer player, Vector3 position, float scale);
R3DAPI void R3D_DrawAnimatedModelEx(R3D_Model model, R3D_AnimationPlayer player, Vector3 position, Quaternion rotation, Vector3 scale);
R3DAPI void R3D_DrawAnimatedModelPro(R3D_Model model, R3D_AnimationPlayer player, Matrix transform);

R3DAPI void R3D_DrawAnimatedModelInstanced(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int count);
R3DAPI void R3D_DrawAnimatedModelInstancedEx(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int count, Matrix transform);

R3DAPI void R3D_DrawDecal(R3D_Decal decal, Matrix transform);
R3DAPI void R3D_DrawDecalInstanced(R3D_Decal decal, R3D_InstanceBuffer instances, int count);
```

Apologies for this sudden breaking change, it's been long overdue.
Better late than never, these functions should now remain stable.