### PR TITLE
[internal] Review of uniform names

### DIFF
--- a/shaders/deferred/ambient.frag
+++ b/shaders/deferred/ambient.frag
@@ -23,17 +23,17 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexAlbedo;
-uniform sampler2D uTexNormal;
-uniform sampler2D uTexDepth;
-uniform sampler2D uTexSSAO;
-uniform sampler2D uTexSSIL;
-uniform sampler2D uTexSSR;
-uniform sampler2D uTexORM;
+uniform sampler2D uAlbedoTex;
+uniform sampler2D uNormalTex;
+uniform sampler2D uDepthTex;
+uniform sampler2D uSsaoTex;
+uniform sampler2D uSsilTex;
+uniform sampler2D uSsrTex;
+uniform sampler2D uOrmTex;
 
-uniform samplerCubeArray uCubeIrradiance;
-uniform samplerCubeArray uCubePrefilter;
-uniform sampler2D uTexBrdfLut;
+uniform samplerCubeArray uIrradianceTex;
+uniform samplerCubeArray uPrefilterTex;
+uniform sampler2D uBrdfLutTex;
 
 uniform float uMipCountSSR;
 
@@ -51,18 +51,18 @@ layout(location = 1) out vec4 FragSpecular;
 
 void main()
 {
-    vec3 albedo = texture(uTexAlbedo, vTexCoord).rgb;
-    vec3 orm = texture(uTexORM, vTexCoord).rgb;
+    vec3 albedo = texture(uAlbedoTex, vTexCoord).rgb;
+    vec3 orm = texture(uOrmTex, vTexCoord).rgb;
 
-    vec4 ssr = textureLod(uTexSSR, vTexCoord, orm.g * uMipCountSSR);
-    float ssao = texture(uTexSSAO, vTexCoord).r;
-    vec4 ssil = texture(uTexSSIL, vTexCoord);
+    vec4 ssr = textureLod(uSsrTex, vTexCoord, orm.g * uMipCountSSR);
+    float ssao = texture(uSsaoTex, vTexCoord).r;
+    vec4 ssil = texture(uSsilTex, vTexCoord);
 
     orm.x *= ssao * ssil.w;
 
     vec3 F0 = PBR_ComputeF0(orm.z, 0.5, albedo);
-    vec3 P = V_GetWorldPosition(uTexDepth, vTexCoord);
-    vec3 N = V_GetWorldNormal(uTexNormal, vTexCoord);
+    vec3 P = V_GetWorldPosition(uDepthTex, vTexCoord);
+    vec3 N = V_GetWorldNormal(uNormalTex, vTexCoord);
     vec3 V = normalize(uView.position - P);
     float NdotV = max(dot(N, V), 0.0);
     vec3 kD = albedo * (1.0 - orm.z);

--- a/shaders/deferred/compose.frag
+++ b/shaders/deferred/compose.frag
@@ -17,8 +17,8 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexDiffuse;
-uniform sampler2D uTexSpecular;
+uniform sampler2D uDiffuseTex;
+uniform sampler2D uSpecularTex;
 
 /* === Fragments === */
 
@@ -28,8 +28,8 @@ layout(location = 0) out vec3 FragColor;
 
 void main()
 {
-    vec3 diffuse = texture(uTexDiffuse, vTexCoord).rgb;
-    vec3 specular = texture(uTexSpecular, vTexCoord).rgb;
+    vec3 diffuse = texture(uDiffuseTex, vTexCoord).rgb;
+    vec3 specular = texture(uSpecularTex, vTexCoord).rgb;
 
     FragColor = diffuse + specular;
 }

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -48,11 +48,11 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexAlbedo;
-uniform sampler2D uTexNormal;
-uniform sampler2D uTexDepth;
-uniform sampler2D uTexSSAO;
-uniform sampler2D uTexORM;
+uniform sampler2D uAlbedoTex;
+uniform sampler2D uNormalTex;
+uniform sampler2D uDepthTex;
+uniform sampler2D uSsaoTex;
+uniform sampler2D uOrmTex;
 
 uniform Light uLight;
 
@@ -178,8 +178,8 @@ void main()
 {
     /* Sample albedo and ORM texture and extract values */
     
-    vec3 albedo = texture(uTexAlbedo, vTexCoord).rgb;
-    vec3 orm = texture(uTexORM, vTexCoord).rgb;
+    vec3 albedo = texture(uAlbedoTex, vTexCoord).rgb;
+    vec3 orm = texture(uOrmTex, vTexCoord).rgb;
     float roughness = orm.g;
     float metalness = orm.b;
 
@@ -189,8 +189,8 @@ void main()
 
     /* Get position and normal in world space */
 
-    vec3 position = V_GetWorldPosition(uTexDepth, vTexCoord);
-    vec3 N = V_GetWorldNormal(uTexNormal, vTexCoord);
+    vec3 position = V_GetWorldPosition(uDepthTex, vTexCoord);
+    vec3 N = V_GetWorldNormal(uNormalTex, vTexCoord);
 
     /* Compute view direction and the dot product of the normal and view direction */
     
@@ -269,7 +269,7 @@ void main()
 
 	/* Apply SSAO to diffuse lighting (accordingly to light affect) */
 
-    diffuse *= mix(1.0, texture(uTexSSAO, vTexCoord).r, uSSAOLightAffect);
+    diffuse *= mix(1.0, texture(uSsaoTex, vTexCoord).r, uSSAOLightAffect);
 
     /* Compute final lighting contribution */
 

--- a/shaders/include/blocks/env.glsl
+++ b/shaders/include/blocks/env.glsl
@@ -96,13 +96,13 @@ void IBL_SampleProbe(inout vec3 irr, inout vec3 rad, inout float wIrr, inout flo
     if (weight < 1e-6) return;
 
     if (probe.irradiance >= 0) {
-        vec3 probeIrr = IBL_SampleIrradiance(uCubeIrradiance, probe.irradiance, N);
+        vec3 probeIrr = IBL_SampleIrradiance(uIrradianceTex, probe.irradiance, N);
         irr += probeIrr.rgb * weight;
         wIrr += weight;
     }
 
     if (probe.prefilter >= 0) {
-        vec3 probeRad = IBL_SamplePrefilter(uCubePrefilter, probe.prefilter, V, N, roughness);
+        vec3 probeRad = IBL_SamplePrefilter(uPrefilterTex, probe.prefilter, V, N, roughness);
         rad += probeRad.rgb * weight;
         wRad += weight;
     }
@@ -140,19 +140,19 @@ void E_ComputeAmbientAndProbes(inout vec3 irradiance, inout vec3 radiance, vec3 
     if (wIrradiance < 1.0) {
         vec3 ambientIrr = vec3(0.0);
         if (uAmbient.irradiance < 0) ambientIrr = uAmbient.color.rgb;
-        else ambientIrr = IBL_SampleIrradiance(uCubeIrradiance, uAmbient.irradiance, N, uAmbient.rotation);
+        else ambientIrr = IBL_SampleIrradiance(uIrradianceTex, uAmbient.irradiance, N, uAmbient.rotation);
         irradiance += ambientIrr * (1.0 - wIrradiance) * uAmbient.energy;
     }
 
     if (wRadiance < 1.0 && uAmbient.prefilter >= 0) {
-        vec3 ambientRad = IBL_SamplePrefilter(uCubePrefilter, uAmbient.prefilter, V, N, uAmbient.rotation, roughness);
+        vec3 ambientRad = IBL_SamplePrefilter(uPrefilterTex, uAmbient.prefilter, V, N, uAmbient.rotation, roughness);
         radiance += ambientRad * (1.0 - wRadiance) * uAmbient.energy;
     }
 
     irradiance *= occlusion;
     radiance *= IBL_GetSpecularOcclusion(NdotV, occlusion, roughness);
 
-    vec2 brdf = texture(uTexBrdfLut, vec2(NdotV, roughness)).xy;
+    vec2 brdf = texture(uBrdfLutTex, vec2(NdotV, roughness)).xy;
     IBL_MultiScattering(irradiance, radiance, diffuse, F0, brdf, NdotV, roughness);
 }
 
@@ -163,7 +163,7 @@ void E_ComputeAmbientOnly(inout vec3 irradiance, inout vec3 radiance, vec3 diffu
     float metalness = orm.z;
 
     if (uAmbient.irradiance >= 0) {
-        vec3 ambientIrr = IBL_SampleIrradiance(uCubeIrradiance, uAmbient.irradiance, N, uAmbient.rotation);
+        vec3 ambientIrr = IBL_SampleIrradiance(uIrradianceTex, uAmbient.irradiance, N, uAmbient.rotation);
         irradiance += ambientIrr.rgb * uAmbient.energy;
     }
     else {
@@ -171,14 +171,14 @@ void E_ComputeAmbientOnly(inout vec3 irradiance, inout vec3 radiance, vec3 diffu
     }
 
     if (uAmbient.prefilter >= 0) {
-        vec3 ambientRad = IBL_SamplePrefilter(uCubePrefilter, uAmbient.prefilter, V, N, uAmbient.rotation, roughness);
+        vec3 ambientRad = IBL_SamplePrefilter(uPrefilterTex, uAmbient.prefilter, V, N, uAmbient.rotation, roughness);
         radiance += ambientRad.rgb * uAmbient.energy;
     }
 
     irradiance *= occlusion;
     radiance *= IBL_GetSpecularOcclusion(NdotV, occlusion, roughness);
 
-    vec2 brdf = texture(uTexBrdfLut, vec2(NdotV, roughness)).xy;
+    vec2 brdf = texture(uBrdfLutTex, vec2(NdotV, roughness)).xy;
     IBL_MultiScattering(irradiance, radiance, diffuse, F0, brdf, NdotV, roughness);
 }
 

--- a/shaders/post/bloom.frag
+++ b/shaders/post/bloom.frag
@@ -20,8 +20,8 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexColor;
-uniform sampler2D uTexBloomBlur;
+uniform sampler2D uSceneTex;
+uniform sampler2D uBloomTex;
 
 uniform lowp int uBloomMode;
 uniform float uBloomIntensity;
@@ -35,10 +35,10 @@ out vec3 FragColor;
 void main()
 {
     // Sampling scene color texture
-    vec3 color = texture(uTexColor, vTexCoord).rgb;
+    vec3 color = texture(uSceneTex, vTexCoord).rgb;
 
     // Apply bloom
-    vec3 bloom = texture(uTexBloomBlur, vTexCoord).rgb;
+    vec3 bloom = texture(uBloomTex, vTexCoord).rgb;
     bloom *= uBloomIntensity;
 
     if (uBloomMode == BLOOM_MIX) {

--- a/shaders/post/dof.frag
+++ b/shaders/post/dof.frag
@@ -28,8 +28,8 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexColor;
-uniform sampler2D uTexDepth;
+uniform sampler2D uSceneTex;
+uniform sampler2D uDepthTex;
 
 uniform float uFocusPoint;
 uniform float uFocusScale;
@@ -55,11 +55,11 @@ float GetBlurSize(float depth)
 
 void main()
 {
-    vec2 texelSize = 1.0 / vec2(textureSize(uTexColor, 0));
-    vec3 color = texture(uTexColor, vTexCoord).rgb;
+    vec2 texelSize = 1.0 / vec2(textureSize(uSceneTex, 0));
+    vec3 color = texture(uSceneTex, vTexCoord).rgb;
 
     // Center depth and CoC
-    float centerDepth = V_GetLinearDepth(uTexDepth, vTexCoord);
+    float centerDepth = V_GetLinearDepth(uDepthTex, vTexCoord);
     float centerSize  = GetBlurSize(centerDepth);
 
     //scatter as gather
@@ -70,8 +70,8 @@ void main()
     {
         vec2 tc = vTexCoord + vec2(cos(ang), sin(ang)) * texelSize * radius;
 
-        vec3 sampleColor = texture(uTexColor, tc).rgb;
-        float sampleDepth = V_GetLinearDepth(uTexDepth, tc);
+        vec3 sampleColor = texture(uSceneTex, tc).rgb;
+        float sampleDepth = V_GetLinearDepth(uDepthTex, tc);
         float sampleSize  = GetBlurSize(sampleDepth);
 
         if (sampleDepth > centerDepth) {

--- a/shaders/post/fog.frag
+++ b/shaders/post/fog.frag
@@ -25,8 +25,8 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexColor;
-uniform sampler2D uTexDepth;
+uniform sampler2D uSceneTex;
+uniform sampler2D uDepthTex;
 
 uniform lowp int uFogMode;
 uniform vec3 uFogColor;
@@ -70,8 +70,8 @@ float FogFactor(float dist, int mode, float density, float start, float end)
 
 void main()
 {
-    float depth = V_GetLinearDepth(uTexDepth, vTexCoord);
-    vec3 color = texture(uTexColor, vTexCoord).rgb;
+    float depth = V_GetLinearDepth(uDepthTex, vTexCoord);
+    vec3 color = texture(uSceneTex, vTexCoord).rgb;
 
     float fogFactor = FogFactor(depth, uFogMode, uFogDensity, uFogStart, uFogEnd);
     fogFactor *= uSkyAffect * step(depth, uView.far);

--- a/shaders/post/fxaa.frag
+++ b/shaders/post/fxaa.frag
@@ -32,8 +32,8 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexture;
-uniform vec2 uTexelSize;
+uniform sampler2D uSourceTex;
+uniform vec2 uSourceTexel;
 
 /* === Fragments === */
 
@@ -136,11 +136,11 @@ void main()
 {
     vec2 pos = vTexCoord;
 
-    vec3 rgbN = FxaaTexOff(uTexture, pos.xy, ivec2( 0,-1), uTexelSize).xyz;
-    vec3 rgbW = FxaaTexOff(uTexture, pos.xy, ivec2(-1, 0), uTexelSize).xyz;
-    vec3 rgbM = FxaaTexOff(uTexture, pos.xy, ivec2( 0, 0), uTexelSize).xyz;
-    vec3 rgbE = FxaaTexOff(uTexture, pos.xy, ivec2( 1, 0), uTexelSize).xyz;
-    vec3 rgbS = FxaaTexOff(uTexture, pos.xy, ivec2( 0, 1), uTexelSize).xyz;
+    vec3 rgbN = FxaaTexOff(uSourceTex, pos.xy, ivec2( 0,-1), uSourceTexel).xyz;
+    vec3 rgbW = FxaaTexOff(uSourceTex, pos.xy, ivec2(-1, 0), uSourceTexel).xyz;
+    vec3 rgbM = FxaaTexOff(uSourceTex, pos.xy, ivec2( 0, 0), uSourceTexel).xyz;
+    vec3 rgbE = FxaaTexOff(uSourceTex, pos.xy, ivec2( 1, 0), uSourceTexel).xyz;
+    vec3 rgbS = FxaaTexOff(uSourceTex, pos.xy, ivec2( 0, 1), uSourceTexel).xyz;
     
     float lumaN = FxaaLuma(rgbN);
     float lumaW = FxaaLuma(rgbW);
@@ -163,10 +163,10 @@ void main()
     float blendL = max(0.0, (rangeL / range) - FXAA_SUBPIX_TRIM) * FXAA_SUBPIX_TRIM_SCALE; 
     blendL = min(FXAA_SUBPIX_CAP, blendL);
     
-    vec3 rgbNW = FxaaTexOff(uTexture, pos.xy, ivec2(-1,-1), uTexelSize).xyz;
-    vec3 rgbNE = FxaaTexOff(uTexture, pos.xy, ivec2( 1,-1), uTexelSize).xyz;
-    vec3 rgbSW = FxaaTexOff(uTexture, pos.xy, ivec2(-1, 1), uTexelSize).xyz;
-    vec3 rgbSE = FxaaTexOff(uTexture, pos.xy, ivec2( 1, 1), uTexelSize).xyz;
+    vec3 rgbNW = FxaaTexOff(uSourceTex, pos.xy, ivec2(-1,-1), uSourceTexel).xyz;
+    vec3 rgbNE = FxaaTexOff(uSourceTex, pos.xy, ivec2( 1,-1), uSourceTexel).xyz;
+    vec3 rgbSW = FxaaTexOff(uSourceTex, pos.xy, ivec2(-1, 1), uSourceTexel).xyz;
+    vec3 rgbSE = FxaaTexOff(uSourceTex, pos.xy, ivec2( 1, 1), uSourceTexel).xyz;
     rgbL += (rgbNW + rgbNE + rgbSW + rgbSE);
     rgbL *= vec3(1.0/9.0);
     
@@ -185,7 +185,7 @@ void main()
         abs((0.25 * lumaNE) + (-0.5 * lumaE) + (0.25 * lumaSE));
         
     bool horzSpan = edgeHorz >= edgeVert;
-    float lengthSign = horzSpan ? -uTexelSize.y : -uTexelSize.x;
+    float lengthSign = horzSpan ? -uSourceTexel.y : -uSourceTexel.x;
     
     if(!horzSpan) {
         lumaN = lumaW;
@@ -211,7 +211,7 @@ void main()
     gradientN *= FXAA_SEARCH_THRESHOLD;
     
     vec2 posP = posN;
-    vec2 offNP = horzSpan ? vec2(uTexelSize.x, 0.0) : vec2(0.0, uTexelSize.y); 
+    vec2 offNP = horzSpan ? vec2(uSourceTexel.x, 0.0) : vec2(0.0, uSourceTexel.y); 
     float lumaEndN = lumaN;
     float lumaEndP = lumaN;
     bool doneN = false;
@@ -221,10 +221,10 @@ void main()
     
     for(int i = 0; i < FXAA_SEARCH_STEPS; i++) {
         if(!doneN) {
-            lumaEndN = FxaaLuma(texture(uTexture, posN.xy).xyz);
+            lumaEndN = FxaaLuma(texture(uSourceTex, posN.xy).xyz);
         }
         if(!doneP) {
-            lumaEndP = FxaaLuma(texture(uTexture, posP.xy).xyz);
+            lumaEndP = FxaaLuma(texture(uSourceTex, posP.xy).xyz);
         }
         
         doneN = doneN || (abs(lumaEndN - lumaN) >= gradientN);
@@ -253,7 +253,7 @@ void main()
     float spanLength = (dstP + dstN);
     dstN = directionN ? dstN : dstP;
     float subPixelOffset = (0.5 + (dstN * (-1.0/spanLength))) * lengthSign;
-    vec3 rgbF = texture(uTexture, vec2(
+    vec3 rgbF = texture(uSourceTex, vec2(
         pos.x + (horzSpan ? 0.0 : subPixelOffset),
         pos.y + (horzSpan ? subPixelOffset : 0.0))).xyz;
 

--- a/shaders/post/output.frag
+++ b/shaders/post/output.frag
@@ -29,7 +29,7 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexColor;        //< Scene color texture
+uniform sampler2D uSceneTex;        //< Scene color texture
 uniform float uTonemapExposure;     //< Tonemap exposure
 uniform float uTonemapWhite;        //< Tonemap white point, not used with AGX
 uniform int uTonemapMode;           //< Tonemap mode used (e.g. TONEMAP_LINEAR)
@@ -219,7 +219,7 @@ vec3 LinearToSRGB(vec3 color)
 
 void main()
 {
-    vec3 color = texture(uTexColor, vTexCoord).rgb;
+    vec3 color = texture(uSceneTex, vTexCoord).rgb;
 
     color = Tonemapping(color, uTonemapExposure, uTonemapWhite);
     color = Adjustments(color, uBrightness, uContrast, uSaturation);

--- a/shaders/prepare/atrous_wavelet.frag
+++ b/shaders/prepare/atrous_wavelet.frag
@@ -19,9 +19,9 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexSource;
-uniform sampler2D uTexNormal;
-uniform sampler2D uTexDepth;
+uniform sampler2D uSourceTex;
+uniform sampler2D uNormalTex;
+uniform sampler2D uDepthTex;
 
 uniform int uStepSize;  // Powers of 2: 1, 2, 4, 8... for each pass
 
@@ -91,18 +91,18 @@ void main()
     vec4 result = vec4(0.0);
     float totalWeight = 0.0;
 
-    vec2 texelSize = 1.0 / vec2(textureSize(uTexSource, 0));
-    vec3 centerNormal = V_GetViewNormal(uTexNormal, vTexCoord);
-    float centerDepth = V_GetLinearDepth(uTexDepth, vTexCoord);
+    vec2 texelSize = 1.0 / vec2(textureSize(uSourceTex, 0));
+    vec3 centerNormal = V_GetViewNormal(uNormalTex, vTexCoord);
+    float centerDepth = V_GetLinearDepth(uDepthTex, vTexCoord);
 
     for (int i = 0; i < KERNEL_SIZE; ++i)
     {
         vec2 offset = vec2(OFFSETS[i] * uStepSize) * texelSize;
         vec2 uv = vTexCoord + offset;
 
-        vec4 sampleValue = texture(uTexSource, uv);
-        vec3 sampleNormal = V_GetViewNormal(uTexNormal, uv);
-        float sampleDepth = V_GetLinearDepth(uTexDepth, uv);
+        vec4 sampleValue = texture(uSourceTex, uv);
+        vec3 sampleNormal = V_GetViewNormal(uNormalTex, uv);
+        float sampleDepth = V_GetLinearDepth(uDepthTex, uv);
 
         float wNormal = NormalWeight(centerNormal, sampleNormal);
         float wDepth = DepthWeight(centerDepth, sampleDepth);

--- a/shaders/prepare/blur_down.frag
+++ b/shaders/prepare/blur_down.frag
@@ -12,22 +12,20 @@
 #version 330 core
 
 noperspective in vec2 vTexCoord;
-
-uniform sampler2D uTexSource;
-uniform int uMipSource;
-
+uniform sampler2D uSourceTex;
+uniform int uSourceLod;
 out vec4 FragColor;
 
 void main()
 {
-    vec2 halfPixel = 0.5 / vec2(textureSize(uTexSource, uMipSource));
-    float lod = float(uMipSource);
+    vec2 halfPixel = 0.5 / vec2(textureSize(uSourceTex, uSourceLod));
+    float lod = float(uSourceLod);
 
-    vec4 sum = textureLod(uTexSource, vTexCoord, lod) * 4.0;
-    sum += textureLod(uTexSource, vTexCoord - halfPixel.xy, lod);
-    sum += textureLod(uTexSource, vTexCoord + halfPixel.xy, lod);
-    sum += textureLod(uTexSource, vTexCoord + vec2(halfPixel.x, -halfPixel.y), lod);
-    sum += textureLod(uTexSource, vTexCoord - vec2(halfPixel.x, -halfPixel.y), lod);
+    vec4 sum = textureLod(uSourceTex, vTexCoord, lod) * 4.0;
+    sum += textureLod(uSourceTex, vTexCoord - halfPixel.xy, lod);
+    sum += textureLod(uSourceTex, vTexCoord + halfPixel.xy, lod);
+    sum += textureLod(uSourceTex, vTexCoord + vec2(halfPixel.x, -halfPixel.y), lod);
+    sum += textureLod(uSourceTex, vTexCoord - vec2(halfPixel.x, -halfPixel.y), lod);
 
     FragColor = sum / 8.0;
 }

--- a/shaders/prepare/blur_up.frag
+++ b/shaders/prepare/blur_up.frag
@@ -12,23 +12,23 @@
 #version 330 core
 
 noperspective in vec2 vTexCoord;
-uniform sampler2D uTexSource;
-uniform int uMipSource;
+uniform sampler2D uSourceTex;
+uniform int uSourceLod;
 out vec4 FragColor;
 
 void main()
 {
-    vec2 halfPixel = 0.5 / vec2(textureSize(uTexSource, uMipSource));
-    float lod = float(uMipSource);
+    vec2 halfPixel = 0.5 / vec2(textureSize(uSourceTex, uSourceLod));
+    float lod = float(uSourceLod);
 
-    vec4 sum = textureLod(uTexSource, vTexCoord + vec2(-halfPixel.x * 2.0, 0.0), lod);
-    sum += textureLod(uTexSource, vTexCoord + vec2(-halfPixel.x, halfPixel.y), lod) * 2.0;
-    sum += textureLod(uTexSource, vTexCoord + vec2(0.0, halfPixel.y * 2.0), lod);
-    sum += textureLod(uTexSource, vTexCoord + vec2(halfPixel.x, halfPixel.y), lod) * 2.0;
-    sum += textureLod(uTexSource, vTexCoord + vec2(halfPixel.x * 2.0, 0.0), lod);
-    sum += textureLod(uTexSource, vTexCoord + vec2(halfPixel.x, -halfPixel.y), lod) * 2.0;
-    sum += textureLod(uTexSource, vTexCoord + vec2(0.0, -halfPixel.y * 2.0), lod);
-    sum += textureLod(uTexSource, vTexCoord + vec2(-halfPixel.x, -halfPixel.y), lod) * 2.0;
+    vec4 sum = textureLod(uSourceTex, vTexCoord + vec2(-halfPixel.x * 2.0, 0.0), lod);
+    sum += textureLod(uSourceTex, vTexCoord + vec2(-halfPixel.x, halfPixel.y), lod) * 2.0;
+    sum += textureLod(uSourceTex, vTexCoord + vec2(0.0, halfPixel.y * 2.0), lod);
+    sum += textureLod(uSourceTex, vTexCoord + vec2(halfPixel.x, halfPixel.y), lod) * 2.0;
+    sum += textureLod(uSourceTex, vTexCoord + vec2(halfPixel.x * 2.0, 0.0), lod);
+    sum += textureLod(uSourceTex, vTexCoord + vec2(halfPixel.x, -halfPixel.y), lod) * 2.0;
+    sum += textureLod(uSourceTex, vTexCoord + vec2(0.0, -halfPixel.y * 2.0), lod);
+    sum += textureLod(uSourceTex, vTexCoord + vec2(-halfPixel.x, -halfPixel.y), lod) * 2.0;
 
     FragColor = sum / 12.0;
 }

--- a/shaders/prepare/cubeface_down.frag
+++ b/shaders/prepare/cubeface_down.frag
@@ -10,10 +10,10 @@
 
 noperspective in vec2 vTexCoord;
 
-uniform samplerCube uCube;
-uniform float uSrcTexel;
-uniform float uSrcLod;
-uniform int uFace;
+uniform samplerCube uSourceTex;
+uniform float uSourceTexel;
+uniform float uSourceLod;
+uniform int uSourceFace;
 
 out vec4 FragColor;
 
@@ -35,7 +35,7 @@ vec3 GetDirection(vec2 uv, int face)
 
 void main()
 {
-    float offset = uSrcTexel * 0.5;
+    float offset = uSourceTexel * 0.5;
 
     vec2 offsets[4] = vec2[4](
         vec2(-offset, -offset),
@@ -46,10 +46,10 @@ void main()
 
     vec4 result = vec4(0.0);
 
-    result += textureLod(uCube, GetDirection(vTexCoord + offsets[0], uFace), uSrcLod);
-    result += textureLod(uCube, GetDirection(vTexCoord + offsets[1], uFace), uSrcLod);
-    result += textureLod(uCube, GetDirection(vTexCoord + offsets[2], uFace), uSrcLod);
-    result += textureLod(uCube, GetDirection(vTexCoord + offsets[3], uFace), uSrcLod);
+    result += textureLod(uSourceTex, GetDirection(vTexCoord + offsets[0], uSourceFace), uSourceLod);
+    result += textureLod(uSourceTex, GetDirection(vTexCoord + offsets[1], uSourceFace), uSourceLod);
+    result += textureLod(uSourceTex, GetDirection(vTexCoord + offsets[2], uSourceFace), uSourceLod);
+    result += textureLod(uSourceTex, GetDirection(vTexCoord + offsets[3], uSourceFace), uSourceLod);
 
     FragColor = result * 0.25;
 }

--- a/shaders/prepare/cubemap_from_equirectangular.frag
+++ b/shaders/prepare/cubemap_from_equirectangular.frag
@@ -10,7 +10,7 @@
 
 in vec3 vPosition;
 
-uniform sampler2D uTexEquirectangular;
+uniform sampler2D uPanoramaTex;
 
 out vec4 FragColor;
 
@@ -25,6 +25,6 @@ vec2 SampleSphericalMap(vec3 v)
 void main()
 {
     vec2 uv = SampleSphericalMap(normalize(vPosition));
-    vec3 color = texture(uTexEquirectangular, uv).rgb;
+    vec3 color = texture(uPanoramaTex, uv).rgb;
     FragColor = vec4(color, 1.0);
 }

--- a/shaders/prepare/cubemap_irradiance.frag
+++ b/shaders/prepare/cubemap_irradiance.frag
@@ -18,7 +18,7 @@ in vec3 vPosition;
 
 /* === Uniforms === */
 
-uniform samplerCube uTexCubemap;
+uniform samplerCube uSourceTex;
 
 /* === Fragments === */
 
@@ -55,7 +55,7 @@ void main()
             // tangent space to world
             vec3 sampleVec = tangentSample.x * right + tangentSample.y * up + tangentSample.z * N; 
 
-            irradiance += texture(uTexCubemap, sampleVec).rgb * cos(theta) * sin(theta);
+            irradiance += texture(uSourceTex, sampleVec).rgb * cos(theta) * sin(theta);
             nrSamples++;
         }
     }

--- a/shaders/prepare/cubemap_prefilter.frag
+++ b/shaders/prepare/cubemap_prefilter.frag
@@ -23,9 +23,9 @@ in vec3 vPosition;
 
 /* === Uniforms === */
 
-uniform samplerCube uTexCubemap;    //< Source cubemap
-uniform float uResolution;          //< Resolution of the source cubemap
-uniform float uNumLevels;           //< Level count of the source cubemap
+uniform samplerCube uSourceTex;     //< Source cubemap
+uniform float uSourceNumLevels;     //< Level count of the source cubemap
+uniform float uSourceFaceSize;      //< Resolution of the source cubemap
 uniform float uRoughness;           //< Roughness (relative to mip level)
 
 /* === Fragments === */
@@ -98,7 +98,7 @@ void main()
     /* --- Handle the case where roughness = 0 (perfect mirror) --- */
 
     if (uRoughness <= EPSILON) {
-        FragColor = textureLod(uTexCubemap, N, 0.0);
+        FragColor = textureLod(uSourceTex, N, 0.0);
         return;
     }
 
@@ -129,10 +129,10 @@ void main()
             float HdotV = max(dot(H, V), 0.0);
 
             float pdf = (D * NdotH) / max(4.0 * HdotV, EPSILON);
-            float mipLevel = ComputeMipLevel(pdf, uResolution);
-            mipLevel = clamp(mipLevel, 0.0, uNumLevels - 1.0);
+            float mipLevel = ComputeMipLevel(pdf, uSourceFaceSize);
+            mipLevel = clamp(mipLevel, 0.0, uSourceNumLevels - 1.0);
 
-            vec3 sampleColor = textureLod(uTexCubemap, L, mipLevel).rgb;
+            vec3 sampleColor = textureLod(uSourceTex, L, mipLevel).rgb;
             prefilteredColor += sampleColor * NdotL;
             totalWeight += NdotL;
         }

--- a/shaders/prepare/ssao.frag
+++ b/shaders/prepare/ssao.frag
@@ -24,8 +24,8 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexDepth;
-uniform sampler2D uTexNormal;
+uniform sampler2D uNormalTex;
+uniform sampler2D uDepthTex;
 
 uniform int uSampleCount;
 uniform float uRadius;
@@ -57,8 +57,8 @@ vec2 TapLocation(int i, float spinAngle, out float rNorm)
 
 void main()
 {
-    vec3 position = V_GetViewPosition(uTexDepth, vTexCoord);
-    vec3 normal = V_GetViewNormal(uTexNormal, vTexCoord);
+    vec3 position = V_GetViewPosition(uDepthTex, vTexCoord);
+    vec3 normal = V_GetViewNormal(uNormalTex, vTexCoord);
 
     // Compute the radius in screen space
     float projScale = uView.proj[0][0];
@@ -81,7 +81,7 @@ void main()
         vec2 offset = vTexCoord + dir * ssRadius * rNorm;
 
         // The "SAO" paper recommends using mipmaps of the linearized depth here, but hey
-        vec3 samplePos = V_GetViewPosition(uTexDepth, offset);
+        vec3 samplePos = V_GetViewPosition(uDepthTex, offset);
         vec3 v = samplePos - position;
 
         float vv = dot(v, v);

--- a/shaders/prepare/ssil.frag
+++ b/shaders/prepare/ssil.frag
@@ -25,10 +25,10 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexLight;
-uniform sampler2D uTexPrevSSIL;
-uniform sampler2D uTexNormal;
-uniform sampler2D uTexDepth;
+uniform sampler2D uLightingTex;
+uniform sampler2D uHistoryTex;
+uniform sampler2D uNormalTex;
+uniform sampler2D uDepthTex;
 
 uniform float uSampleCount;
 uniform float uSampleRadius;
@@ -67,8 +67,8 @@ uint UpdateSectors(float minHorizon, float maxHorizon, uint outBitfield)
 
 vec3 SampleLight(vec2 texCoord)
 {
-    vec3 indirect = texture(uTexPrevSSIL, texCoord).rgb;
-    vec3 direct = texture(uTexLight, texCoord).rgb;
+    vec3 indirect = texture(uHistoryTex, texCoord).rgb;
+    vec3 direct = texture(uLightingTex, texCoord).rgb;
     return direct + uBounce * indirect;
 }
 
@@ -82,8 +82,8 @@ void main()
     float visibility = 0.0;
     vec3 lighting = vec3(0.0);
 
-    vec3 position = V_GetViewPosition(uTexDepth, vTexCoord);
-    vec3 normal = V_GetViewNormal(uTexNormal, vTexCoord);
+    vec3 position = V_GetViewPosition(uDepthTex, vTexCoord);
+    vec3 normal = V_GetViewNormal(uNormalTex, vTexCoord);
     vec3 camera = normalize(-position);
 
     float sliceRotation = M_TAU / (uSliceCount - 1.0);
@@ -116,8 +116,8 @@ void main()
             float sampleStep = (currentSample + jitter) / uSampleCount + sampleOffset;
             vec2 sampleUV = vTexCoord - sampleStep * sampleScale * omega * uView.aspect;
 
-            vec3 samplePosition = V_GetViewPosition(uTexDepth, sampleUV);
-            vec3 sampleNormal = V_GetViewNormal(uTexNormal, sampleUV);
+            vec3 samplePosition = V_GetViewPosition(uDepthTex, sampleUV);
+            vec3 sampleNormal = V_GetViewNormal(uNormalTex, sampleUV);
             vec3 sampleLight = SampleLight(sampleUV);
 
             vec3 sampleDistance = samplePosition - position;
@@ -150,7 +150,7 @@ void main()
         visibility += 1.0 - float(BitCount(occlusion)) / float(SECTOR_COUNT);
     }
 
-    vec4 history = texture(uTexPrevSSIL, vTexCoord);
+    vec4 history = texture(uHistoryTex, vTexCoord);
     visibility /= uSliceCount;
     lighting /= uSliceCount;
 

--- a/shaders/prepare/ssr.frag
+++ b/shaders/prepare/ssr.frag
@@ -20,11 +20,11 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexColor;
-uniform sampler2D uTexAlbedo;
-uniform sampler2D uTexNormal;
-uniform sampler2D uTexORM;
-uniform sampler2D uTexDepth;
+uniform sampler2D uLightingTex;
+uniform sampler2D uAlbedoTex;
+uniform sampler2D uNormalTex;
+uniform sampler2D uOrmTex;
+uniform sampler2D uDepthTex;
 
 uniform int uMaxRaySteps;
 uniform int uBinarySearchSteps;
@@ -53,9 +53,9 @@ float ScreenEdgeFade(vec2 uv)
 
 vec4 SampleScene(vec2 texCoord)
 {
-    vec3 albedo = texture(uTexAlbedo, texCoord).rgb;
-    vec3 light = texture(uTexColor, texCoord).rgb;
-    vec3 orm = texture(uTexORM, texCoord).rgb;
+    vec3 albedo = texture(uAlbedoTex, texCoord).rgb;
+    vec3 light = texture(uLightingTex, texCoord).rgb;
+    vec3 orm = texture(uOrmTex, texCoord).rgb;
 
     vec3 ambient = uAmbientColor * uAmbientEnergy;
     ambient *= albedo * (1.0 - orm.b);
@@ -73,7 +73,7 @@ vec3 BinarySearch(vec3 startPos, vec3 endPos)
         vec3 midPos = (startPos + endPos) * 0.5;
         vec2 uv = V_WorldToScreen(midPos);
 
-        vec3 sampledViewPos = V_GetViewPosition(uTexDepth, uv);
+        vec3 sampledViewPos = V_GetViewPosition(uDepthTex, uv);
         vec3 midViewPos = (uView.view * vec4(midPos, 1.0)).xyz;
 
         float depthDiff = sampledViewPos.z - midViewPos.z;
@@ -103,7 +103,7 @@ vec4 TraceReflectionRay(vec3 startPos, vec3 reflectionDir)
         vec2 uv = V_WorldToScreen(currentPos);
         if (V_OffScreen(uv)) break;
 
-        vec3 sampledViewPos = V_GetViewPosition(uTexDepth, uv);
+        vec3 sampledViewPos = V_GetViewPosition(uDepthTex, uv);
         vec3 currentViewPos = (uView.view * vec4(currentPos, 1.0)).xyz;
 
         float depthDiff = sampledViewPos.z - currentViewPos.z;
@@ -126,10 +126,10 @@ void main()
 {
     FragColor = vec4(0.0);
 
-    float depth = texture(uTexDepth, vTexCoord).r;
+    float depth = texture(uDepthTex, vTexCoord).r;
     if (depth > 1.0 - 1e-5) return;
 
-    vec3 worldNormal = V_GetWorldNormal(uTexNormal, vTexCoord);
+    vec3 worldNormal = V_GetWorldNormal(uNormalTex, vTexCoord);
     vec3 worldPos = V_GetWorldPosition(vTexCoord, depth);
 
     vec3 viewDir = normalize(worldPos - uView.position);

--- a/shaders/scene/decal.frag
+++ b/shaders/scene/decal.frag
@@ -22,16 +22,16 @@ smooth in vec4 vClipPos;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexAlbedo;
-uniform sampler2D uTexNormal; // Unused - placeholder for future implementation
-uniform sampler2D uTexEmission;
-uniform sampler2D uTexORM;
-uniform sampler2D uTexDepth;
+uniform sampler2D uAlbedoMap;
+uniform sampler2D uNormalMap;   // Unused - placeholder for future implementation
+uniform sampler2D uEmissionMap;
+uniform sampler2D uOrmMap;
+uniform sampler2D uDepthTex;
 
-uniform mat4 uMatNormal; // Unused - placeholder for future implementation
+uniform mat4 uMatNormal;        // Unused - placeholder for future implementation
 
 uniform float uAlphaCutoff;
-uniform float uNormalScale; // Unused - placeholder for future implementation
+uniform float uNormalScale;     // Unused - placeholder for future implementation
 uniform float uOcclusion;
 uniform float uRoughness;
 uniform float uMetalness;
@@ -55,7 +55,7 @@ void main()
     vec2 fragTexCoord = screenPos * 0.5 + 0.5;
 
     // Reconstruct position in view space
-    vec3 positionViewSpace = V_GetViewPosition(uTexDepth, fragTexCoord);
+    vec3 positionViewSpace = V_GetViewPosition(uDepthTex, fragTexCoord);
 
     // Convert from world space to decal projector's model space
     vec4 positionModelSpace = vMatDecal * vec4(positionViewSpace, 1.0);
@@ -72,14 +72,14 @@ void main()
     vec2 decalTexCoord = uTexCoordOffset + (positionModelSpace.xz + 0.5) * uTexCoordScale;
 
     // Sample albedo texture and discard if below alpha cutoff
-    vec4 albedo = vColor * texture(uTexAlbedo, decalTexCoord);
+    vec4 albedo = vColor * texture(uAlbedoMap, decalTexCoord);
     if (albedo.a < uAlphaCutoff) discard;
 
 	// Apply material values
     FragAlbedo = albedo;	
-    FragEmission = vec4(vEmission, 1.0) * texture(uTexEmission, decalTexCoord);
+    FragEmission = vec4(vEmission, 1.0) * texture(uEmissionMap, decalTexCoord);
 
-    vec3 orm = texture(uTexORM, decalTexCoord).xyz;
+    vec3 orm = texture(uOrmMap, decalTexCoord).xyz;
     FragORM.x = uOcclusion * orm.x;
     FragORM.y = uRoughness * orm.y;
     FragORM.z = uMetalness * orm.z;

--- a/shaders/scene/depth.frag
+++ b/shaders/scene/depth.frag
@@ -15,7 +15,7 @@ smooth in vec4 vColor;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexAlbedo;
+uniform sampler2D uAlbedoMap;
 uniform float uAlphaCutoff;
 
 /* === Main function === */
@@ -24,6 +24,6 @@ void main()
 {
     // NOTE: The depth is automatically written
 
-    float alpha = vColor.a * texture(uTexAlbedo, vTexCoord).a;
+    float alpha = vColor.a * texture(uAlbedoMap, vTexCoord).a;
     if (alpha < uAlphaCutoff) discard;
 }

--- a/shaders/scene/depth_cube.frag
+++ b/shaders/scene/depth_cube.frag
@@ -12,7 +12,7 @@ smooth in vec3 vPosition;
 smooth in vec2 vTexCoord;
 smooth in vec4 vColor;
 
-uniform sampler2D uTexAlbedo;
+uniform sampler2D uAlbedoMap;
 
 uniform float uAlphaCutoff;
 uniform vec3 uViewPosition;
@@ -20,7 +20,7 @@ uniform float uFar;
 
 void main()
 {
-    float alpha = vColor.a * texture(uTexAlbedo, vTexCoord).a;
+    float alpha = vColor.a * texture(uAlbedoMap, vTexCoord).a;
     if (alpha < uAlphaCutoff) discard;
 
     gl_FragDepth = length(vPosition - uViewPosition) / uFar;

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -54,17 +54,17 @@ in vec4 vPosLightSpace[NUM_FORWARD_LIGHTS];
 
 /* === Uniforms === */
 
-uniform sampler2D uTexAlbedo;
-uniform sampler2D uTexEmission;
-uniform sampler2D uTexNormal;
-uniform sampler2D uTexORM;
+uniform sampler2D uAlbedoMap;
+uniform sampler2D uEmissionMap;
+uniform sampler2D uNormalMap;
+uniform sampler2D uOrmMap;
 
 uniform samplerCube uShadowMapCube[NUM_FORWARD_LIGHTS];
 uniform sampler2D uShadowMap2D[NUM_FORWARD_LIGHTS];
 
-uniform samplerCubeArray uCubeIrradiance;
-uniform samplerCubeArray uCubePrefilter;
-uniform sampler2D uTexBrdfLut;
+uniform samplerCubeArray uIrradianceTex;
+uniform samplerCubeArray uPrefilterTex;
+uniform sampler2D uBrdfLutTex;
 
 uniform float uNormalScale;
 uniform float uOcclusion;
@@ -210,9 +210,9 @@ void main()
 {
     /* Sample material maps */
 
-    vec4 albedo = vColor * texture(uTexAlbedo, vTexCoord);
-    vec3 emission = vEmission * texture(uTexEmission, vTexCoord).rgb;
-    vec3 orm = texture(uTexORM, vTexCoord).rgb;
+    vec4 albedo = vColor * texture(uAlbedoMap, vTexCoord);
+    vec3 emission = vEmission * texture(uEmissionMap, vTexCoord).rgb;
+    vec3 orm = texture(uOrmMap, vTexCoord).rgb;
 
     float occlusion = uOcclusion * orm.x;
     float roughness = uRoughness * orm.y;
@@ -226,7 +226,7 @@ void main()
 
     /* Sample normal and compute view direction vector */
 
-    vec3 N = normalize(vTBN * M_NormalScale(texture(uTexNormal, vTexCoord).rgb * 2.0 - 1.0, uNormalScale));
+    vec3 N = normalize(vTBN * M_NormalScale(texture(uNormalMap, vTexCoord).rgb * 2.0 - 1.0, uNormalScale));
     if (!gl_FrontFacing) N = -N; // Flip for back facing triangles with double sided meshes
 
     vec3 V = normalize(uViewPosition - vPosition);

--- a/shaders/scene/geometry.frag
+++ b/shaders/scene/geometry.frag
@@ -21,10 +21,10 @@ smooth in mat3 vTBN;
 
 /* === Uniforms === */
 
-uniform sampler2D uTexAlbedo;
-uniform sampler2D uTexNormal;
-uniform sampler2D uTexEmission;
-uniform sampler2D uTexORM;
+uniform sampler2D uAlbedoMap;
+uniform sampler2D uNormalMap;
+uniform sampler2D uEmissionMap;
+uniform sampler2D uOrmMap;
 
 uniform float uAlphaCutoff;
 uniform float uNormalScale;
@@ -43,17 +43,17 @@ layout(location = 3) out vec3 FragORM;
 
 void main()
 {
-    vec4 albedo = vColor * texture(uTexAlbedo, vTexCoord);
+    vec4 albedo = vColor * texture(uAlbedoMap, vTexCoord);
     if (albedo.a < uAlphaCutoff) discard;
 
-    vec3 N = normalize(vTBN * M_NormalScale(texture(uTexNormal, vTexCoord).rgb * 2.0 - 1.0, uNormalScale));
+    vec3 N = normalize(vTBN * M_NormalScale(texture(uNormalMap, vTexCoord).rgb * 2.0 - 1.0, uNormalScale));
     if (!gl_FrontFacing) N = -N; // Flip for back facing triangles with double sided meshes
 
     FragAlbedo = albedo.rgb;
-    FragEmission = vEmission * texture(uTexEmission, vTexCoord).rgb;
+    FragEmission = vEmission * texture(uEmissionMap, vTexCoord).rgb;
     FragNormal = M_EncodeOctahedral(N);
 
-    vec3 orm = texture(uTexORM, vTexCoord).rgb;
+    vec3 orm = texture(uOrmMap, vTexCoord).rgb;
 
     FragORM.r = uOcclusion * orm.x;
     FragORM.g = uRoughness * orm.y;

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -53,12 +53,12 @@ uniform bool uSkinning;
 uniform int uBillboard;
 
 #if defined(FORWARD) || defined(PROBE)
-uniform mat4 uMatLightVP[NUM_FORWARD_LIGHTS];
+uniform mat4 uLightViewProj[NUM_FORWARD_LIGHTS];
 #endif // FORWARD
 
 #if defined(DEPTH) || defined(DEPTH_CUBE) || defined(PROBE)
 uniform mat4 uMatInvView;   // inv view only for billboard modes
-uniform mat4 uMatVP;
+uniform mat4 uMatViewProj;
 #endif // DEPTH || DEPTH_CUBE
 
 /* === Varyings === */
@@ -218,12 +218,12 @@ void main()
 
 #if defined(FORWARD) || defined(PROBE)
     for (int i = 0; i < NUM_FORWARD_LIGHTS; i++) {
-        vPosLightSpace[i] = uMatLightVP[i] * vec4(vPosition, 1.0);
+        vPosLightSpace[i] = uLightViewProj[i] * vec4(vPosition, 1.0);
     }
 #endif // FORWARD
 
 #if defined(DEPTH) || defined(DEPTH_CUBE) || defined(PROBE)
-    gl_Position = uMatVP * vec4(vPosition, 1.0);
+    gl_Position = uMatViewProj * vec4(vPosition, 1.0);
 #else
     gl_Position = uView.viewProj * vec4(vPosition, 1.0);
 #endif

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -36,7 +36,7 @@ layout(location = 13) in vec4 iColor;
 
 /* === Uniforms === */
 
-uniform sampler1D uTexBoneMatrices;
+uniform sampler1D uBoneMatricesTex;
 
 uniform mat4 uMatModel;
 uniform mat4 uMatNormal;
@@ -84,10 +84,10 @@ mat4 BoneMatrix(int boneID)
 {
     int baseIndex = 4 * boneID;
 
-    vec4 row0 = texelFetch(uTexBoneMatrices, baseIndex + 0, 0);
-    vec4 row1 = texelFetch(uTexBoneMatrices, baseIndex + 1, 0);
-    vec4 row2 = texelFetch(uTexBoneMatrices, baseIndex + 2, 0);
-    vec4 row3 = texelFetch(uTexBoneMatrices, baseIndex + 3, 0);
+    vec4 row0 = texelFetch(uBoneMatricesTex, baseIndex + 0, 0);
+    vec4 row1 = texelFetch(uBoneMatricesTex, baseIndex + 1, 0);
+    vec4 row2 = texelFetch(uBoneMatricesTex, baseIndex + 2, 0);
+    vec4 row3 = texelFetch(uBoneMatricesTex, baseIndex + 3, 0);
 
     return transpose(mat4(row0, row1, row2, row3));
 }

--- a/shaders/scene/skybox.frag
+++ b/shaders/scene/skybox.frag
@@ -10,12 +10,12 @@
 
 in vec3 vPosition;
 
-uniform samplerCube uSkyTex;
+uniform samplerCube uSkyMap;
 uniform float uSkyEnergy;
 
 layout(location = 0) out vec3 FragColor;
 
 void main()
 {
-    FragColor = texture(uSkyTex, vPosition).rgb * uSkyEnergy;
+    FragColor = texture(uSkyMap, vPosition).rgb * uSkyEnergy;
 }

--- a/shaders/scene/skybox.frag
+++ b/shaders/scene/skybox.frag
@@ -10,12 +10,12 @@
 
 in vec3 vPosition;
 
-uniform samplerCube uCubeSky;
+uniform samplerCube uSkyTex;
 uniform float uSkyEnergy;
 
 layout(location = 0) out vec3 FragColor;
 
 void main()
 {
-    FragColor = texture(uCubeSky, vPosition).rgb * uSkyEnergy;
+    FragColor = texture(uSkyTex, vPosition).rgb * uSkyEnergy;
 }

--- a/src/common/r3d_pass.c
+++ b/src/common/r3d_pass.c
@@ -25,7 +25,7 @@ void r3d_pass_prepare_irradiance(int layerMap, GLuint srcCubemap, int srcSize)
     const Matrix matProj = MatrixPerspective(90.0 * DEG2RAD, 1.0, 0.1, 10.0);
 
     R3D_SHADER_USE(prepare.cubemapIrradiance);
-    R3D_SHADER_BIND_SAMPLER_CUBE(prepare.cubemapIrradiance, uCubemap, srcCubemap);
+    R3D_SHADER_BIND_SAMPLER_CUBE(prepare.cubemapIrradiance, uSourceTex, srcCubemap);
 
     R3D_SHADER_SET_MAT4(prepare.cubemapIrradiance, uMatProj, matProj);
 
@@ -38,7 +38,7 @@ void r3d_pass_prepare_irradiance(int layerMap, GLuint srcCubemap, int srcSize)
         R3D_PRIMITIVE_DRAW_CUBE();
     }
 
-    R3D_SHADER_UNBIND_SAMPLER_CUBE(prepare.cubemapIrradiance, uCubemap);
+    R3D_SHADER_UNBIND_SAMPLER_CUBE(prepare.cubemapIrradiance, uSourceTex);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     glViewport(0, 0, rlGetFramebufferWidth(), rlGetFramebufferHeight());
@@ -49,14 +49,14 @@ void r3d_pass_prepare_irradiance(int layerMap, GLuint srcCubemap, int srcSize)
 void r3d_pass_prepare_prefilter(int layerMap, GLuint srcCubemap, int srcSize)
 {
     const Matrix matProj = MatrixPerspective(90.0 * DEG2RAD, 1.0, 0.1, 10.0);
-    int srcMipCount = 1 + (int)floor(log2(srcSize));
+    int srcNumLevels = 1 + (int)floor(log2(srcSize));
 
     R3D_SHADER_USE(prepare.cubemapPrefilter);
-    R3D_SHADER_BIND_SAMPLER_CUBE(prepare.cubemapPrefilter, uCubemap, srcCubemap);
+    R3D_SHADER_BIND_SAMPLER_CUBE(prepare.cubemapPrefilter, uSourceTex, srcCubemap);
 
     R3D_SHADER_SET_MAT4(prepare.cubemapPrefilter, uMatProj, matProj);
-    R3D_SHADER_SET_FLOAT(prepare.cubemapPrefilter, uResolution, srcSize);
-    R3D_SHADER_SET_FLOAT(prepare.cubemapPrefilter, uNumLevels, srcMipCount);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapPrefilter, uSourceNumLevels, srcNumLevels);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapPrefilter, uSourceFaceSize, srcSize);
 
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_CULL_FACE);
@@ -72,7 +72,7 @@ void r3d_pass_prepare_prefilter(int layerMap, GLuint srcCubemap, int srcSize)
         }
     }
 
-    R3D_SHADER_UNBIND_SAMPLER_CUBE(prepare.cubemapPrefilter, uCubemap);
+    R3D_SHADER_UNBIND_SAMPLER_CUBE(prepare.cubemapPrefilter, uSourceTex);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     glViewport(0, 0, rlGetFramebufferWidth(), rlGetFramebufferHeight());

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -564,12 +564,12 @@ void r3d_shader_load_scene_skybox(void)
     GET_LOCATION(scene.skybox, uRotation);
     GET_LOCATION(scene.skybox, uMatView);
     GET_LOCATION(scene.skybox, uMatProj);
-    GET_LOCATION(scene.skybox, uSkyTex);
+    GET_LOCATION(scene.skybox, uSkyMap);
     GET_LOCATION(scene.skybox, uSkyEnergy);
 
     USE_SHADER(scene.skybox);
 
-    SET_SAMPLER_CUBE(scene.skybox, uSkyTex, 0);
+    SET_SAMPLER_CUBE(scene.skybox, uSkyMap, 0);
 }
 
 void r3d_shader_load_scene_depth(void)

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -236,34 +236,34 @@ void r3d_shader_load_prepare_atrous_wavelet(void)
 
     SET_UNIFORM_BUFFER(prepare.atrousWavelet, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(prepare.atrousWavelet, uTexSource);
-    GET_LOCATION(prepare.atrousWavelet, uTexNormal);
-    GET_LOCATION(prepare.atrousWavelet, uTexDepth);
+    GET_LOCATION(prepare.atrousWavelet, uSourceTex);
+    GET_LOCATION(prepare.atrousWavelet, uNormalTex);
+    GET_LOCATION(prepare.atrousWavelet, uDepthTex);
     GET_LOCATION(prepare.atrousWavelet, uStepSize);
 
     USE_SHADER(prepare.atrousWavelet);
 
-    SET_SAMPLER_2D(prepare.atrousWavelet, uTexSource, 0);
-    SET_SAMPLER_2D(prepare.atrousWavelet, uTexNormal, 1);
-    SET_SAMPLER_2D(prepare.atrousWavelet, uTexDepth, 2);
+    SET_SAMPLER_2D(prepare.atrousWavelet, uSourceTex, 0);
+    SET_SAMPLER_2D(prepare.atrousWavelet, uNormalTex, 1);
+    SET_SAMPLER_2D(prepare.atrousWavelet, uDepthTex, 2);
 }
 
 void r3d_shader_load_prepare_blur_down(void)
 {
     LOAD_SHADER(prepare.blurDown, SCREEN_VERT, BLUR_DOWN_FRAG);
-    GET_LOCATION(prepare.blurDown, uTexSource);
-    GET_LOCATION(prepare.blurDown, uMipSource);
+    GET_LOCATION(prepare.blurDown, uSourceTex);
+    GET_LOCATION(prepare.blurDown, uSourceLod);
     USE_SHADER(prepare.blurDown);
-    SET_SAMPLER_2D(prepare.blurDown, uTexSource, 0);
+    SET_SAMPLER_2D(prepare.blurDown, uSourceTex, 0);
 }
 
 void r3d_shader_load_prepare_blur_up(void)
 {
     LOAD_SHADER(prepare.blurUp, SCREEN_VERT, BLUR_UP_FRAG);
-    GET_LOCATION(prepare.blurUp, uTexSource);
-    GET_LOCATION(prepare.blurUp, uMipSource);
+    GET_LOCATION(prepare.blurUp, uSourceTex);
+    GET_LOCATION(prepare.blurUp, uSourceLod);
     USE_SHADER(prepare.blurUp);
-    SET_SAMPLER_2D(prepare.blurUp, uTexSource, 0);
+    SET_SAMPLER_2D(prepare.blurUp, uSourceTex, 0);
 }
 
 void r3d_shader_load_prepare_ssao(void)
@@ -272,8 +272,8 @@ void r3d_shader_load_prepare_ssao(void)
 
     SET_UNIFORM_BUFFER(prepare.ssao, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(prepare.ssao, uTexDepth);
-    GET_LOCATION(prepare.ssao, uTexNormal);
+    GET_LOCATION(prepare.ssao, uNormalTex);
+    GET_LOCATION(prepare.ssao, uDepthTex);
     GET_LOCATION(prepare.ssao, uSampleCount);
     GET_LOCATION(prepare.ssao, uRadius);
     GET_LOCATION(prepare.ssao, uBias);
@@ -282,8 +282,8 @@ void r3d_shader_load_prepare_ssao(void)
 
     USE_SHADER(prepare.ssao);
 
-    SET_SAMPLER_2D(prepare.ssao, uTexDepth, 0);
-    SET_SAMPLER_2D(prepare.ssao, uTexNormal, 1);
+    SET_SAMPLER_2D(prepare.ssao, uNormalTex, 0);
+    SET_SAMPLER_2D(prepare.ssao, uDepthTex, 1);
 }
 
 void r3d_shader_load_prepare_ssil(void)
@@ -292,10 +292,10 @@ void r3d_shader_load_prepare_ssil(void)
 
     SET_UNIFORM_BUFFER(prepare.ssil, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(prepare.ssil, uTexLight);
-    GET_LOCATION(prepare.ssil, uTexPrevSSIL);
-    GET_LOCATION(prepare.ssil, uTexNormal);
-    GET_LOCATION(prepare.ssil, uTexDepth);
+    GET_LOCATION(prepare.ssil, uLightingTex);
+    GET_LOCATION(prepare.ssil, uHistoryTex);
+    GET_LOCATION(prepare.ssil, uNormalTex);
+    GET_LOCATION(prepare.ssil, uDepthTex);
     GET_LOCATION(prepare.ssil, uSampleCount);
     GET_LOCATION(prepare.ssil, uSampleRadius);
     GET_LOCATION(prepare.ssil, uSliceCount);
@@ -307,10 +307,10 @@ void r3d_shader_load_prepare_ssil(void)
 
     USE_SHADER(prepare.ssil);
 
-    SET_SAMPLER_2D(prepare.ssil, uTexLight, 0);
-    SET_SAMPLER_2D(prepare.ssil, uTexPrevSSIL, 1);
-    SET_SAMPLER_2D(prepare.ssil, uTexNormal, 2);
-    SET_SAMPLER_2D(prepare.ssil, uTexDepth, 3);
+    SET_SAMPLER_2D(prepare.ssil, uLightingTex, 0);
+    SET_SAMPLER_2D(prepare.ssil, uHistoryTex, 1);
+    SET_SAMPLER_2D(prepare.ssil, uNormalTex, 2);
+    SET_SAMPLER_2D(prepare.ssil, uDepthTex, 3);
 }
 
 void r3d_shader_load_prepare_ssr(void)
@@ -319,11 +319,11 @@ void r3d_shader_load_prepare_ssr(void)
 
     SET_UNIFORM_BUFFER(prepare.ssr, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(prepare.ssr, uTexColor);
-    GET_LOCATION(prepare.ssr, uTexAlbedo);
-    GET_LOCATION(prepare.ssr, uTexNormal);
-    GET_LOCATION(prepare.ssr, uTexORM);
-    GET_LOCATION(prepare.ssr, uTexDepth);
+    GET_LOCATION(prepare.ssr, uLightingTex);
+    GET_LOCATION(prepare.ssr, uAlbedoTex);
+    GET_LOCATION(prepare.ssr, uNormalTex);
+    GET_LOCATION(prepare.ssr, uOrmTex);
+    GET_LOCATION(prepare.ssr, uDepthTex);
     GET_LOCATION(prepare.ssr, uMaxRaySteps);
     GET_LOCATION(prepare.ssr, uBinarySearchSteps);
     GET_LOCATION(prepare.ssr, uRayMarchLength);
@@ -336,11 +336,11 @@ void r3d_shader_load_prepare_ssr(void)
 
     USE_SHADER(prepare.ssr);
 
-    SET_SAMPLER_2D(prepare.ssr, uTexColor, 0);
-    SET_SAMPLER_2D(prepare.ssr, uTexAlbedo, 1);
-    SET_SAMPLER_2D(prepare.ssr, uTexNormal, 2);
-    SET_SAMPLER_2D(prepare.ssr, uTexORM, 3);
-    SET_SAMPLER_2D(prepare.ssr, uTexDepth, 4);
+    SET_SAMPLER_2D(prepare.ssr, uLightingTex, 0);
+    SET_SAMPLER_2D(prepare.ssr, uAlbedoTex, 1);
+    SET_SAMPLER_2D(prepare.ssr, uNormalTex, 2);
+    SET_SAMPLER_2D(prepare.ssr, uOrmTex, 3);
+    SET_SAMPLER_2D(prepare.ssr, uDepthTex, 4);
 }
 
 void r3d_shader_load_prepare_bloom_down(void)
@@ -374,14 +374,14 @@ void r3d_shader_load_prepare_cubeface_down(void)
 {
     LOAD_SHADER(prepare.cubefaceDown, SCREEN_VERT, CUBEFACE_DOWN_FRAG);
 
-    GET_LOCATION(prepare.cubefaceDown, uCube);
-    GET_LOCATION(prepare.cubefaceDown, uSrcTexel);
-    GET_LOCATION(prepare.cubefaceDown, uSrcLod);
-    GET_LOCATION(prepare.cubefaceDown, uFace);
+    GET_LOCATION(prepare.cubefaceDown, uSourceTex);
+    GET_LOCATION(prepare.cubefaceDown, uSourceTexel);
+    GET_LOCATION(prepare.cubefaceDown, uSourceLod);
+    GET_LOCATION(prepare.cubefaceDown, uSourceFace);
 
     USE_SHADER(prepare.cubefaceDown);
 
-    SET_SAMPLER_CUBE(prepare.cubefaceDown, uCube, 0);
+    SET_SAMPLER_CUBE(prepare.cubefaceDown, uSourceTex, 0);
 }
 
 void r3d_shader_load_prepare_cubemap_from_equirectangular(void)
@@ -390,11 +390,11 @@ void r3d_shader_load_prepare_cubemap_from_equirectangular(void)
 
     GET_LOCATION(prepare.cubemapFromEquirectangular, uMatProj);
     GET_LOCATION(prepare.cubemapFromEquirectangular, uMatView);
-    GET_LOCATION(prepare.cubemapFromEquirectangular, uTexEquirectangular);
+    GET_LOCATION(prepare.cubemapFromEquirectangular, uPanoramaTex);
 
     USE_SHADER(prepare.cubemapFromEquirectangular);
 
-    SET_SAMPLER_2D(prepare.cubemapFromEquirectangular, uTexEquirectangular, 0);
+    SET_SAMPLER_2D(prepare.cubemapFromEquirectangular, uPanoramaTex, 0);
 }
 
 void r3d_shader_load_prepare_cubemap_irradiance(void)
@@ -403,11 +403,11 @@ void r3d_shader_load_prepare_cubemap_irradiance(void)
 
     GET_LOCATION(prepare.cubemapIrradiance, uMatProj);
     GET_LOCATION(prepare.cubemapIrradiance, uMatView);
-    GET_LOCATION(prepare.cubemapIrradiance, uCubemap);
+    GET_LOCATION(prepare.cubemapIrradiance, uSourceTex);
 
     USE_SHADER(prepare.cubemapIrradiance);
 
-    SET_SAMPLER_CUBE(prepare.cubemapIrradiance, uCubemap, 0);
+    SET_SAMPLER_CUBE(prepare.cubemapIrradiance, uSourceTex, 0);
 }
 
 void r3d_shader_load_prepare_cubemap_prefilter(void)
@@ -416,14 +416,14 @@ void r3d_shader_load_prepare_cubemap_prefilter(void)
 
     GET_LOCATION(prepare.cubemapPrefilter, uMatProj);
     GET_LOCATION(prepare.cubemapPrefilter, uMatView);
-    GET_LOCATION(prepare.cubemapPrefilter, uCubemap);
-    GET_LOCATION(prepare.cubemapPrefilter, uResolution);
-    GET_LOCATION(prepare.cubemapPrefilter, uNumLevels);
+    GET_LOCATION(prepare.cubemapPrefilter, uSourceTex);
+    GET_LOCATION(prepare.cubemapPrefilter, uSourceNumLevels);
+    GET_LOCATION(prepare.cubemapPrefilter, uSourceFaceSize);
     GET_LOCATION(prepare.cubemapPrefilter, uRoughness);
 
     USE_SHADER(prepare.cubemapPrefilter);
 
-    SET_SAMPLER_CUBE(prepare.cubemapPrefilter, uCubemap, 0);
+    SET_SAMPLER_CUBE(prepare.cubemapPrefilter, uSourceTex, 0);
 }
 
 void r3d_shader_load_scene_geometry(void)
@@ -435,7 +435,7 @@ void r3d_shader_load_scene_geometry(void)
 
     SET_UNIFORM_BUFFER(scene.geometry, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(scene.geometry, uTexBoneMatrices);
+    GET_LOCATION(scene.geometry, uBoneMatricesTex);
     GET_LOCATION(scene.geometry, uMatNormal);
     GET_LOCATION(scene.geometry, uMatModel);
     GET_LOCATION(scene.geometry, uAlbedoColor);
@@ -446,10 +446,10 @@ void r3d_shader_load_scene_geometry(void)
     GET_LOCATION(scene.geometry, uInstancing);
     GET_LOCATION(scene.geometry, uSkinning);
     GET_LOCATION(scene.geometry, uBillboard);
-    GET_LOCATION(scene.geometry, uTexAlbedo);
-    GET_LOCATION(scene.geometry, uTexNormal);
-    GET_LOCATION(scene.geometry, uTexEmission);
-    GET_LOCATION(scene.geometry, uTexORM);
+    GET_LOCATION(scene.geometry, uAlbedoMap);
+    GET_LOCATION(scene.geometry, uNormalMap);
+    GET_LOCATION(scene.geometry, uEmissionMap);
+    GET_LOCATION(scene.geometry, uOrmMap);
     GET_LOCATION(scene.geometry, uAlphaCutoff);
     GET_LOCATION(scene.geometry, uNormalScale);
     GET_LOCATION(scene.geometry, uOcclusion);
@@ -458,11 +458,11 @@ void r3d_shader_load_scene_geometry(void)
 
     USE_SHADER(scene.geometry);
 
-    SET_SAMPLER_1D(scene.geometry, uTexBoneMatrices, 0);
-    SET_SAMPLER_2D(scene.geometry, uTexAlbedo, 1);
-    SET_SAMPLER_2D(scene.geometry, uTexNormal, 2);
-    SET_SAMPLER_2D(scene.geometry, uTexEmission, 3);
-    SET_SAMPLER_2D(scene.geometry, uTexORM, 4);
+    SET_SAMPLER_1D(scene.geometry, uBoneMatricesTex, 0);
+    SET_SAMPLER_2D(scene.geometry, uAlbedoMap, 1);
+    SET_SAMPLER_2D(scene.geometry, uNormalMap, 2);
+    SET_SAMPLER_2D(scene.geometry, uEmissionMap, 3);
+    SET_SAMPLER_2D(scene.geometry, uOrmMap, 4);
 }
 
 void r3d_shader_load_scene_forward(void)
@@ -485,7 +485,7 @@ void r3d_shader_load_scene_forward(void)
     SET_UNIFORM_BUFFER(scene.forward, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(scene.forward, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
-    GET_LOCATION(scene.forward, uTexBoneMatrices);
+    GET_LOCATION(scene.forward, uBoneMatricesTex);
     GET_LOCATION(scene.forward, uMatNormal);
     GET_LOCATION(scene.forward, uMatModel);
     GET_LOCATION(scene.forward, uAlbedoColor);
@@ -496,13 +496,13 @@ void r3d_shader_load_scene_forward(void)
     GET_LOCATION(scene.forward, uInstancing);
     GET_LOCATION(scene.forward, uSkinning);
     GET_LOCATION(scene.forward, uBillboard);
-    GET_LOCATION(scene.forward, uTexAlbedo);
-    GET_LOCATION(scene.forward, uTexEmission);
-    GET_LOCATION(scene.forward, uTexNormal);
-    GET_LOCATION(scene.forward, uTexORM);
-    GET_LOCATION(scene.forward, uCubeIrradiance);
-    GET_LOCATION(scene.forward, uCubePrefilter);
-    GET_LOCATION(scene.forward, uTexBrdfLut);
+    GET_LOCATION(scene.forward, uAlbedoMap);
+    GET_LOCATION(scene.forward, uEmissionMap);
+    GET_LOCATION(scene.forward, uNormalMap);
+    GET_LOCATION(scene.forward, uOrmMap);
+    GET_LOCATION(scene.forward, uIrradianceTex);
+    GET_LOCATION(scene.forward, uPrefilterTex);
+    GET_LOCATION(scene.forward, uBrdfLutTex);
     GET_LOCATION(scene.forward, uNormalScale);
     GET_LOCATION(scene.forward, uOcclusion);
     GET_LOCATION(scene.forward, uRoughness);
@@ -511,14 +511,14 @@ void r3d_shader_load_scene_forward(void)
 
     USE_SHADER(scene.forward);
 
-    SET_SAMPLER_1D(scene.forward, uTexBoneMatrices, 0);
-    SET_SAMPLER_2D(scene.forward, uTexAlbedo, 1);
-    SET_SAMPLER_2D(scene.forward, uTexEmission, 2);
-    SET_SAMPLER_2D(scene.forward, uTexNormal, 3);
-    SET_SAMPLER_2D(scene.forward, uTexORM, 4);
-    SET_SAMPLER_CUBE_ARRAY(scene.forward, uCubeIrradiance, 5);
-    SET_SAMPLER_CUBE_ARRAY(scene.forward, uCubePrefilter, 6);
-    SET_SAMPLER_2D(scene.forward, uTexBrdfLut, 7);
+    SET_SAMPLER_1D(scene.forward, uBoneMatricesTex, 0);
+    SET_SAMPLER_2D(scene.forward, uAlbedoMap, 1);
+    SET_SAMPLER_2D(scene.forward, uEmissionMap, 2);
+    SET_SAMPLER_2D(scene.forward, uNormalMap, 3);
+    SET_SAMPLER_2D(scene.forward, uOrmMap, 4);
+    SET_SAMPLER_CUBE_ARRAY(scene.forward, uIrradianceTex, 5);
+    SET_SAMPLER_CUBE_ARRAY(scene.forward, uPrefilterTex, 6);
+    SET_SAMPLER_2D(scene.forward, uBrdfLutTex, 7);
 
     int shadowMapSlot = 10;
     for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++)
@@ -564,12 +564,12 @@ void r3d_shader_load_scene_skybox(void)
     GET_LOCATION(scene.skybox, uRotation);
     GET_LOCATION(scene.skybox, uMatView);
     GET_LOCATION(scene.skybox, uMatProj);
+    GET_LOCATION(scene.skybox, uSkyTex);
     GET_LOCATION(scene.skybox, uSkyEnergy);
-    GET_LOCATION(scene.skybox, uCubeSky);
 
     USE_SHADER(scene.skybox);
 
-    SET_SAMPLER_CUBE(scene.skybox, uCubeSky, 0);
+    SET_SAMPLER_CUBE(scene.skybox, uSkyTex, 0);
 }
 
 void r3d_shader_load_scene_depth(void)
@@ -579,7 +579,7 @@ void r3d_shader_load_scene_depth(void)
     LOAD_SHADER(scene.depth, vsCode, DEPTH_FRAG);
     RL_FREE(vsCode);
 
-    GET_LOCATION(scene.depth, uTexBoneMatrices);
+    GET_LOCATION(scene.depth, uBoneMatricesTex);
     GET_LOCATION(scene.depth, uMatInvView);
     GET_LOCATION(scene.depth, uMatModel);
     GET_LOCATION(scene.depth, uMatVP);
@@ -589,13 +589,13 @@ void r3d_shader_load_scene_depth(void)
     GET_LOCATION(scene.depth, uInstancing);
     GET_LOCATION(scene.depth, uSkinning);
     GET_LOCATION(scene.depth, uBillboard);
-    GET_LOCATION(scene.depth, uTexAlbedo);
+    GET_LOCATION(scene.depth, uAlbedoMap);
     GET_LOCATION(scene.depth, uAlphaCutoff);
 
     USE_SHADER(scene.depth);
 
-    SET_SAMPLER_1D(scene.depth, uTexBoneMatrices, 0);
-    SET_SAMPLER_2D(scene.depth, uTexAlbedo, 1);
+    SET_SAMPLER_1D(scene.depth, uBoneMatricesTex, 0);
+    SET_SAMPLER_2D(scene.depth, uAlbedoMap, 1);
 }
 
 void r3d_shader_load_scene_depth_cube(void)
@@ -605,7 +605,7 @@ void r3d_shader_load_scene_depth_cube(void)
     LOAD_SHADER(scene.depthCube, vsCode, DEPTH_CUBE_FRAG);
     RL_FREE(vsCode);
 
-    GET_LOCATION(scene.depthCube, uTexBoneMatrices);
+    GET_LOCATION(scene.depthCube, uBoneMatricesTex);
     GET_LOCATION(scene.depthCube, uMatInvView);
     GET_LOCATION(scene.depthCube, uMatModel);
     GET_LOCATION(scene.depthCube, uMatVP);
@@ -615,15 +615,15 @@ void r3d_shader_load_scene_depth_cube(void)
     GET_LOCATION(scene.depthCube, uInstancing);
     GET_LOCATION(scene.depthCube, uSkinning);
     GET_LOCATION(scene.depthCube, uBillboard);
-    GET_LOCATION(scene.depthCube, uTexAlbedo);
+    GET_LOCATION(scene.depthCube, uAlbedoMap);
     GET_LOCATION(scene.depthCube, uAlphaCutoff);
     GET_LOCATION(scene.depthCube, uViewPosition);
     GET_LOCATION(scene.depthCube, uFar);
 
     USE_SHADER(scene.depthCube);
 
-    SET_SAMPLER_1D(scene.depthCube, uTexBoneMatrices, 0);
-    SET_SAMPLER_2D(scene.depthCube, uTexAlbedo, 1);
+    SET_SAMPLER_1D(scene.depthCube, uBoneMatricesTex, 0);
+    SET_SAMPLER_2D(scene.depthCube, uAlbedoMap, 1);
 }
 
 void r3d_shader_load_scene_probe(void)
@@ -646,7 +646,7 @@ void r3d_shader_load_scene_probe(void)
     SET_UNIFORM_BUFFER(scene.probe, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(scene.probe, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
-    GET_LOCATION(scene.probe, uTexBoneMatrices);
+    GET_LOCATION(scene.probe, uBoneMatricesTex);
     GET_LOCATION(scene.probe, uMatInvView);
     GET_LOCATION(scene.probe, uMatNormal);
     GET_LOCATION(scene.probe, uMatModel);
@@ -659,13 +659,13 @@ void r3d_shader_load_scene_probe(void)
     GET_LOCATION(scene.probe, uInstancing);
     GET_LOCATION(scene.probe, uSkinning);
     GET_LOCATION(scene.probe, uBillboard);
-    GET_LOCATION(scene.probe, uTexAlbedo);
-    GET_LOCATION(scene.probe, uTexEmission);
-    GET_LOCATION(scene.probe, uTexNormal);
-    GET_LOCATION(scene.probe, uTexORM);
-    GET_LOCATION(scene.probe, uCubeIrradiance);
-    GET_LOCATION(scene.probe, uCubePrefilter);
-    GET_LOCATION(scene.probe, uTexBrdfLut);
+    GET_LOCATION(scene.probe, uAlbedoMap);
+    GET_LOCATION(scene.probe, uEmissionMap);
+    GET_LOCATION(scene.probe, uNormalMap);
+    GET_LOCATION(scene.probe, uOrmMap);
+    GET_LOCATION(scene.probe, uIrradianceTex);
+    GET_LOCATION(scene.probe, uPrefilterTex);
+    GET_LOCATION(scene.probe, uBrdfLutTex);
     GET_LOCATION(scene.probe, uNormalScale);
     GET_LOCATION(scene.probe, uOcclusion);
     GET_LOCATION(scene.probe, uRoughness);
@@ -675,14 +675,14 @@ void r3d_shader_load_scene_probe(void)
 
     USE_SHADER(scene.probe);
 
-    SET_SAMPLER_1D(scene.probe, uTexBoneMatrices, 0);
-    SET_SAMPLER_2D(scene.probe, uTexAlbedo, 1);
-    SET_SAMPLER_2D(scene.probe, uTexEmission, 2);
-    SET_SAMPLER_2D(scene.probe, uTexNormal, 3);
-    SET_SAMPLER_2D(scene.probe, uTexORM, 4);
-    SET_SAMPLER_CUBE_ARRAY(scene.probe, uCubeIrradiance, 5);
-    SET_SAMPLER_CUBE_ARRAY(scene.probe, uCubePrefilter, 6);
-    SET_SAMPLER_2D(scene.probe, uTexBrdfLut, 7);
+    SET_SAMPLER_1D(scene.probe, uBoneMatricesTex, 0);
+    SET_SAMPLER_2D(scene.probe, uAlbedoMap, 1);
+    SET_SAMPLER_2D(scene.probe, uEmissionMap, 2);
+    SET_SAMPLER_2D(scene.probe, uNormalMap, 3);
+    SET_SAMPLER_2D(scene.probe, uOrmMap, 4);
+    SET_SAMPLER_CUBE_ARRAY(scene.probe, uIrradianceTex, 5);
+    SET_SAMPLER_CUBE_ARRAY(scene.probe, uPrefilterTex, 6);
+    SET_SAMPLER_2D(scene.probe, uBrdfLutTex, 7);
 
     int shadowMapSlot = 10;
     for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++)
@@ -732,11 +732,11 @@ void r3d_shader_load_scene_decal(void)
     GET_LOCATION(scene.decal, uTexCoordOffset);
     GET_LOCATION(scene.decal, uTexCoordScale);
     GET_LOCATION(scene.decal, uInstancing);
-    GET_LOCATION(scene.decal, uTexAlbedo);
-    GET_LOCATION(scene.decal, uTexNormal);
-    GET_LOCATION(scene.decal, uTexEmission);
-    GET_LOCATION(scene.decal, uTexORM);
-    GET_LOCATION(scene.decal, uTexDepth);
+    GET_LOCATION(scene.decal, uAlbedoMap);
+    GET_LOCATION(scene.decal, uNormalMap);
+    GET_LOCATION(scene.decal, uEmissionMap);
+    GET_LOCATION(scene.decal, uOrmMap);
+    GET_LOCATION(scene.decal, uDepthTex);
     GET_LOCATION(scene.decal, uAlphaCutoff);
     GET_LOCATION(scene.decal, uNormalScale);
     GET_LOCATION(scene.decal, uOcclusion);
@@ -745,11 +745,11 @@ void r3d_shader_load_scene_decal(void)
 
     USE_SHADER(scene.decal);
 
-    SET_SAMPLER_2D(scene.decal, uTexAlbedo, 0);
-    SET_SAMPLER_2D(scene.decal, uTexNormal, 1);
-    SET_SAMPLER_2D(scene.decal, uTexEmission, 2);
-    SET_SAMPLER_2D(scene.decal, uTexORM, 3);
-    SET_SAMPLER_2D(scene.decal, uTexDepth, 4);
+    SET_SAMPLER_2D(scene.decal, uAlbedoMap, 0);
+    SET_SAMPLER_2D(scene.decal, uNormalMap, 1);
+    SET_SAMPLER_2D(scene.decal, uEmissionMap, 2);
+    SET_SAMPLER_2D(scene.decal, uOrmMap, 3);
+    SET_SAMPLER_2D(scene.decal, uDepthTex, 4);
 }
 
 void r3d_shader_load_deferred_ambient(void)
@@ -765,31 +765,31 @@ void r3d_shader_load_deferred_ambient(void)
     SET_UNIFORM_BUFFER(deferred.ambient, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(deferred.ambient, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
-    GET_LOCATION(deferred.ambient, uTexAlbedo);
-    GET_LOCATION(deferred.ambient, uTexNormal);
-    GET_LOCATION(deferred.ambient, uTexDepth);
-    GET_LOCATION(deferred.ambient, uTexSSAO);
-    GET_LOCATION(deferred.ambient, uTexSSIL);
-    GET_LOCATION(deferred.ambient, uTexSSR);
-    GET_LOCATION(deferred.ambient, uTexORM);
-    GET_LOCATION(deferred.ambient, uCubeIrradiance);
-    GET_LOCATION(deferred.ambient, uCubePrefilter);
-    GET_LOCATION(deferred.ambient, uTexBrdfLut);
+    GET_LOCATION(deferred.ambient, uAlbedoTex);
+    GET_LOCATION(deferred.ambient, uNormalTex);
+    GET_LOCATION(deferred.ambient, uDepthTex);
+    GET_LOCATION(deferred.ambient, uSsaoTex);
+    GET_LOCATION(deferred.ambient, uSsilTex);
+    GET_LOCATION(deferred.ambient, uSsrTex);
+    GET_LOCATION(deferred.ambient, uOrmTex);
+    GET_LOCATION(deferred.ambient, uIrradianceTex);
+    GET_LOCATION(deferred.ambient, uPrefilterTex);
+    GET_LOCATION(deferred.ambient, uBrdfLutTex);
     GET_LOCATION(deferred.ambient, uMipCountSSR);
 
     USE_SHADER(deferred.ambient);
 
-    SET_SAMPLER_2D(deferred.ambient, uTexAlbedo, 0);
-    SET_SAMPLER_2D(deferred.ambient, uTexNormal, 1);
-    SET_SAMPLER_2D(deferred.ambient, uTexDepth, 2);
-    SET_SAMPLER_2D(deferred.ambient, uTexSSAO, 3);
-    SET_SAMPLER_2D(deferred.ambient, uTexSSIL, 4);
-    SET_SAMPLER_2D(deferred.ambient, uTexSSR, 5);
-    SET_SAMPLER_2D(deferred.ambient, uTexORM, 6);
+    SET_SAMPLER_2D(deferred.ambient, uAlbedoTex, 0);
+    SET_SAMPLER_2D(deferred.ambient, uNormalTex, 1);
+    SET_SAMPLER_2D(deferred.ambient, uDepthTex, 2);
+    SET_SAMPLER_2D(deferred.ambient, uSsaoTex, 3);
+    SET_SAMPLER_2D(deferred.ambient, uSsilTex, 4);
+    SET_SAMPLER_2D(deferred.ambient, uSsrTex, 5);
+    SET_SAMPLER_2D(deferred.ambient, uOrmTex, 6);
 
-    SET_SAMPLER_CUBE_ARRAY(deferred.ambient, uCubeIrradiance, 7);
-    SET_SAMPLER_CUBE_ARRAY(deferred.ambient, uCubePrefilter, 8);
-    SET_SAMPLER_2D(deferred.ambient, uTexBrdfLut, 9);
+    SET_SAMPLER_CUBE_ARRAY(deferred.ambient, uIrradianceTex, 7);
+    SET_SAMPLER_CUBE_ARRAY(deferred.ambient, uPrefilterTex, 8);
+    SET_SAMPLER_2D(deferred.ambient, uBrdfLutTex, 9);
 }
 
 void r3d_shader_load_deferred_lighting(void)
@@ -798,11 +798,11 @@ void r3d_shader_load_deferred_lighting(void)
 
     SET_UNIFORM_BUFFER(deferred.lighting, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(deferred.lighting, uTexAlbedo);
-    GET_LOCATION(deferred.lighting, uTexNormal);
-    GET_LOCATION(deferred.lighting, uTexDepth);
-    GET_LOCATION(deferred.lighting, uTexSSAO);
-    GET_LOCATION(deferred.lighting, uTexORM);
+    GET_LOCATION(deferred.lighting, uAlbedoTex);
+    GET_LOCATION(deferred.lighting, uNormalTex);
+    GET_LOCATION(deferred.lighting, uDepthTex);
+    GET_LOCATION(deferred.lighting, uSsaoTex);
+    GET_LOCATION(deferred.lighting, uOrmTex);
     GET_LOCATION(deferred.lighting, uSSAOLightAffect);
 
     GET_LOCATION(deferred.lighting, uLight.matVP);
@@ -828,11 +828,11 @@ void r3d_shader_load_deferred_lighting(void)
 
     USE_SHADER(deferred.lighting);
 
-    SET_SAMPLER_2D(deferred.lighting, uTexAlbedo, 0);
-    SET_SAMPLER_2D(deferred.lighting, uTexNormal, 1);
-    SET_SAMPLER_2D(deferred.lighting, uTexDepth, 2);
-    SET_SAMPLER_2D(deferred.lighting, uTexSSAO, 3);
-    SET_SAMPLER_2D(deferred.lighting, uTexORM, 4);
+    SET_SAMPLER_2D(deferred.lighting, uAlbedoTex, 0);
+    SET_SAMPLER_2D(deferred.lighting, uNormalTex, 1);
+    SET_SAMPLER_2D(deferred.lighting, uDepthTex, 2);
+    SET_SAMPLER_2D(deferred.lighting, uSsaoTex, 3);
+    SET_SAMPLER_2D(deferred.lighting, uOrmTex, 4);
 
     SET_SAMPLER_2D(deferred.lighting, uLight.shadowMap, 5);
     SET_SAMPLER_CUBE(deferred.lighting, uLight.shadowCubemap, 6);
@@ -842,28 +842,28 @@ void r3d_shader_load_deferred_compose(void)
 {
     LOAD_SHADER(deferred.compose, SCREEN_VERT, COMPOSE_FRAG);
 
-    GET_LOCATION(deferred.compose, uTexDiffuse);
-    GET_LOCATION(deferred.compose, uTexSpecular);
+    GET_LOCATION(deferred.compose, uDiffuseTex);
+    GET_LOCATION(deferred.compose, uSpecularTex);
 
     USE_SHADER(deferred.compose);
 
-    SET_SAMPLER_2D(deferred.compose, uTexDiffuse, 0);
-    SET_SAMPLER_2D(deferred.compose, uTexSpecular, 1);
+    SET_SAMPLER_2D(deferred.compose, uDiffuseTex, 0);
+    SET_SAMPLER_2D(deferred.compose, uSpecularTex, 1);
 }
 
 void r3d_shader_load_post_bloom(void)
 {
     LOAD_SHADER(post.bloom, SCREEN_VERT, BLOOM_FRAG);
 
-    GET_LOCATION(post.bloom, uTexColor);
-    GET_LOCATION(post.bloom, uTexBloomBlur);
+    GET_LOCATION(post.bloom, uSceneTex);
+    GET_LOCATION(post.bloom, uBloomTex);
     GET_LOCATION(post.bloom, uBloomMode);
     GET_LOCATION(post.bloom, uBloomIntensity);
 
     USE_SHADER(post.bloom);
 
-    SET_SAMPLER_2D(post.bloom, uTexColor, 0);
-    SET_SAMPLER_2D(post.bloom, uTexBloomBlur, 1);
+    SET_SAMPLER_2D(post.bloom, uSceneTex, 0);
+    SET_SAMPLER_2D(post.bloom, uBloomTex, 1);
 }
 
 void r3d_shader_load_post_fog(void)
@@ -872,8 +872,8 @@ void r3d_shader_load_post_fog(void)
 
     SET_UNIFORM_BUFFER(post.fog, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(post.fog, uTexColor);
-    GET_LOCATION(post.fog, uTexDepth);
+    GET_LOCATION(post.fog, uSceneTex);
+    GET_LOCATION(post.fog, uDepthTex);
     GET_LOCATION(post.fog, uFogMode);
     GET_LOCATION(post.fog, uFogColor);
     GET_LOCATION(post.fog, uFogStart);
@@ -883,8 +883,8 @@ void r3d_shader_load_post_fog(void)
 
     USE_SHADER(post.fog);
 
-    SET_SAMPLER_2D(post.fog, uTexColor, 0);
-    SET_SAMPLER_2D(post.fog, uTexDepth, 1);
+    SET_SAMPLER_2D(post.fog, uSceneTex, 0);
+    SET_SAMPLER_2D(post.fog, uDepthTex, 1);
 }
 
 void r3d_shader_load_post_dof(void)
@@ -893,8 +893,8 @@ void r3d_shader_load_post_dof(void)
 
     SET_UNIFORM_BUFFER(post.dof, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(post.dof, uTexColor);
-    GET_LOCATION(post.dof, uTexDepth);
+    GET_LOCATION(post.dof, uSceneTex);
+    GET_LOCATION(post.dof, uDepthTex);
     GET_LOCATION(post.dof, uFocusPoint);
     GET_LOCATION(post.dof, uFocusScale);
     GET_LOCATION(post.dof, uMaxBlurSize);
@@ -902,15 +902,15 @@ void r3d_shader_load_post_dof(void)
 
     USE_SHADER(post.dof);
 
-    SET_SAMPLER_2D(post.dof, uTexColor, 0);
-    SET_SAMPLER_2D(post.dof, uTexDepth, 1);
+    SET_SAMPLER_2D(post.dof, uSceneTex, 0);
+    SET_SAMPLER_2D(post.dof, uDepthTex, 1);
 }
 
 void r3d_shader_load_post_output(void)
 {
     LOAD_SHADER(post.output, SCREEN_VERT, OUTPUT_FRAG);
 
-    GET_LOCATION(post.output, uTexColor);
+    GET_LOCATION(post.output, uSceneTex);
     GET_LOCATION(post.output, uTonemapExposure);
     GET_LOCATION(post.output, uTonemapWhite);
     GET_LOCATION(post.output, uTonemapMode);
@@ -920,19 +920,19 @@ void r3d_shader_load_post_output(void)
 
     USE_SHADER(post.output);
 
-    SET_SAMPLER_2D(post.output, uTexColor, 0);
+    SET_SAMPLER_2D(post.output, uSceneTex, 0);
 }
 
 void r3d_shader_load_post_fxaa(void)
 {
     LOAD_SHADER(post.fxaa, SCREEN_VERT, FXAA_FRAG);
 
-    GET_LOCATION(post.fxaa, uTexture);
-    GET_LOCATION(post.fxaa, uTexelSize);
+    GET_LOCATION(post.fxaa, uSourceTex);
+    GET_LOCATION(post.fxaa, uSourceTexel);
 
     USE_SHADER(post.fxaa);
 
-    SET_SAMPLER_2D(post.fxaa, uTexture, 0);
+    SET_SAMPLER_2D(post.fxaa, uSourceTex, 0);
 }
 
 // ========================================

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -523,7 +523,7 @@ void r3d_shader_load_scene_forward(void)
     int shadowMapSlot = 10;
     for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++)
     {
-        GET_LOCATION_ARRAY(scene.forward, uMatLightVP, i);
+        GET_LOCATION_ARRAY(scene.forward, uLightViewProj, i);
         GET_LOCATION_ARRAY(scene.forward, uShadowMapCube, i);
         GET_LOCATION_ARRAY(scene.forward, uShadowMap2D, i);
 
@@ -582,7 +582,7 @@ void r3d_shader_load_scene_depth(void)
     GET_LOCATION(scene.depth, uBoneMatricesTex);
     GET_LOCATION(scene.depth, uMatInvView);
     GET_LOCATION(scene.depth, uMatModel);
-    GET_LOCATION(scene.depth, uMatVP);
+    GET_LOCATION(scene.depth, uMatViewProj);
     GET_LOCATION(scene.depth, uAlbedoColor);
     GET_LOCATION(scene.depth, uTexCoordOffset);
     GET_LOCATION(scene.depth, uTexCoordScale);
@@ -608,7 +608,7 @@ void r3d_shader_load_scene_depth_cube(void)
     GET_LOCATION(scene.depthCube, uBoneMatricesTex);
     GET_LOCATION(scene.depthCube, uMatInvView);
     GET_LOCATION(scene.depthCube, uMatModel);
-    GET_LOCATION(scene.depthCube, uMatVP);
+    GET_LOCATION(scene.depthCube, uMatViewProj);
     GET_LOCATION(scene.depthCube, uAlbedoColor);
     GET_LOCATION(scene.depthCube, uTexCoordOffset);
     GET_LOCATION(scene.depthCube, uTexCoordScale);
@@ -650,7 +650,7 @@ void r3d_shader_load_scene_probe(void)
     GET_LOCATION(scene.probe, uMatInvView);
     GET_LOCATION(scene.probe, uMatNormal);
     GET_LOCATION(scene.probe, uMatModel);
-    GET_LOCATION(scene.probe, uMatVP);
+    GET_LOCATION(scene.probe, uMatViewProj);
     GET_LOCATION(scene.probe, uAlbedoColor);
     GET_LOCATION(scene.probe, uEmissionColor);
     GET_LOCATION(scene.probe, uEmissionEnergy);
@@ -687,7 +687,7 @@ void r3d_shader_load_scene_probe(void)
     int shadowMapSlot = 10;
     for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++)
     {
-        GET_LOCATION_ARRAY(scene.probe, uMatLightVP, i);
+        GET_LOCATION_ARRAY(scene.probe, uLightViewProj, i);
         GET_LOCATION_ARRAY(scene.probe, uShadowMapCube, i);
         GET_LOCATION_ARRAY(scene.probe, uShadowMap2D, i);
 

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -389,7 +389,7 @@ typedef struct {
 typedef struct {
     unsigned int id;
     r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
-    r3d_shader_uniform_mat4_t uMatLightVP[R3D_SHADER_NUM_FORWARD_LIGHTS];
+    r3d_shader_uniform_mat4_t uLightViewProj[R3D_SHADER_NUM_FORWARD_LIGHTS];
     r3d_shader_uniform_mat4_t uMatNormal;
     r3d_shader_uniform_mat4_t uMatModel;
     r3d_shader_uniform_vec4_t uAlbedoColor;
@@ -441,7 +441,7 @@ typedef struct {
     r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatModel;
-    r3d_shader_uniform_mat4_t uMatVP;
+    r3d_shader_uniform_mat4_t uMatViewProj;
     r3d_shader_uniform_vec4_t uAlbedoColor;
     r3d_shader_uniform_vec2_t uTexCoordOffset;
     r3d_shader_uniform_vec2_t uTexCoordScale;
@@ -457,7 +457,7 @@ typedef struct {
     r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatModel;
-    r3d_shader_uniform_mat4_t uMatVP;
+    r3d_shader_uniform_mat4_t uMatViewProj;
     r3d_shader_uniform_vec4_t uAlbedoColor;
     r3d_shader_uniform_vec2_t uTexCoordOffset;
     r3d_shader_uniform_vec2_t uTexCoordScale;
@@ -473,11 +473,11 @@ typedef struct {
 typedef struct {
     unsigned int id;
     r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
-    r3d_shader_uniform_mat4_t uMatLightVP[R3D_SHADER_NUM_FORWARD_LIGHTS];
+    r3d_shader_uniform_mat4_t uLightViewProj[R3D_SHADER_NUM_FORWARD_LIGHTS];
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatNormal;
     r3d_shader_uniform_mat4_t uMatModel;
-    r3d_shader_uniform_mat4_t uMatVP;
+    r3d_shader_uniform_mat4_t uMatViewProj;
     r3d_shader_uniform_vec4_t uAlbedoColor;
     r3d_shader_uniform_vec3_t uEmissionColor;
     r3d_shader_uniform_float_t uEmissionEnergy;

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -252,28 +252,28 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexSource;
-    r3d_shader_uniform_sampler2D_t uTexNormal;
-    r3d_shader_uniform_sampler2D_t uTexDepth;
+    r3d_shader_uniform_sampler2D_t uSourceTex;
+    r3d_shader_uniform_sampler2D_t uNormalTex;
+    r3d_shader_uniform_sampler2D_t uDepthTex;
     r3d_shader_uniform_int_t uStepSize;
 } r3d_shader_prepare_atrous_wavelet_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexSource;
-    r3d_shader_uniform_int_t uMipSource;
+    r3d_shader_uniform_sampler2D_t uSourceTex;
+    r3d_shader_uniform_int_t uSourceLod;
 } r3d_shader_prepare_blur_down_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexSource;
-    r3d_shader_uniform_int_t uMipSource;
+    r3d_shader_uniform_sampler2D_t uSourceTex;
+    r3d_shader_uniform_int_t uSourceLod;
 } r3d_shader_prepare_blur_up_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexDepth;
-    r3d_shader_uniform_sampler2D_t uTexNormal;
+    r3d_shader_uniform_sampler2D_t uNormalTex;
+    r3d_shader_uniform_sampler2D_t uDepthTex;
     r3d_shader_uniform_int_t uSampleCount;
     r3d_shader_uniform_float_t uRadius;
     r3d_shader_uniform_float_t uBias;
@@ -283,10 +283,10 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexLight;
-    r3d_shader_uniform_sampler2D_t uTexPrevSSIL;
-    r3d_shader_uniform_sampler2D_t uTexNormal;
-    r3d_shader_uniform_sampler2D_t uTexDepth;
+    r3d_shader_uniform_sampler2D_t uLightingTex;
+    r3d_shader_uniform_sampler2D_t uHistoryTex;
+    r3d_shader_uniform_sampler2D_t uNormalTex;
+    r3d_shader_uniform_sampler2D_t uDepthTex;
     r3d_shader_uniform_float_t uSampleCount;
     r3d_shader_uniform_float_t uSampleRadius;
     r3d_shader_uniform_float_t uSliceCount;
@@ -299,11 +299,11 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexColor;
-    r3d_shader_uniform_sampler2D_t uTexAlbedo;
-    r3d_shader_uniform_sampler2D_t uTexNormal;
-    r3d_shader_uniform_sampler2D_t uTexORM;
-    r3d_shader_uniform_sampler2D_t uTexDepth;
+    r3d_shader_uniform_sampler2D_t uLightingTex;
+    r3d_shader_uniform_sampler2D_t uAlbedoTex;
+    r3d_shader_uniform_sampler2D_t uNormalTex;
+    r3d_shader_uniform_sampler2D_t uOrmTex;
+    r3d_shader_uniform_sampler2D_t uDepthTex;
     r3d_shader_uniform_int_t uMaxRaySteps;
     r3d_shader_uniform_int_t uBinarySearchSteps;
     r3d_shader_uniform_float_t uRayMarchLength;
@@ -332,39 +332,39 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_samplerCube_t uCube;
-    r3d_shader_uniform_float_t uSrcTexel;
-    r3d_shader_uniform_float_t uSrcLod;
-    r3d_shader_uniform_int_t uFace;
+    r3d_shader_uniform_samplerCube_t uSourceTex;
+    r3d_shader_uniform_float_t uSourceTexel;
+    r3d_shader_uniform_float_t uSourceLod;
+    r3d_shader_uniform_int_t uSourceFace;
 } r3d_shader_prepare_cubeface_down_t;
 
 typedef struct {
     unsigned int id;
     r3d_shader_uniform_mat4_t uMatProj;
     r3d_shader_uniform_mat4_t uMatView;
-    r3d_shader_uniform_sampler2D_t uTexEquirectangular;
+    r3d_shader_uniform_sampler2D_t uPanoramaTex;
 } r3d_shader_prepare_cubemap_from_equirectangular_t;
 
 typedef struct {
     unsigned int id;
     r3d_shader_uniform_mat4_t uMatProj;
     r3d_shader_uniform_mat4_t uMatView;
-    r3d_shader_uniform_samplerCube_t uCubemap;
+    r3d_shader_uniform_samplerCube_t uSourceTex;
 } r3d_shader_prepare_cubemap_irradiance_t;
 
 typedef struct {
     unsigned int id;
     r3d_shader_uniform_mat4_t uMatProj;
     r3d_shader_uniform_mat4_t uMatView;
-    r3d_shader_uniform_samplerCube_t uCubemap;
-    r3d_shader_uniform_float_t uResolution;
-    r3d_shader_uniform_float_t uNumLevels;
+    r3d_shader_uniform_samplerCube_t uSourceTex;
+    r3d_shader_uniform_float_t uSourceNumLevels;
+    r3d_shader_uniform_float_t uSourceFaceSize;
     r3d_shader_uniform_float_t uRoughness;
 } r3d_shader_prepare_cubemap_prefilter_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler1D_t uTexBoneMatrices;
+    r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatNormal;
     r3d_shader_uniform_mat4_t uMatModel;
     r3d_shader_uniform_vec4_t uAlbedoColor;
@@ -375,10 +375,10 @@ typedef struct {
     r3d_shader_uniform_int_t uInstancing;
     r3d_shader_uniform_int_t uSkinning;
     r3d_shader_uniform_int_t uBillboard;
-    r3d_shader_uniform_sampler2D_t uTexAlbedo;
-    r3d_shader_uniform_sampler2D_t uTexNormal;
-    r3d_shader_uniform_sampler2D_t uTexEmission;
-    r3d_shader_uniform_sampler2D_t uTexORM;
+    r3d_shader_uniform_sampler2D_t uAlbedoMap;
+    r3d_shader_uniform_sampler2D_t uNormalMap;
+    r3d_shader_uniform_sampler2D_t uEmissionMap;
+    r3d_shader_uniform_sampler2D_t uOrmMap;
     r3d_shader_uniform_float_t uAlphaCutoff;
     r3d_shader_uniform_float_t uNormalScale;
     r3d_shader_uniform_float_t uOcclusion;
@@ -388,7 +388,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler1D_t uTexBoneMatrices;
+    r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatLightVP[R3D_SHADER_NUM_FORWARD_LIGHTS];
     r3d_shader_uniform_mat4_t uMatNormal;
     r3d_shader_uniform_mat4_t uMatModel;
@@ -400,15 +400,15 @@ typedef struct {
     r3d_shader_uniform_int_t uInstancing;
     r3d_shader_uniform_int_t uSkinning;
     r3d_shader_uniform_int_t uBillboard;
-    r3d_shader_uniform_sampler2D_t uTexAlbedo;
-    r3d_shader_uniform_sampler2D_t uTexEmission;
-    r3d_shader_uniform_sampler2D_t uTexNormal;
-    r3d_shader_uniform_sampler2D_t uTexORM;
+    r3d_shader_uniform_sampler2D_t uAlbedoMap;
+    r3d_shader_uniform_sampler2D_t uEmissionMap;
+    r3d_shader_uniform_sampler2D_t uNormalMap;
+    r3d_shader_uniform_sampler2D_t uOrmMap;
     r3d_shader_uniform_samplerCube_t uShadowMapCube[R3D_SHADER_NUM_FORWARD_LIGHTS];
     r3d_shader_uniform_sampler2D_t uShadowMap2D[R3D_SHADER_NUM_FORWARD_LIGHTS];
-    r3d_shader_uniform_samplerCubeArray_t uCubeIrradiance;
-    r3d_shader_uniform_samplerCubeArray_t uCubePrefilter;
-    r3d_shader_uniform_sampler2D_t uTexBrdfLut;
+    r3d_shader_uniform_samplerCubeArray_t uIrradianceTex;
+    r3d_shader_uniform_samplerCubeArray_t uPrefilterTex;
+    r3d_shader_uniform_sampler2D_t uBrdfLutTex;
     r3d_shader_uniform_float_t uNormalScale;
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
@@ -438,7 +438,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler1D_t uTexBoneMatrices;
+    r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatModel;
     r3d_shader_uniform_mat4_t uMatVP;
@@ -448,13 +448,13 @@ typedef struct {
     r3d_shader_uniform_int_t uInstancing;
     r3d_shader_uniform_int_t uSkinning;
     r3d_shader_uniform_int_t uBillboard;
-    r3d_shader_uniform_sampler2D_t uTexAlbedo;
+    r3d_shader_uniform_sampler2D_t uAlbedoMap;
     r3d_shader_uniform_float_t uAlphaCutoff;
 } r3d_shader_scene_depth_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler1D_t uTexBoneMatrices;
+    r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatModel;
     r3d_shader_uniform_mat4_t uMatVP;
@@ -464,7 +464,7 @@ typedef struct {
     r3d_shader_uniform_int_t uInstancing;
     r3d_shader_uniform_int_t uSkinning;
     r3d_shader_uniform_int_t uBillboard;
-    r3d_shader_uniform_sampler2D_t uTexAlbedo;
+    r3d_shader_uniform_sampler2D_t uAlbedoMap;
     r3d_shader_uniform_float_t uAlphaCutoff;
     r3d_shader_uniform_vec3_t uViewPosition;
     r3d_shader_uniform_float_t uFar;
@@ -472,7 +472,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler1D_t uTexBoneMatrices;
+    r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatLightVP[R3D_SHADER_NUM_FORWARD_LIGHTS];
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatNormal;
@@ -486,15 +486,15 @@ typedef struct {
     r3d_shader_uniform_int_t uInstancing;
     r3d_shader_uniform_int_t uSkinning;
     r3d_shader_uniform_int_t uBillboard;
-    r3d_shader_uniform_sampler2D_t uTexAlbedo;
-    r3d_shader_uniform_sampler2D_t uTexEmission;
-    r3d_shader_uniform_sampler2D_t uTexNormal;
-    r3d_shader_uniform_sampler2D_t uTexORM;
+    r3d_shader_uniform_sampler2D_t uAlbedoMap;
+    r3d_shader_uniform_sampler2D_t uEmissionMap;
+    r3d_shader_uniform_sampler2D_t uNormalMap;
+    r3d_shader_uniform_sampler2D_t uOrmMap;
     r3d_shader_uniform_samplerCube_t uShadowMapCube[R3D_SHADER_NUM_FORWARD_LIGHTS];
     r3d_shader_uniform_sampler2D_t uShadowMap2D[R3D_SHADER_NUM_FORWARD_LIGHTS];
-    r3d_shader_uniform_samplerCubeArray_t uCubeIrradiance;
-    r3d_shader_uniform_samplerCubeArray_t uCubePrefilter;
-    r3d_shader_uniform_sampler2D_t uTexBrdfLut;
+    r3d_shader_uniform_samplerCubeArray_t uIrradianceTex;
+    r3d_shader_uniform_samplerCubeArray_t uPrefilterTex;
+    r3d_shader_uniform_sampler2D_t uBrdfLutTex;
     r3d_shader_uniform_float_t uNormalScale;
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
@@ -533,11 +533,11 @@ typedef struct {
     r3d_shader_uniform_vec2_t uTexCoordOffset;
     r3d_shader_uniform_vec2_t uTexCoordScale;
     r3d_shader_uniform_int_t uInstancing;
-    r3d_shader_uniform_sampler2D_t uTexAlbedo;
-    r3d_shader_uniform_sampler2D_t uTexNormal;
-    r3d_shader_uniform_sampler2D_t uTexEmission;
-    r3d_shader_uniform_sampler2D_t uTexORM;
-    r3d_shader_uniform_sampler2D_t uTexDepth;
+    r3d_shader_uniform_sampler2D_t uAlbedoMap;
+    r3d_shader_uniform_sampler2D_t uNormalMap;
+    r3d_shader_uniform_sampler2D_t uEmissionMap;
+    r3d_shader_uniform_sampler2D_t uOrmMap;
+    r3d_shader_uniform_sampler2D_t uDepthTex;
     r3d_shader_uniform_float_t uAlphaCutoff;
     r3d_shader_uniform_float_t uNormalScale;
     r3d_shader_uniform_float_t uOcclusion;
@@ -555,22 +555,22 @@ typedef struct {
     r3d_shader_uniform_vec4_t uRotation;
     r3d_shader_uniform_mat4_t uMatView;
     r3d_shader_uniform_mat4_t uMatProj;
+    r3d_shader_uniform_samplerCube_t uSkyTex;
     r3d_shader_uniform_float_t uSkyEnergy;
-    r3d_shader_uniform_samplerCube_t uCubeSky;
 } r3d_shader_scene_skybox_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexAlbedo;
-    r3d_shader_uniform_sampler2D_t uTexNormal;
-    r3d_shader_uniform_sampler2D_t uTexDepth;
-    r3d_shader_uniform_sampler2D_t uTexSSAO;
-    r3d_shader_uniform_sampler2D_t uTexSSIL;
-    r3d_shader_uniform_sampler2D_t uTexSSR;
-    r3d_shader_uniform_sampler2D_t uTexORM;
-    r3d_shader_uniform_samplerCubeArray_t uCubeIrradiance;
-    r3d_shader_uniform_samplerCubeArray_t uCubePrefilter;
-    r3d_shader_uniform_sampler2D_t uTexBrdfLut;
+    r3d_shader_uniform_sampler2D_t uAlbedoTex;
+    r3d_shader_uniform_sampler2D_t uNormalTex;
+    r3d_shader_uniform_sampler2D_t uDepthTex;
+    r3d_shader_uniform_sampler2D_t uSsaoTex;
+    r3d_shader_uniform_sampler2D_t uSsilTex;
+    r3d_shader_uniform_sampler2D_t uSsrTex;
+    r3d_shader_uniform_sampler2D_t uOrmTex;
+    r3d_shader_uniform_samplerCubeArray_t uIrradianceTex;
+    r3d_shader_uniform_samplerCubeArray_t uPrefilterTex;
+    r3d_shader_uniform_sampler2D_t uBrdfLutTex;
     r3d_shader_uniform_float_t uMipCountSSR;
 } r3d_shader_deferred_ambient_t;
 
@@ -598,32 +598,32 @@ typedef struct {
         r3d_shader_uniform_int_t type;
         r3d_shader_uniform_int_t shadow;
     } uLight;
-    r3d_shader_uniform_sampler2D_t uTexAlbedo;
-    r3d_shader_uniform_sampler2D_t uTexNormal;
-    r3d_shader_uniform_sampler2D_t uTexDepth;
-    r3d_shader_uniform_sampler2D_t uTexSSAO;
-    r3d_shader_uniform_sampler2D_t uTexORM;
+    r3d_shader_uniform_sampler2D_t uAlbedoTex;
+    r3d_shader_uniform_sampler2D_t uNormalTex;
+    r3d_shader_uniform_sampler2D_t uDepthTex;
+    r3d_shader_uniform_sampler2D_t uSsaoTex;
+    r3d_shader_uniform_sampler2D_t uOrmTex;
     r3d_shader_uniform_float_t uSSAOLightAffect;
 } r3d_shader_deferred_lighting_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexDiffuse;
-    r3d_shader_uniform_sampler2D_t uTexSpecular;
+    r3d_shader_uniform_sampler2D_t uDiffuseTex;
+    r3d_shader_uniform_sampler2D_t uSpecularTex;
 } r3d_shader_deferred_compose_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexColor;
-    r3d_shader_uniform_sampler2D_t uTexBloomBlur;
+    r3d_shader_uniform_sampler2D_t uSceneTex;
+    r3d_shader_uniform_sampler2D_t uBloomTex;
     r3d_shader_uniform_int_t uBloomMode;
     r3d_shader_uniform_float_t uBloomIntensity;
 } r3d_shader_post_bloom_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexColor;
-    r3d_shader_uniform_sampler2D_t uTexDepth;
+    r3d_shader_uniform_sampler2D_t uSceneTex;
+    r3d_shader_uniform_sampler2D_t uDepthTex;
     r3d_shader_uniform_int_t uFogMode;
     r3d_shader_uniform_vec3_t uFogColor;
     r3d_shader_uniform_float_t uFogStart;
@@ -634,8 +634,8 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexColor;
-    r3d_shader_uniform_sampler2D_t uTexDepth;
+    r3d_shader_uniform_sampler2D_t uSceneTex;
+    r3d_shader_uniform_sampler2D_t uDepthTex;
     r3d_shader_uniform_float_t uFocusPoint;
     r3d_shader_uniform_float_t uFocusScale;
     r3d_shader_uniform_float_t uMaxBlurSize;
@@ -644,7 +644,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexColor;
+    r3d_shader_uniform_sampler2D_t uSceneTex;
     r3d_shader_uniform_float_t uTonemapExposure;
     r3d_shader_uniform_float_t uTonemapWhite;
     r3d_shader_uniform_int_t uTonemapMode;
@@ -655,8 +655,8 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexture;
-    r3d_shader_uniform_vec2_t uTexelSize;
+    r3d_shader_uniform_sampler2D_t uSourceTex;
+    r3d_shader_uniform_vec2_t uSourceTexel;
 } r3d_shader_post_fxaa_t;
 
 // ========================================

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -555,7 +555,7 @@ typedef struct {
     r3d_shader_uniform_vec4_t uRotation;
     r3d_shader_uniform_mat4_t uMatView;
     r3d_shader_uniform_mat4_t uMatProj;
-    r3d_shader_uniform_samplerCube_t uSkyTex;
+    r3d_shader_uniform_samplerCube_t uSkyMap;
     r3d_shader_uniform_float_t uSkyEnergy;
 } r3d_shader_scene_skybox_t;
 

--- a/src/r3d_cubemap.c
+++ b/src/r3d_cubemap.c
@@ -119,7 +119,7 @@ static R3D_Cubemap load_cubemap_from_panorama(Image image, int size)
 
     R3D_SHADER_USE(prepare.cubemapFromEquirectangular);
     R3D_SHADER_SET_MAT4(prepare.cubemapFromEquirectangular, uMatProj, matProj);
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.cubemapFromEquirectangular, uTexEquirectangular, panorama.id);
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.cubemapFromEquirectangular, uPanoramaTex, panorama.id);
 
     GLuint workFBO;
     glGenFramebuffers(1, &workFBO);
@@ -136,7 +136,7 @@ static R3D_Cubemap load_cubemap_from_panorama(Image image, int size)
         R3D_PRIMITIVE_DRAW_CUBE();
     }
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.cubemapFromEquirectangular, uTexEquirectangular);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.cubemapFromEquirectangular, uPanoramaTex);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glDeleteFramebuffers(1, &workFBO);
     UnloadTexture(panorama);

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -573,7 +573,7 @@ void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* matVP)
     /* --- Send matrices --- */
 
     R3D_SHADER_SET_MAT4(scene.depth, uMatModel, group->transform);
-    R3D_SHADER_SET_MAT4(scene.depth, uMatVP, *matVP);
+    R3D_SHADER_SET_MAT4(scene.depth, uMatViewProj, *matVP);
 
     /* --- Send skinning related data --- */
 
@@ -641,7 +641,7 @@ void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* m
     /* --- Send matrices --- */
 
     R3D_SHADER_SET_MAT4(scene.depthCube, uMatModel, group->transform);
-    R3D_SHADER_SET_MAT4(scene.depthCube, uMatVP, *matVP);
+    R3D_SHADER_SET_MAT4(scene.depthCube, uMatViewProj, *matVP);
 
     /* --- Send skinning related data --- */
 
@@ -719,7 +719,7 @@ void raster_probe(const r3d_draw_call_t* call, const Matrix* invView, const Matr
     R3D_SHADER_SET_MAT4(scene.probe, uMatInvView, *invView);
     R3D_SHADER_SET_MAT4(scene.probe, uMatModel, group->transform);
     R3D_SHADER_SET_MAT4(scene.probe, uMatNormal, matNormal);
-    R3D_SHADER_SET_MAT4(scene.probe, uMatVP, *viewProj);
+    R3D_SHADER_SET_MAT4(scene.probe, uMatViewProj, *viewProj);
 
     /* --- Send skinning related data --- */
 
@@ -1103,7 +1103,7 @@ static void pass_scene_probe_send_lights(const r3d_draw_call_t* call, bool probe
             else {
                 R3D_SHADER_SET_FLOAT(scene.probe, uLights[iLight].shadowTexelSize, light->shadowTexelSize);
                 R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uShadowMap2D[iLight], light->shadowMap.tex);
-                R3D_SHADER_SET_MAT4(scene.probe, uMatLightVP[iLight], light->matVP);
+                R3D_SHADER_SET_MAT4(scene.probe, uLightViewProj[iLight], light->matVP);
             }
             R3D_SHADER_SET_FLOAT(scene.probe, uLights[iLight].shadowSoftness, light->shadowSoftness);
             R3D_SHADER_SET_FLOAT(scene.probe, uLights[iLight].shadowDepthBias, light->shadowDepthBias);
@@ -1721,7 +1721,7 @@ static void pass_scene_forward_send_lights(const r3d_draw_call_t* call)
             else {
                 R3D_SHADER_SET_FLOAT(scene.forward, uLights[iLight].shadowTexelSize, light->shadowTexelSize);
                 R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uShadowMap2D[iLight], light->shadowMap.tex);
-                R3D_SHADER_SET_MAT4(scene.forward, uMatLightVP[iLight], light->matVP);
+                R3D_SHADER_SET_MAT4(scene.forward, uLightViewProj[iLight], light->matVP);
             }
             R3D_SHADER_SET_FLOAT(scene.forward, uLights[iLight].shadowSoftness, light->shadowSoftness);
             R3D_SHADER_SET_FLOAT(scene.forward, uLights[iLight].shadowDepthBias, light->shadowDepthBias);

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1196,7 +1196,7 @@ void pass_scene_probes(void)
                 R3D_SHADER_USE(scene.skybox);
                 glDisable(GL_CULL_FACE);
 
-                R3D_SHADER_BIND_SAMPLER_CUBE(scene.skybox, uSkyTex, R3D.environment.background.sky.texture);
+                R3D_SHADER_BIND_SAMPLER_CUBE(scene.skybox, uSkyMap, R3D.environment.background.sky.texture);
                 R3D_SHADER_SET_FLOAT(scene.skybox, uSkyEnergy, R3D.environment.background.energy);
                 R3D_SHADER_SET_VEC4(scene.skybox, uRotation, R3D.environment.background.rotation);
                 R3D_SHADER_SET_MAT4(scene.skybox, uMatView, probe->view[iFace]);
@@ -1204,7 +1204,7 @@ void pass_scene_probes(void)
 
                 R3D_PRIMITIVE_DRAW_CUBE();
 
-                R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.skybox, uSkyTex);
+                R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.skybox, uSkyMap);
             }
             else {
                 Vector4 background = {
@@ -1794,7 +1794,7 @@ void pass_scene_background(r3d_target_t sceneTarget)
         R3D_SHADER_USE(scene.skybox);
         glDisable(GL_CULL_FACE);
 
-        R3D_SHADER_BIND_SAMPLER_CUBE(scene.skybox, uSkyTex, R3D.environment.background.sky.texture);
+        R3D_SHADER_BIND_SAMPLER_CUBE(scene.skybox, uSkyMap, R3D.environment.background.sky.texture);
         R3D_SHADER_SET_FLOAT(scene.skybox, uSkyEnergy, R3D.environment.background.energy);
         R3D_SHADER_SET_VEC4(scene.skybox, uRotation, R3D.environment.background.rotation);
         R3D_SHADER_SET_MAT4(scene.skybox, uMatView, R3D.viewState.view);
@@ -1802,7 +1802,7 @@ void pass_scene_background(r3d_target_t sceneTarget)
 
         R3D_PRIMITIVE_DRAW_CUBE();
 
-        R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.skybox, uSkyTex);
+        R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.skybox, uSkyMap);
     }
     else {
         Vector4 background = {

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -578,7 +578,7 @@ void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* matVP)
     /* --- Send skinning related data --- */
 
     if (group->texPose > 0) {
-        R3D_SHADER_BIND_SAMPLER_1D(scene.depth, uTexBoneMatrices, group->texPose);
+        R3D_SHADER_BIND_SAMPLER_1D(scene.depth, uBoneMatricesTex, group->texPose);
         R3D_SHADER_SET_INT(scene.depth, uSkinning, true);
     }
     else {
@@ -599,7 +599,7 @@ void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* matVP)
 
     /* --- Set transparency material data --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.depth, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.depth, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
     R3D_SHADER_SET_COL4(scene.depth, uAlbedoColor, call->material.albedo.color);
 
     if (call->material.transparencyMode == R3D_TRANSPARENCY_PREPASS) {
@@ -631,7 +631,7 @@ void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* matVP)
 
     /* --- Unbind samplers --- */
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.depth, uTexAlbedo);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.depth, uAlbedoMap);
 }
 
 void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* matVP)
