### PR TITLE
Implementation of clusters

### DIFF
--- a/examples/animation.c
+++ b/examples/animation.c
@@ -12,7 +12,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D with FXAA and no frustum culling
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), R3D_FLAG_FXAA | R3D_FLAG_NO_FRUSTUM_CULLING);
+    R3D_Init(GetScreenWidth(), GetScreenHeight(), R3D_FLAG_FXAA);
 
     // Enable post-processing effects
     R3D_ENVIRONMENT_SET(ssao.enabled, true);

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -33,9 +33,8 @@ typedef uint32_t R3D_Flags;
 #define R3D_FLAG_FXAA                   (1 << 0)    ///< Enables Fast Approximate Anti-Aliasing (FXAA)
 #define R3D_FLAG_BLIT_LINEAR            (1 << 1)    ///< Uses linear filtering when blitting the final image
 #define R3D_FLAG_ASPECT_KEEP            (1 << 2)    ///< Maintains the aspect ratio of the internal resolution when blitting the final image
-#define R3D_FLAG_NO_FRUSTUM_CULLING     (1 << 3)    ///< Disables internal frustum culling. Manual culling is allowed, but may break shadow visibility if objects casting shadows are skipped.
-#define R3D_FLAG_TRANSPARENT_SORTING    (1 << 4)    ///< Back-to-front sorting of transparent objects for correct blending of non-discarded fragments. Be careful, in 'force forward' mode this flag will also sort opaque objects in 'near-to-far' but in the same sorting pass.
-#define R3D_FLAG_OPAQUE_SORTING         (1 << 5)    ///< Front-to-back sorting of opaque objects to optimize depth testing at the cost of additional sorting. Please note, in 'force forward' mode this flag has no effect, see transparent sorting.
+#define R3D_FLAG_TRANSPARENT_SORTING    (1 << 3)    ///< Back-to-front sorting of transparent objects for correct blending of non-discarded fragments.
+#define R3D_FLAG_OPAQUE_SORTING         (1 << 4)    ///< Front-to-back sorting of opaque objects to optimize depth testing at the cost of additional sorting.
 
 /**
  * @brief Bitfield type used to specify rendering layers for 3D objects.

--- a/include/r3d/r3d_draw.h
+++ b/include/r3d/r3d_draw.h
@@ -58,6 +58,9 @@ R3DAPI void R3D_BeginEx(RenderTexture target, Camera3D camera);
  */
 R3DAPI void R3D_End(void);
 
+R3DAPI void R3D_BeginCluster(BoundingBox aabb);
+R3DAPI void R3D_EndCluster(void);
+
 /**
  * @brief Queues a mesh draw command.
  *

--- a/include/r3d/r3d_draw.h
+++ b/include/r3d/r3d_draw.h
@@ -58,7 +58,22 @@ R3DAPI void R3D_BeginEx(RenderTexture target, Camera3D camera);
  */
 R3DAPI void R3D_End(void);
 
+/**
+ * @brief Begins a clustered draw pass.
+ *
+ * All draw calls submitted in this pass are first tested against the
+ * cluster AABB. If the cluster fails the scene/shadow frustum test,
+ * none of the contained objects are tested or drawn.
+ *
+ * @param aabb Bounding box used as the cluster-level frustum test.
+ */
 R3DAPI void R3D_BeginCluster(BoundingBox aabb);
+
+/**
+ * @brief Ends the current clustered draw pass.
+ *
+ * Stops submitting draw calls to the active cluster.
+ */
 R3DAPI void R3D_EndCluster(void);
 
 /**


### PR DESCRIPTION
This PR adds support for clustered draw passes using a bounding box.

Two new functions are introduced:
```c
R3DAPI void R3D_BeginCluster(BoundingBox aabb);
R3DAPI void R3D_EndCluster(void);
```

They start and end a clustered draw pass. All draw calls submitted inside the pass depend on the cluster's visibility. If the cluster is outside the scene or shadow frustum, every draw call in it is skipped. This applies to both scene rendering and shadows.

This lets users organize their scenes to minimize individual frustum tests, while keeping full control over how clusters are defined.

It also solves the custom shadow culling problem mentioned here: https://github.com/Bigfoot71/r3d/issues/89
And that closes the discussion opened here: https://github.com/Bigfoot71/r3d/discussions/118

The alternative would have been to expose explicit shadow passes, but that would quickly become too complex, and it still wouldn't solve omni lights, which must render six times.

Clusters are a much cleaner solution.

The `R3D_FLAG_NO_FRUSTUM_CULLING` flag has been removed, since everything needed for proper culling is now available.

For the same reason, the `globalAabb` parameter was removed from instanced rendering. Clusters should now be used instead. If instancing is done outside a cluster, no frustum test is performed.

The only tricky case left is skinned models. For now, their frustum culling relies only on clusters, since their bounding boxes match only the bind pose. I left TODO notes about that.

Currently, if a model has a skinning texture, it is automatically treated as visible. Even though the bind-pose frustum test would technically work, I chose not to complicate things until we have a proper, general solution.

Finally, for now only one cluster pass can be active at a time, they cannot be nested.
This could be a nice improvement for the future, enabling even more powerful hierarchical culling.