### PR TITLE
Procedural cubemaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/prepare/cubemap_from_equirectangular.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/cubemap_irradiance.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/cubemap_prefilter.frag"
+    "${R3D_ROOT_PATH}/shaders/prepare/cubemap_skybox.frag"
     "${R3D_ROOT_PATH}/shaders/scene/scene.vert"
     "${R3D_ROOT_PATH}/shaders/scene/geometry.frag"
     "${R3D_ROOT_PATH}/shaders/scene/forward.frag"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@
 * [x] **Skybox Revision and Reflection Probes**
   Revise the skybox system and add support for reflection probes, including probe blending.
 
-* [ ] **Skybox Generation Support**
+* [x] **Skybox Generation Support**
   Add support for procedural skybox generation.
 
 * [ ] **Improve Shadow Map Management**

--- a/include/r3d/r3d_cubemap.h
+++ b/include/r3d/r3d_cubemap.h
@@ -19,6 +19,27 @@
  */
 
 // ========================================
+// CONSTANTS
+// ========================================
+
+#define R3D_CUBEMAP_SKY_BASE                                    \
+    R3D_LITERAL(R3D_CubemapSky) {                               \
+        .skyTopColor = (Color) {98, 116, 140, 255},             \
+        .skyHorizonColor = (Color) {165, 167, 171, 255},        \
+        .skyHorizonCurve = 0.15f,                               \
+        .skyEnergy = 1.0f,                                      \
+        .groundBottomColor = (Color) {51, 43, 34, 255},         \
+        .groundHorizonColor = (Color) {165, 167, 171, 255},     \
+        .groundHorizonCurve = 0.02f,                            \
+        .groundEnergy = 1.0f,                                   \
+        .sunDirection = (Vector3) {-1.0f, -1.0f, -1.0f},        \
+        .sunColor = (Color) {255, 255, 255, 255},               \
+        .sunSize = 1.5f * DEG2RAD,                              \
+        .sunCurve = 0.15,                                       \
+        .sunEnergy = 1.0f,                                      \
+    }
+
+// ========================================
 // ENUM TYPES
 // ========================================
 
@@ -29,12 +50,12 @@
  * the layout based on image dimensions.
  */
 typedef enum R3D_CubemapLayout {
-    R3D_CUBEMAP_LAYOUT_AUTO_DETECT = 0,         // Automatically detect layout type
-    R3D_CUBEMAP_LAYOUT_LINE_VERTICAL,           // Layout is defined by a vertical line with faces
-    R3D_CUBEMAP_LAYOUT_LINE_HORIZONTAL,         // Layout is defined by a horizontal line with faces
-    R3D_CUBEMAP_LAYOUT_CROSS_THREE_BY_FOUR,     // Layout is defined by a 3x4 cross with cubemap faces
-    R3D_CUBEMAP_LAYOUT_CROSS_FOUR_BY_THREE,     // Layout is defined by a 4x3 cross with cubemap faces
-    R3D_CUBEMAP_LAYOUT_PANORAMA                 // Layout is defined by an equirectangular panorama
+    R3D_CUBEMAP_LAYOUT_AUTO_DETECT = 0,         ///< Automatically detect layout type
+    R3D_CUBEMAP_LAYOUT_LINE_VERTICAL,           ///< Layout is defined by a vertical line with faces
+    R3D_CUBEMAP_LAYOUT_LINE_HORIZONTAL,         ///< Layout is defined by a horizontal line with faces
+    R3D_CUBEMAP_LAYOUT_CROSS_THREE_BY_FOUR,     ///< Layout is defined by a 3x4 cross with cubemap faces
+    R3D_CUBEMAP_LAYOUT_CROSS_FOUR_BY_THREE,     ///< Layout is defined by a 4x3 cross with cubemap faces
+    R3D_CUBEMAP_LAYOUT_PANORAMA                 ///< Layout is defined by an equirectangular panorama
 } R3D_CubemapLayout;
 
 // ========================================