@@ -646,7 +646,7 @@ void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* m
     /* --- Send skinning related data --- */
 
     if (group->texPose > 0) {
-        R3D_SHADER_BIND_SAMPLER_1D(scene.depthCube, uTexBoneMatrices, group->texPose);
+        R3D_SHADER_BIND_SAMPLER_1D(scene.depthCube, uBoneMatricesTex, group->texPose);
         R3D_SHADER_SET_INT(scene.depthCube, uSkinning, true);
     }
     else {
@@ -667,7 +667,7 @@ void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* m
 
     /* --- Set transparency material data --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.depthCube, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.depthCube, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
     R3D_SHADER_SET_COL4(scene.depthCube, uAlbedoColor, call->material.albedo.color);
 
     if (call->material.transparencyMode == R3D_TRANSPARENCY_PREPASS) {
@@ -705,7 +705,7 @@ void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* m
 
     /* --- Unbind samplers --- */
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.depthCube, uTexAlbedo);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.depthCube, uAlbedoMap);
 }
 
 void raster_probe(const r3d_draw_call_t* call, const Matrix* invView, const Matrix* viewProj)
@@ -724,7 +724,7 @@ void raster_probe(const r3d_draw_call_t* call, const Matrix* invView, const Matr
     /* --- Send skinning related data --- */
 
     if (group->texPose > 0) {
-        R3D_SHADER_BIND_SAMPLER_1D(scene.probe, uTexBoneMatrices, group->texPose);
+        R3D_SHADER_BIND_SAMPLER_1D(scene.probe, uBoneMatricesTex, group->texPose);
         R3D_SHADER_SET_INT(scene.probe, uSkinning, true);
     }
     else {
@@ -755,10 +755,10 @@ void raster_probe(const r3d_draw_call_t* call, const Matrix* invView, const Matr
 
     /* --- Bind active texture maps --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uTexNormal, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uTexEmission, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uTexORM, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */
 
@@ -778,10 +778,10 @@ void raster_probe(const r3d_draw_call_t* call, const Matrix* invView, const Matr
 
     /* --- Unbind all bound texture maps --- */
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uTexAlbedo);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uTexNormal);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uTexEmission);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uTexORM);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uAlbedoMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uNormalMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uEmissionMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uOrmMap);
 }
 
 void raster_geometry(const r3d_draw_call_t* call)
@@ -798,7 +798,7 @@ void raster_geometry(const r3d_draw_call_t* call)
     /* --- Send skinning related data --- */
 
     if (group->texPose > 0) {
-        R3D_SHADER_BIND_SAMPLER_1D(scene.geometry, uTexBoneMatrices, group->texPose);
+        R3D_SHADER_BIND_SAMPLER_1D(scene.geometry, uBoneMatricesTex, group->texPose);
         R3D_SHADER_SET_INT(scene.geometry, uSkinning, true);
     }
     else {
@@ -833,10 +833,10 @@ void raster_geometry(const r3d_draw_call_t* call)
 
     /* --- Bind active texture maps --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uTexNormal, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uTexEmission, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uTexORM, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */
 
@@ -855,10 +855,10 @@ void raster_geometry(const r3d_draw_call_t* call)
 
     /* --- Unbind all bound texture maps --- */
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uTexAlbedo);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uTexNormal);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uTexEmission);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uTexORM);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uAlbedoMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uNormalMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uEmissionMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uOrmMap);
 }
 
 void raster_decal(const r3d_draw_call_t* call)
@@ -896,10 +896,10 @@ void raster_decal(const r3d_draw_call_t* call)
 
     /* --- Bind active texture maps --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexNormal, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexEmission, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexORM, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */
 