@@ -48,8 +69,34 @@ typedef enum R3D_CubemapLayout {
  */
 typedef struct R3D_Cubemap {
     uint32_t texture;
+    uint32_t fbo;
     int size;
 } R3D_Cubemap;
+
+/**
+ * @brief Parameters for procedural sky generation.
+ *
+ * Curves control gradient falloff (lower = sharper transition at horizon).
+ */
+typedef struct R3D_CubemapSky {
+
+    Color skyTopColor;          // Sky color at zenith
+    Color skyHorizonColor;      // Sky color at horizon
+    float skyHorizonCurve;      // Gradient curve exponent (0.01 - 1.0, typical: 0.15)
+    float skyEnergy;            // Sky brightness multiplier
+
+    Color groundBottomColor;    // Ground color at nadir
+    Color groundHorizonColor;   // Ground color at horizon
+    float groundHorizonCurve;   // Gradient curve exponent (typical: 0.02)
+    float groundEnergy;         // Ground brightness multiplier
+
+    Vector3 sunDirection;       // Direction from which light comes (not normalized)
+    Color sunColor;             // Sun disk color
+    float sunSize;              // Sun angular size in radians (real sun: ~0.0087 rad = 0.5°)
+    float sunCurve;             // Sun edge softness exponent (typical: 0.15)
+    float sunEnergy;            // Sun brightness multiplier
+
+} R3D_CubemapSky;
 
 // ========================================
 // PUBLIC API
@@ -74,9 +121,25 @@ R3DAPI R3D_Cubemap R3D_LoadCubemap(const char* fileName, R3D_CubemapLayout layou
 R3DAPI R3D_Cubemap R3D_LoadCubemapFromImage(Image image, R3D_CubemapLayout layout);
 
 /**
+ * @brief Generates a procedural sky cubemap.
+ *
+ * Creates a GPU cubemap with procedural gradient sky and sun rendering.
+ * The cubemap is ready for use as environment map or IBL source.
+ */
+R3DAPI R3D_Cubemap R3D_GenCubemapSky(int size, R3D_CubemapSky params);
+
+/**
  * @brief Releases GPU resources associated with a cubemap.
  */
 R3DAPI void R3D_UnloadCubemap(R3D_Cubemap cubemap);
+
+/**
+ * @brief Updates an existing procedural sky cubemap.
+ *
+ * Re-renders the cubemap with new parameters. Faster than unload + generate
+ * when animating sky conditions (time of day, weather, etc.).
+ */
+R3DAPI void R3D_UpdateCubemapSky(R3D_Cubemap* cubemap, R3D_CubemapSky params);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/r3d/r3d_cubemap.h
+++ b/include/r3d/r3d_cubemap.h
@@ -90,7 +90,7 @@ typedef struct R3D_CubemapSky {
     float groundHorizonCurve;   // Gradient curve exponent (typical: 0.02)
     float groundEnergy;         // Ground brightness multiplier
 
-    Vector3 sunDirection;       // Direction from which light comes (not normalized)
+    Vector3 sunDirection;       // Direction from which light comes (can take not normalized)
     Color sunColor;             // Sun disk color
     float sunSize;              // Sun angular size in radians (real sun: ~0.0087 rad = 0.5°)
     float sunCurve;             // Sun edge softness exponent (typical: 0.15)

--- a/shaders/prepare/cubemap_skybox.frag
+++ b/shaders/prepare/cubemap_skybox.frag
@@ -1,0 +1,85 @@
+/* cubemap_skybox.frag -- Skybox generation fragment shader
+ *
+ * Copyright (c) 2025 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+/* === Includes === */
+
+#include "../include/math.glsl"
+
+/* === Varyings === */
+
+in vec3 vPosition;
+
+/* === Uniforms === */
+
+uniform vec3 uSkyTopColor;
+uniform vec3 uSkyHorizonColor;
+uniform float uSkyHorizonCurve;
+uniform float uSkyEnergy;
+
+uniform vec3 uGroundBottomColor;
+uniform vec3 uGroundHorizonColor;
+uniform float uGroundHorizonCurve;
+uniform float uGroundEnergy;
+
+uniform vec3 uSunDirection;
+uniform vec3 uSunColor;
+uniform float uSunSize;
+uniform float uSunCurve;
+uniform float uSunEnergy;
+
+/* === Fragments === */
+
+out vec4 FragColor;
+
+/* === Program === */
+
+void main()
+{
+    /* --- Normalization of ray direction --- */
+
+    vec3 eyeDir = normalize(vPosition);
+    vec3 sunDir = normalize(uSunDirection);
+
+    /* --- Vertical angle calculation --- */
+
+    float verticalAngle = acos(clamp(eyeDir.y, -1.0, 1.0));
+
+    /* --- Sky gradient (above the horizon) --- */
+
+    vec3 color;
+
+    if (eyeDir.y >= 0.0) {
+        float c = (1.0 - verticalAngle / (M_PI * 0.5));
+        float skyGradient = clamp(1.0 - pow(1.0 - c, 1.0 / max(uSkyHorizonCurve, 0.001)), 0.0, 1.0);
+        color = mix(uSkyHorizonColor, uSkyTopColor, skyGradient) * uSkyEnergy;
+    }
+    else {
+        float c = (verticalAngle - (M_PI * 0.5)) / (M_PI * 0.5);
+        float groundGradient = clamp(1.0 - pow(1.0 - c, 1.0 / max(uGroundHorizonCurve, 0.001)), 0.0, 1.0);
+        color = mix(uGroundHorizonColor, uGroundBottomColor, groundGradient) * uGroundEnergy;
+    }
+
+    /* --- Sun contribution --- */
+
+    float sunAngle = acos(dot(sunDir, eyeDir));
+
+    if (sunAngle < uSunSize) {
+        color = uSunColor * uSunEnergy;
+    }
+    else if (sunAngle < uSunSize * 10.0) {
+        float c2 = (sunAngle - uSunSize) / (uSunSize * 10.0 - uSunSize);
+        float sunFade = clamp(1.0 - pow(1.0 - c2, 1.0 / max(uSunCurve, 0.001)), 0.0, 1.0);
+        color = mix(uSunColor * uSunEnergy, color, sunFade);
+    }
+
+    /* --- Output --- */
+
+    FragColor = vec4(color, 1.0);
+}

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -34,6 +34,7 @@
 #include <shaders/cubemap_from_equirectangular.frag.h>
 #include <shaders/cubemap_irradiance.frag.h>
 #include <shaders/cubemap_prefilter.frag.h>
+#include <shaders/cubemap_skybox.frag.h>
 #include <shaders/scene.vert.h>
 #include <shaders/geometry.frag.h>
 #include <shaders/forward.frag.h>
@@ -424,6 +425,29 @@ void r3d_shader_load_prepare_cubemap_prefilter(void)
     USE_SHADER(prepare.cubemapPrefilter);
 
     SET_SAMPLER_CUBE(prepare.cubemapPrefilter, uSourceTex, 0);
+}
+
+void r3d_shader_load_prepare_cubemap_skybox(void)
+{
+    LOAD_SHADER(prepare.cubemapSkybox, CUBEMAP_VERT, CUBEMAP_SKYBOX_FRAG);
+
+    GET_LOCATION(prepare.cubemapSkybox, uMatProj);
+    GET_LOCATION(prepare.cubemapSkybox, uMatView);
+    GET_LOCATION(prepare.cubemapSkybox, uSkyTopColor);
+    GET_LOCATION(prepare.cubemapSkybox, uSkyHorizonColor);
+    GET_LOCATION(prepare.cubemapSkybox, uSkyHorizonCurve);
+    GET_LOCATION(prepare.cubemapSkybox, uSkyEnergy);
+    GET_LOCATION(prepare.cubemapSkybox, uGroundBottomColor);
+    GET_LOCATION(prepare.cubemapSkybox, uGroundHorizonColor);
+    GET_LOCATION(prepare.cubemapSkybox, uGroundHorizonCurve);
+    GET_LOCATION(prepare.cubemapSkybox, uGroundEnergy);
+    GET_LOCATION(prepare.cubemapSkybox, uSunDirection);
+    GET_LOCATION(prepare.cubemapSkybox, uSunColor);
+    GET_LOCATION(prepare.cubemapSkybox, uSunSize);
+    GET_LOCATION(prepare.cubemapSkybox, uSunCurve);
+    GET_LOCATION(prepare.cubemapSkybox, uSunEnergy);
+
+    USE_SHADER(prepare.cubemapSkybox);
 }
 
 void r3d_shader_load_scene_geometry(void)
@@ -975,6 +999,7 @@ void r3d_shader_quit()
     UNLOAD_SHADER(prepare.cubemapFromEquirectangular);
     UNLOAD_SHADER(prepare.cubemapIrradiance);
     UNLOAD_SHADER(prepare.cubemapPrefilter);
+    UNLOAD_SHADER(prepare.cubemapSkybox);
 
     UNLOAD_SHADER(scene.geometry);
     UNLOAD_SHADER(scene.forward);

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -364,6 +364,25 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
+    r3d_shader_uniform_mat4_t uMatProj;
+    r3d_shader_uniform_mat4_t uMatView;
+    r3d_shader_uniform_vec3_t uSkyTopColor;
+    r3d_shader_uniform_vec3_t uSkyHorizonColor;
+    r3d_shader_uniform_float_t uSkyHorizonCurve;
+    r3d_shader_uniform_float_t uSkyEnergy;
+    r3d_shader_uniform_vec3_t uGroundBottomColor;
+    r3d_shader_uniform_vec3_t uGroundHorizonColor;
+    r3d_shader_uniform_float_t uGroundHorizonCurve;
+    r3d_shader_uniform_float_t uGroundEnergy;
+    r3d_shader_uniform_vec3_t uSunDirection;
+    r3d_shader_uniform_vec3_t uSunColor;
+    r3d_shader_uniform_float_t uSunSize;
+    r3d_shader_uniform_float_t uSunCurve;
+    r3d_shader_uniform_float_t uSunEnergy;
+} r3d_shader_prepare_cubemap_skybox_t;
+
+typedef struct {
+    unsigned int id;
     r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatNormal;
     r3d_shader_uniform_mat4_t uMatModel;
@@ -682,6 +701,7 @@ extern struct r3d_shader {
         r3d_shader_prepare_cubemap_from_equirectangular_t cubemapFromEquirectangular;
         r3d_shader_prepare_cubemap_irradiance_t cubemapIrradiance;
         r3d_shader_prepare_cubemap_prefilter_t cubemapPrefilter;
+        r3d_shader_prepare_cubemap_skybox_t cubemapSkybox;
     } prepare;
 
     // Scene shaders
@@ -732,6 +752,7 @@ void r3d_shader_load_prepare_cubeface_down(void);
 void r3d_shader_load_prepare_cubemap_from_equirectangular(void);
 void r3d_shader_load_prepare_cubemap_irradiance(void);
 void r3d_shader_load_prepare_cubemap_prefilter(void);
+void r3d_shader_load_prepare_cubemap_skybox(void);
 void r3d_shader_load_scene_geometry(void);
 void r3d_shader_load_scene_forward(void);
 void r3d_shader_load_scene_background(void);
@@ -765,6 +786,7 @@ static const struct r3d_shader_loader {
         r3d_shader_loader_func cubemapFromEquirectangular;
         r3d_shader_loader_func cubemapIrradiance;
         r3d_shader_loader_func cubemapPrefilter;
+        r3d_shader_loader_func cubemapSkybox;
     } prepare;
 
     // Scene shaders
@@ -810,6 +832,7 @@ static const struct r3d_shader_loader {
         .cubemapFromEquirectangular = r3d_shader_load_prepare_cubemap_from_equirectangular,
         .cubemapIrradiance = r3d_shader_load_prepare_cubemap_irradiance,
         .cubemapPrefilter = r3d_shader_load_prepare_cubemap_prefilter,
+        .cubemapSkybox = r3d_shader_load_prepare_cubemap_skybox,
     },
 
     .scene = {


### PR DESCRIPTION
Adds basic support for generating procedural skyboxes.

I was inspired by Godot for the generation parameters, here they are:
```c
typedef struct R3D_CubemapSky {

    Color skyTopColor;          // Sky color at zenith
    Color skyHorizonColor;      // Sky color at horizon
    float skyHorizonCurve;      // Gradient curve exponent (0.01 - 1.0, typical: 0.15)
    float skyEnergy;            // Sky brightness multiplier

    Color groundBottomColor;    // Ground color at nadir
    Color groundHorizonColor;   // Ground color at horizon
    float groundHorizonCurve;   // Gradient curve exponent (typical: 0.02)
    float groundEnergy;         // Ground brightness multiplier

    Vector3 sunDirection;       // Direction from which light comes (can take not normalized)
    Color sunColor;             // Sun disk color
    float sunSize;              // Sun angular size in radians (real sun: ~0.0087 rad = 0.5°)
    float sunCurve;             // Sun edge softness exponent (typical: 0.15)
    float sunEnergy;            // Sun brightness multiplier

} R3D_CubemapSky;
```

There's `R3D_CUBEMAP_SKY_BASE` which also defines a basic configuration, also partly taken from godot, I didn't put in much effort x)

Here is a small example:
<img width="930" height="608" alt="image" src="https://github.com/user-attachments/assets/2f300872-a8fa-45f9-bb58-8d8554142943" />