@@ -923,10 +923,10 @@ void raster_decal(const r3d_draw_call_t* call)
 
     /* --- Unbind all bound texture maps --- */
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uTexAlbedo);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uTexNormal);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uTexEmission);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uTexORM);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uAlbedoMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uNormalMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uEmissionMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uOrmMap);
 }
 
 void raster_forward(const r3d_draw_call_t* call)
@@ -943,7 +943,7 @@ void raster_forward(const r3d_draw_call_t* call)
     /* --- Send skinning related data --- */
 
     if (group->texPose > 0) {
-        R3D_SHADER_BIND_SAMPLER_1D(scene.forward, uTexBoneMatrices, group->texPose);
+        R3D_SHADER_BIND_SAMPLER_1D(scene.forward, uBoneMatricesTex, group->texPose);
         R3D_SHADER_SET_INT(scene.forward, uSkinning, true);
     }
     else {
@@ -974,10 +974,10 @@ void raster_forward(const r3d_draw_call_t* call)
 
     /* --- Bind active texture maps --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uTexAlbedo, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uTexNormal, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uTexEmission, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uTexORM, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */
 
@@ -997,10 +997,10 @@ void raster_forward(const r3d_draw_call_t* call)
 
     /* --- Unbind all bound texture maps --- */
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uTexAlbedo);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uTexNormal);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uTexEmission);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uTexORM);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uAlbedoMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uNormalMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uEmissionMap);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uOrmMap);
 }
 
 void pass_scene_shadow(void)
@@ -1038,7 +1038,7 @@ void pass_scene_shadow(void)
             }
 
             // The bone matrices texture may have been bind during drawcalls, so UNBIND!
-            R3D_SHADER_UNBIND_SAMPLER_1D(scene.depthCube, uTexBoneMatrices);
+            R3D_SHADER_UNBIND_SAMPLER_1D(scene.depthCube, uBoneMatricesTex);
         }
         else {
             glClear(GL_DEPTH_BUFFER_BIT);
@@ -1054,7 +1054,7 @@ void pass_scene_shadow(void)
             #undef COND
 
             // The bone matrices texture may have been bind during drawcalls, so UNBIND!
-            R3D_SHADER_UNBIND_SAMPLER_1D(scene.depth, uTexBoneMatrices);
+            R3D_SHADER_UNBIND_SAMPLER_1D(scene.depth, uBoneMatricesTex);
         }
     }
 }
@@ -1161,9 +1161,9 @@ void pass_scene_probes(void)
             glDepthMask(GL_TRUE);
             glEnable(GL_BLEND);
 
-            R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.probe, uCubeIrradiance, r3d_env_irradiance_get());
-            R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.probe, uCubePrefilter, r3d_env_prefilter_get());
-            R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uTexBrdfLut, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
+            R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.probe, uIrradianceTex, r3d_env_irradiance_get());
+            R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.probe, uPrefilterTex, r3d_env_prefilter_get());
+            R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uBrdfLutTex, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
             R3D_SHADER_SET_VEC3(scene.probe, uViewPosition, probe->position);
             R3D_SHADER_SET_INT(scene.probe, uProbeInterior, probe->interior);
 
@@ -1175,9 +1175,9 @@ void pass_scene_probes(void)
                 raster_probe(call, &invView, &viewProj);
             }
 
-            R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.probe, uCubeIrradiance);
-            R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.probe, uCubePrefilter);
-            R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uTexBrdfLut);
+            R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.probe, uIrradianceTex);
+            R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.probe, uPrefilterTex);
+            R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uBrdfLutTex);
 
             for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++) {
                 R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.probe, uShadowMapCube[i]);
@@ -1185,7 +1185,7 @@ void pass_scene_probes(void)
             }
 
             // NOTE: The storage texture of the matrices may have been bind during drawcalls
-            R3D_SHADER_UNBIND_SAMPLER_1D(scene.probe, uTexBoneMatrices);
+            R3D_SHADER_UNBIND_SAMPLER_1D(scene.probe, uBoneMatricesTex);
 
             /* --- Render background --- */
 
@@ -1196,7 +1196,7 @@ void pass_scene_probes(void)
                 R3D_SHADER_USE(scene.skybox);
                 glDisable(GL_CULL_FACE);
 
-                R3D_SHADER_BIND_SAMPLER_CUBE(scene.skybox, uCubeSky, R3D.environment.background.sky.texture);
+                R3D_SHADER_BIND_SAMPLER_CUBE(scene.skybox, uSkyTex, R3D.environment.background.sky.texture);
                 R3D_SHADER_SET_FLOAT(scene.skybox, uSkyEnergy, R3D.environment.background.energy);
                 R3D_SHADER_SET_VEC4(scene.skybox, uRotation, R3D.environment.background.rotation);
                 R3D_SHADER_SET_MAT4(scene.skybox, uMatView, probe->view[iFace]);
@@ -1204,7 +1204,7 @@ void pass_scene_probes(void)
 
                 R3D_PRIMITIVE_DRAW_CUBE();
 
-                R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.skybox, uCubeSky);
+                R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.skybox, uSkyTex);
             }
             else {
                 Vector4 background = {
@@ -1225,17 +1225,17 @@ void pass_scene_probes(void)
             glDisable(GL_DEPTH_TEST);
             glDisable(GL_BLEND);
 
-            R3D_SHADER_BIND_SAMPLER_CUBE(prepare.cubefaceDown, uCube, r3d_env_capture_get());
-            R3D_SHADER_SET_INT(prepare.cubefaceDown, uFace, iFace);
+            R3D_SHADER_BIND_SAMPLER_CUBE(prepare.cubefaceDown, uSourceTex, r3d_env_capture_get());
+            R3D_SHADER_SET_INT(prepare.cubefaceDown, uSourceFace, iFace);
 
             for (int mipLevel = 1; mipLevel < R3D_ENV_CAPTURE_MIPS; mipLevel++) {
                 r3d_env_capture_bind_fbo(iFace, mipLevel);
-                R3D_SHADER_SET_FLOAT(prepare.cubefaceDown, uSrcTexel, 1.0 / (R3D_ENV_CAPTURE_SIZE >> (mipLevel - 1)));
-                R3D_SHADER_SET_FLOAT(prepare.cubefaceDown, uSrcLod, mipLevel - 1);
+                R3D_SHADER_SET_FLOAT(prepare.cubefaceDown, uSourceTexel, 1.0 / (R3D_ENV_CAPTURE_SIZE >> (mipLevel - 1)));
+                R3D_SHADER_SET_FLOAT(prepare.cubefaceDown, uSourceLod, mipLevel - 1);
                 R3D_PRIMITIVE_DRAW_SCREEN();
             }
 
-            R3D_SHADER_UNBIND_SAMPLER_CUBE(prepare.cubefaceDown, uCube);
+            R3D_SHADER_UNBIND_SAMPLER_CUBE(prepare.cubefaceDown, uSourceTex);
         }
 
         /* --- Generate irradiance and prefilter maps --- */
@@ -1266,7 +1266,7 @@ void pass_scene_geometry(void)
     }
 
     // The bone matrices texture may have been bind during drawcalls, so UNBIND!
-    R3D_SHADER_UNBIND_SAMPLER_1D(scene.geometry, uTexBoneMatrices);
+    R3D_SHADER_UNBIND_SAMPLER_1D(scene.geometry, uBoneMatricesTex);
 }
 
 void pass_scene_prepass(void)
@@ -1299,7 +1299,7 @@ void pass_scene_prepass(void)
     }
 
     // NOTE: The storage texture of the matrices may have been bind during drawcalls
-    R3D_SHADER_UNBIND_SAMPLER_1D(scene.forward, uTexBoneMatrices);
+    R3D_SHADER_UNBIND_SAMPLER_1D(scene.forward, uBoneMatricesTex);
 }
 
 void pass_scene_decals(void)
@@ -1312,14 +1312,14 @@ void pass_scene_decals(void)
     glDepthMask(GL_FALSE);
     glEnable(GL_BLEND);
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uTexDepth, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     const r3d_frustum_t* frustum = &R3D.viewState.frustum;
     R3D_DRAW_FOR_EACH(call, true, frustum, R3D_DRAW_DECAL_INST, R3D_DRAW_DECAL) {
         raster_decal(call);
     }
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uTexDepth);
+    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uDepthTex);
 }
 
 r3d_target_t pass_prepare_ssao(void)
@@ -1341,31 +1341,31 @@ r3d_target_t pass_prepare_ssao(void)
     R3D_SHADER_SET_FLOAT(prepare.ssao, uIntensity, R3D.environment.ssao.intensity);
     R3D_SHADER_SET_FLOAT(prepare.ssao, uPower, R3D.environment.ssao.power);
 
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssao, uTexDepth, r3d_target_get(R3D_TARGET_DEPTH));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssao, uTexNormal, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssao, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssao, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssao, uTexDepth);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssao, uTexNormal);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssao, uNormalTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssao, uDepthTex);
 
     /* --- Denoise SSAO --- */
 
     R3D_SHADER_USE(prepare.atrousWavelet);
 
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.atrousWavelet, uTexNormal, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.atrousWavelet, uTexDepth, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.atrousWavelet, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.atrousWavelet, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     for (int i = 0; i < 4; i++) {
         R3D_TARGET_BIND_AND_SWAP_SSAO(ssaoTarget);
-        R3D_SHADER_BIND_SAMPLER_2D(prepare.atrousWavelet, uTexSource, r3d_target_get(ssaoTarget));
+        R3D_SHADER_BIND_SAMPLER_2D(prepare.atrousWavelet, uSourceTex, r3d_target_get(ssaoTarget));
         R3D_SHADER_SET_INT(prepare.atrousWavelet, uStepSize, 1 << i);
         R3D_PRIMITIVE_DRAW_SCREEN();
     }
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.atrousWavelet, uTexSource);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.atrousWavelet, uTexNormal);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.atrousWavelet, uTexDepth);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.atrousWavelet, uSourceTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.atrousWavelet, uNormalTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.atrousWavelet, uDepthTex);
 
     return r3d_target_swap_ssao(ssaoTarget);
 }
@@ -1397,10 +1397,10 @@ r3d_target_t pass_prepare_ssil(void)
     R3D_TARGET_BIND(SSIL_CURRENT);
     R3D_SHADER_USE(prepare.ssil);
 
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uTexLight, r3d_target_get(R3D_TARGET_DIFFUSE));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uTexPrevSSIL, R3D_TEXTURE_SELECT(r3d_target_get_or_null(SSIL_HISTORY), BLACK));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uTexNormal, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uTexDepth, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uLightingTex, r3d_target_get(R3D_TARGET_DIFFUSE));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uHistoryTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(SSIL_HISTORY), BLACK));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_SHADER_SET_FLOAT(prepare.ssil, uSampleCount, (float)R3D.environment.ssil.sampleCount);
     R3D_SHADER_SET_FLOAT(prepare.ssil, uSampleRadius, R3D.environment.ssil.sampleRadius);
@@ -1413,10 +1413,10 @@ r3d_target_t pass_prepare_ssil(void)
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uTexLight);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uTexPrevSSIL);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uTexNormal);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uTexDepth);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uLightingTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uHistoryTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uNormalTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uDepthTex);
 
     /* --- Blur SSIL (Dual Filtering) --- */
 
@@ -1429,7 +1429,7 @@ r3d_target_t pass_prepare_ssil(void)
 
     // Downsample
     R3D_SHADER_USE(prepare.blurDown);
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.blurDown, uTexSource, r3d_target_get(SSIL_CURRENT));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.blurDown, uSourceTex, r3d_target_get(SSIL_CURRENT));
     for (int mipLevel = 1; mipLevel < mipMax; mipLevel++)
     {
         int dstW, dstH;
@@ -1437,18 +1437,18 @@ r3d_target_t pass_prepare_ssil(void)
         r3d_target_set_mip_level(0, mipLevel);
         glViewport(0, 0, dstW, dstH);
 
-        R3D_SHADER_SET_INT(prepare.blurDown, uMipSource, mipLevel - 1);
+        R3D_SHADER_SET_INT(prepare.blurDown, uSourceLod, mipLevel - 1);
         R3D_PRIMITIVE_DRAW_SCREEN();
 
         if (mipLevel == 1) {
-            R3D_SHADER_BIND_SAMPLER_2D(prepare.blurDown, uTexSource, r3d_target_get(SSIL_MIP));
+            R3D_SHADER_BIND_SAMPLER_2D(prepare.blurDown, uSourceTex, r3d_target_get(SSIL_MIP));
         }
     }
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.blurDown, uTexSource);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.blurDown, uSourceTex);
 
     // Upsample
     R3D_SHADER_USE(prepare.blurUp);
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.blurUp, uTexSource, r3d_target_get(SSIL_MIP));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.blurUp, uSourceTex, r3d_target_get(SSIL_MIP));
     for (int mipLevel = mipMax - 2; mipLevel >= 0; mipLevel--)
     {
         int dstW, dstH;
@@ -1456,10 +1456,10 @@ r3d_target_t pass_prepare_ssil(void)
         r3d_target_set_mip_level(0, mipLevel);
         glViewport(0, 0, dstW, dstH);
 
-        R3D_SHADER_SET_INT(prepare.blurUp, uMipSource, mipLevel + 1);
+        R3D_SHADER_SET_INT(prepare.blurUp, uSourceLod, mipLevel + 1);
         R3D_PRIMITIVE_DRAW_SCREEN();
     }
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.blurUp, uTexSource);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.blurUp, uSourceTex);
 
     /* --- Swap history --- */
 
@@ -1481,11 +1481,11 @@ r3d_target_t pass_prepare_ssr(void)
     R3D_TARGET_BIND(R3D_TARGET_SSR);
     R3D_SHADER_USE(prepare.ssr);
 
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uTexColor, r3d_target_get(R3D_TARGET_DIFFUSE));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uTexAlbedo, r3d_target_get(R3D_TARGET_ALBEDO));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uTexNormal, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uTexORM, r3d_target_get(R3D_TARGET_ORM));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uTexDepth, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uLightingTex, r3d_target_get(R3D_TARGET_DIFFUSE));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
+    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_SHADER_SET_INT(prepare.ssr, uMaxRaySteps, R3D.environment.ssr.maxRaySteps);
     R3D_SHADER_SET_INT(prepare.ssr, uBinarySearchSteps, R3D.environment.ssr.binarySearchSteps);
@@ -1500,11 +1500,11 @@ r3d_target_t pass_prepare_ssr(void)
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uTexColor);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uTexAlbedo);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uTexNormal);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uTexORM);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uTexDepth);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uLightingTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uAlbedoTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uNormalTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uOrmTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uDepthTex);
 
     r3d_target_gen_mipmap(R3D_TARGET_SSR);
 
@@ -1531,11 +1531,11 @@ void pass_deferred_lights(r3d_target_t ssaoSource)
 
     R3D_SHADER_USE(deferred.lighting);
 
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uTexAlbedo, r3d_target_get(R3D_TARGET_ALBEDO));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uTexNormal, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uTexDepth, r3d_target_get(R3D_TARGET_DEPTH));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uTexSSAO, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssaoSource), WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uTexORM, r3d_target_get(R3D_TARGET_ORM));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uSsaoTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssaoSource), WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
 
     R3D_SHADER_SET_FLOAT(deferred.lighting, uSSAOLightAffect, R3D.environment.ssao.lightAffect);
 
@@ -1604,10 +1604,10 @@ void pass_deferred_lights(r3d_target_t ssaoSource)
 
     /* --- Unbind all textures --- */
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uTexAlbedo);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uTexNormal);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uTexDepth);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uTexORM);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uAlbedoTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uNormalTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uDepthTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uOrmTex);
 
     R3D_SHADER_UNBIND_SAMPLER_CUBE(deferred.lighting, uLight.shadowCubemap);
     R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uLight.shadowMap);
@@ -1631,30 +1631,30 @@ void pass_deferred_ambient(r3d_target_t ssaoSource, r3d_target_t ssilSource, r3d
     R3D_TARGET_BIND(R3D_TARGET_LIGHTING);
     R3D_SHADER_USE(deferred.ambient);
 
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uTexAlbedo, r3d_target_get(R3D_TARGET_ALBEDO));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uTexNormal, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uTexDepth, r3d_target_get(R3D_TARGET_DEPTH));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uTexSSAO, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssaoSource), WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uTexSSIL, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssilSource), BLACK));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uTexSSR, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssrSource), BLANK));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uTexORM, r3d_target_get(R3D_TARGET_ORM));
-    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uCubeIrradiance, r3d_env_irradiance_get());
-    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uCubePrefilter, r3d_env_prefilter_get());
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uTexBrdfLut, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uSsaoTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssaoSource), WHITE));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uSsilTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssilSource), BLACK));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uSsrTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssrSource), BLANK));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
+    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uIrradianceTex, r3d_env_irradiance_get());
+    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uPrefilterTex, r3d_env_prefilter_get());
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uBrdfLutTex, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
     R3D_SHADER_SET_FLOAT(deferred.ambient, uMipCountSSR, (float)r3d_target_get_mip_count(R3D_TARGET_SSR));
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uTexAlbedo);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uTexNormal);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uTexDepth);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uTexSSAO);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uTexSSIL);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uTexSSR);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uTexORM);
-    R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uCubeIrradiance);
-    R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uCubePrefilter);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uTexBrdfLut);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uAlbedoTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uNormalTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uDepthTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uSsaoTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uSsilTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uSsrTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uOrmTex);
+    R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uIrradianceTex);
+    R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uPrefilterTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uBrdfLutTex);
 }
 
 void pass_deferred_compose(r3d_target_t sceneTarget)
@@ -1668,13 +1668,13 @@ void pass_deferred_compose(r3d_target_t sceneTarget)
 
     R3D_SHADER_USE(deferred.compose);
 
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.compose, uTexDiffuse, r3d_target_get(R3D_TARGET_DIFFUSE));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.compose, uTexSpecular, r3d_target_get(R3D_TARGET_SPECULAR));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.compose, uDiffuseTex, r3d_target_get(R3D_TARGET_DIFFUSE));
+    R3D_SHADER_BIND_SAMPLER_2D(deferred.compose, uSpecularTex, r3d_target_get(R3D_TARGET_SPECULAR));
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.compose, uTexDiffuse);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.compose, uTexSpecular);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.compose, uDiffuseTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.compose, uSpecularTex);
 }
 
 static void pass_scene_forward_send_lights(const r3d_draw_call_t* call)
@@ -1754,9 +1754,9 @@ void pass_scene_forward(r3d_target_t sceneTarget)
     glDepthMask(GL_FALSE);
     glEnable(GL_BLEND);
 
-    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.forward, uCubeIrradiance, r3d_env_irradiance_get());
-    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.forward, uCubePrefilter, r3d_env_prefilter_get());
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uTexBrdfLut, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
+    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.forward, uIrradianceTex, r3d_env_irradiance_get());
+    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.forward, uPrefilterTex, r3d_env_prefilter_get());
+    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uBrdfLutTex, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
 
     R3D_SHADER_SET_VEC3(scene.forward, uViewPosition, R3D.viewState.viewPosition);
 
@@ -1767,9 +1767,9 @@ void pass_scene_forward(r3d_target_t sceneTarget)
     }
 
     if (R3D.environment.background.sky.texture != 0) {
-        R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.forward, uCubeIrradiance);
-        R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.forward, uCubePrefilter);
-        R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uTexBrdfLut);
+        R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.forward, uIrradianceTex);
+        R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.forward, uPrefilterTex);
+        R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uBrdfLutTex);
     }
 
     for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++) {
@@ -1778,7 +1778,7 @@ void pass_scene_forward(r3d_target_t sceneTarget)
     }
 
     // NOTE: The storage texture of the matrices may have been bind during drawcalls
-    R3D_SHADER_UNBIND_SAMPLER_1D(scene.forward, uTexBoneMatrices);
+    R3D_SHADER_UNBIND_SAMPLER_1D(scene.forward, uBoneMatricesTex);
 }
 
 void pass_scene_background(r3d_target_t sceneTarget)
@@ -1794,7 +1794,7 @@ void pass_scene_background(r3d_target_t sceneTarget)
         R3D_SHADER_USE(scene.skybox);
         glDisable(GL_CULL_FACE);
 
-        R3D_SHADER_BIND_SAMPLER_CUBE(scene.skybox, uCubeSky, R3D.environment.background.sky.texture);
+        R3D_SHADER_BIND_SAMPLER_CUBE(scene.skybox, uSkyTex, R3D.environment.background.sky.texture);
         R3D_SHADER_SET_FLOAT(scene.skybox, uSkyEnergy, R3D.environment.background.energy);
         R3D_SHADER_SET_VEC4(scene.skybox, uRotation, R3D.environment.background.rotation);
         R3D_SHADER_SET_MAT4(scene.skybox, uMatView, R3D.viewState.view);
@@ -1802,7 +1802,7 @@ void pass_scene_background(r3d_target_t sceneTarget)
 
         R3D_PRIMITIVE_DRAW_CUBE();
 
-        R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.skybox, uCubeSky);
+        R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.skybox, uSkyTex);
     }
     else {
         Vector4 background = {
@@ -1831,8 +1831,8 @@ r3d_target_t pass_post_fog(r3d_target_t sceneTarget)
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
     R3D_SHADER_USE(post.fog);
 
-    R3D_SHADER_BIND_SAMPLER_2D(post.fog, uTexColor, r3d_target_get(sceneTarget));
-    R3D_SHADER_BIND_SAMPLER_2D(post.fog, uTexDepth, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER_2D(post.fog, uSceneTex, r3d_target_get(sceneTarget));
+    R3D_SHADER_BIND_SAMPLER_2D(post.fog, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_SHADER_SET_INT(post.fog, uFogMode, R3D.environment.fog.mode);
     R3D_SHADER_SET_COL3(post.fog, uFogColor, R3D.environment.fog.color);
@@ -1843,8 +1843,8 @@ r3d_target_t pass_post_fog(r3d_target_t sceneTarget)
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.fog, uTexColor);
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.fog, uTexDepth);
+    R3D_SHADER_UNBIND_SAMPLER_2D(post.fog, uSceneTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(post.fog, uDepthTex);
 
     return sceneTarget;
 }
@@ -1854,8 +1854,8 @@ r3d_target_t pass_post_dof(r3d_target_t sceneTarget)
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
     R3D_SHADER_USE(post.dof);
 
-    R3D_SHADER_BIND_SAMPLER_2D(post.dof, uTexColor, r3d_target_get(sceneTarget));
-    R3D_SHADER_BIND_SAMPLER_2D(post.dof, uTexDepth, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER_2D(post.dof, uSceneTex, r3d_target_get(sceneTarget));
+    R3D_SHADER_BIND_SAMPLER_2D(post.dof, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_SHADER_SET_FLOAT(post.dof, uFocusPoint, R3D.environment.dof.focusPoint);
     R3D_SHADER_SET_FLOAT(post.dof, uFocusScale, R3D.environment.dof.focusScale);
@@ -1864,8 +1864,8 @@ r3d_target_t pass_post_dof(r3d_target_t sceneTarget)
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.dof, uTexColor);
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.dof, uTexDepth);
+    R3D_SHADER_UNBIND_SAMPLER_2D(post.dof, uSceneTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(post.dof, uDepthTex);
 
     return sceneTarget;
 }
@@ -1974,16 +1974,16 @@ r3d_target_t pass_post_bloom(r3d_target_t sceneTarget)
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
     R3D_SHADER_USE(post.bloom);
 
-    R3D_SHADER_BIND_SAMPLER_2D(post.bloom, uTexColor, sceneSourceID);
-    R3D_SHADER_BIND_SAMPLER_2D(post.bloom, uTexBloomBlur, r3d_target_get(R3D_TARGET_BLOOM));
+    R3D_SHADER_BIND_SAMPLER_2D(post.bloom, uSceneTex, sceneSourceID);
+    R3D_SHADER_BIND_SAMPLER_2D(post.bloom, uBloomTex, r3d_target_get(R3D_TARGET_BLOOM));
 
     R3D_SHADER_SET_INT(post.bloom, uBloomMode, R3D.environment.bloom.mode);
     R3D_SHADER_SET_FLOAT(post.bloom, uBloomIntensity, R3D.environment.bloom.intensity);
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.bloom, uTexColor);
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.bloom, uTexBloomBlur);
+    R3D_SHADER_UNBIND_SAMPLER_2D(post.bloom, uSceneTex);
+    R3D_SHADER_UNBIND_SAMPLER_2D(post.bloom, uBloomTex);
 
     return sceneTarget;
 }
@@ -1993,7 +1993,7 @@ r3d_target_t pass_post_output(r3d_target_t sceneTarget)
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
     R3D_SHADER_USE(post.output);
 
-    R3D_SHADER_BIND_SAMPLER_2D(post.output, uTexColor, r3d_target_get(sceneTarget));
+    R3D_SHADER_BIND_SAMPLER_2D(post.output, uSceneTex, r3d_target_get(sceneTarget));
 
     R3D_SHADER_SET_FLOAT(post.output, uTonemapExposure, R3D.environment.tonemap.exposure);
     R3D_SHADER_SET_FLOAT(post.output, uTonemapWhite, R3D.environment.tonemap.white);
@@ -2004,7 +2004,7 @@ r3d_target_t pass_post_output(r3d_target_t sceneTarget)
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.output, uTexColor);
+    R3D_SHADER_UNBIND_SAMPLER_2D(post.output, uSceneTex);
 
     return sceneTarget;
 }
@@ -2014,12 +2014,12 @@ r3d_target_t pass_post_fxaa(r3d_target_t sceneTarget)
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
     R3D_SHADER_USE(post.fxaa);
 
-    R3D_SHADER_BIND_SAMPLER_2D(post.fxaa, uTexture, r3d_target_get(sceneTarget));
+    R3D_SHADER_BIND_SAMPLER_2D(post.fxaa, uSourceTex, r3d_target_get(sceneTarget));
 
-    R3D_SHADER_SET_VEC2(post.fxaa, uTexelSize, (Vector2) {R3D_TARGET_TEXEL_SIZE});
+    R3D_SHADER_SET_VEC2(post.fxaa, uSourceTexel, (Vector2) {R3D_TARGET_TEXEL_SIZE});
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.fxaa, uTexture);
+    R3D_SHADER_UNBIND_SAMPLER_2D(post.fxaa, uSourceTex);
 
     return sceneTarget;
 }


### PR DESCRIPTION
I've mainly revised the sampler names, they now have the suffix 'Map' when they come from materials, and 'Tex' for everything else (consider internal textures).

I've also revised the names of a few other uniforms, such as `uMatVP` which is now `uMatViewProj`, just to make things a bit clearer.