### PR TITLE
[internal] Light module update

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@
 * [x] **Skybox Generation Support**
   Add support for procedural skybox generation.
 
-* [ ] **Improve Shadow Map Management**
+* [x] **Improve Shadow Map Management**
   Instead of using one shadow map per light, implement an internal batching system with a 2D texture array and `Sample2DArray` in shaders.
   *Note: This would remove per-light independent shadow map resolutions.*
 

--- a/examples/animation.c
+++ b/examples/animation.c
@@ -62,13 +62,13 @@ int main(void)
     R3D_Light lights[2];
     lights[0] = R3D_CreateLight(R3D_LIGHT_OMNI);
     R3D_SetLightPosition(lights[0], (Vector3){-10.0f, 25.0f, 0.0f});
-    R3D_EnableShadow(lights[0], 4096);
+    R3D_EnableShadow(lights[0]);
     R3D_SetLightEnergy(lights[0], 1.25f);
     R3D_SetLightActive(lights[0], true);
 
     lights[1] = R3D_CreateLight(R3D_LIGHT_OMNI);
     R3D_SetLightPosition(lights[1], (Vector3){10.0f, 25.0f, 0.0f});
-    R3D_EnableShadow(lights[1], 4096);
+    R3D_EnableShadow(lights[1]);
     R3D_SetLightEnergy(lights[1], 1.25f);
     R3D_SetLightActive(lights[1], true);
 

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -1,4 +1,3 @@
-#include "r3d/r3d_material.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 
@@ -15,7 +14,6 @@ int main(void)
     R3D_Mesh plane = R3D_GenMeshPlane(1000, 1000, 1, 1);
     R3D_Mesh sphere = R3D_GenMeshSphere(0.5f, 64, 64);
     R3D_Material material = R3D_GetDefaultMaterial();
-    material.transparencyMode = R3D_TRANSPARENCY_PREPASS;
 
     // Setup environment
     R3D_ENVIRONMENT_SET(ambient.color, (Color){10, 10, 10, 255});

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -1,3 +1,4 @@
+#include "r3d/r3d_material.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 
@@ -14,6 +15,7 @@ int main(void)
     R3D_Mesh plane = R3D_GenMeshPlane(1000, 1000, 1, 1);
     R3D_Mesh sphere = R3D_GenMeshSphere(0.5f, 64, 64);
     R3D_Material material = R3D_GetDefaultMaterial();
+    material.transparencyMode = R3D_TRANSPARENCY_PREPASS;
 
     // Setup environment
     R3D_ENVIRONMENT_SET(ambient.color, (Color){10, 10, 10, 255});
@@ -21,7 +23,7 @@ int main(void)
     // Create light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
     R3D_LightLookAt(light, (Vector3){0, 10, 5}, (Vector3){0});
-    R3D_EnableShadow(light, 4096);
+    R3D_EnableShadow(light);
     R3D_SetLightActive(light, true);
 
     // Setup camera

--- a/examples/billboards.c
+++ b/examples/billboards.c
@@ -52,7 +52,7 @@ int main(void)
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){-1, -1, -1});
     R3D_SetShadowDepthBias(light, 0.01f);
-    R3D_EnableShadow(light, 4096);
+    R3D_EnableShadow(light);
     R3D_SetLightActive(light, true);
     R3D_SetLightRange(light, 32.0f);
 

--- a/examples/directional.c
+++ b/examples/directional.c
@@ -42,7 +42,7 @@ int main(void)
     R3D_SetLightDirection(light, (Vector3){0, -1, -1});
     R3D_SetLightActive(light, true);
     R3D_SetLightRange(light, 16.0f);
-    R3D_EnableShadow(light, 4096);
+    R3D_EnableShadow(light);
     R3D_SetShadowDepthBias(light, 0.01f);
     R3D_SetShadowSoftness(light, 2.0f);
 

--- a/examples/emission.c
+++ b/examples/emission.c
@@ -45,7 +45,7 @@ int main(void)
     R3D_LightLookAt(light, (Vector3){0, 10, 5}, (Vector3){0});
     R3D_SetLightOuterCutOff(light, 45.0f);
     R3D_SetLightInnerCutOff(light, 22.5f);
-    R3D_EnableShadow(light, 4096);
+    R3D_EnableShadow(light);
     R3D_SetLightActive(light, true);
 
     // Setup camera

--- a/examples/pbr_car.c
+++ b/examples/pbr_car.c
@@ -47,7 +47,7 @@ int main(void)
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){-1, -1, -1});
     R3D_SetShadowDepthBias(light, 0.003f);
-    R3D_EnableShadow(light, 4096);
+    R3D_EnableShadow(light);
     R3D_SetLightActive(light, true);
     R3D_SetLightEnergy(light, 2.0f);
     R3D_SetLightRange(light, 10);

--- a/examples/probe.c
+++ b/examples/probe.c
@@ -30,7 +30,7 @@ int main(void)
     // Create light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
     R3D_LightLookAt(light, (Vector3){0, 10, 5}, (Vector3){0});
-    R3D_EnableShadow(light, 4096);
+    R3D_EnableShadow(light);
     R3D_SetLightActive(light, true);
 
     // Create probe

--- a/examples/sponza.c
+++ b/examples/sponza.c
@@ -39,7 +39,7 @@ int main(void)
         R3D_SetLightActive(lights[i], true);
         R3D_SetLightEnergy(lights[i], 4.0f);
         R3D_SetShadowUpdateMode(lights[i], R3D_SHADOW_UPDATE_MANUAL);
-        R3D_EnableShadow(lights[i], 4096);
+        R3D_EnableShadow(lights[i]);
     }
 
     // Setup camera

--- a/examples/sprite.c
+++ b/examples/sprite.c
@@ -39,7 +39,7 @@ int main(void)
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
     R3D_LightLookAt(light, (Vector3){0,10,10}, (Vector3){0});
     R3D_SetLightRange(light, 64.0f);
-    R3D_EnableShadow(light, 1024);
+    R3D_EnableShadow(light);
     R3D_SetLightActive(light, true);
 
     // Setup camera

--- a/examples/transparency.c
+++ b/examples/transparency.c
@@ -46,7 +46,7 @@ int main(void)
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
     R3D_LightLookAt(light, (Vector3){0, 10, 5}, (Vector3){0});
     R3D_SetLightActive(light, true);
-    R3D_EnableShadow(light, 4096);
+    R3D_EnableShadow(light);
 
     // Main loop
     while (!WindowShouldClose())

--- a/include/r3d/r3d_lighting.h
+++ b/include/r3d/r3d_lighting.h
@@ -392,25 +392,27 @@ R3DAPI void R3D_SetLightOuterCutOff(R3D_Light id, float degrees);
 // ----------------------------------------
 
 /**
- * @brief Enables shadow casting for a light and sets its shadow map resolution.
+ * @brief Enables shadow rendering for a light.
  *
- * Allocates a shadow map at the given resolution and enables shadow rendering.
- * This function can be called multiple times to resize the shadow map, but doing so
- * reallocates GPU resources and has a performance cost.
+ * Turns on shadow rendering for the light. The engine will allocate a shadow
+ * map if needed, or reuse one previously allocated for another light.
+ *
+ * Shadow map resolutions are fixed: 2048x2048 for spot and point lights,
+ * and 4096x4096 for directional lights.
  *
  * @param id The ID of the light.
- * @param resolution The shadow map resolution.
  *
- * @note Shadow maps are memory-intensive. High resolutions (e.g. 4K) consume significant
- * GPU memory; creating many high-resolution shadow maps may lead crashes...
+ * @note Creating too many shadow-casting lights can exhaust GPU memory and
+ * potentially crash the graphics driver. Disabling shadows on one light and
+ * enabling them on another is free, since existing shadow maps are reused.
  */
-R3DAPI void R3D_EnableShadow(R3D_Light id, int resolution);
+R3DAPI void R3D_EnableShadow(R3D_Light id);
 
 /**
- * @brief Disables shadow casting for a light.
+ * @brief Disables shadow rendering for a light.
  *
- * Disables shadow rendering for the light. The shadow map is preserved in memory,
- * and may be reused later, even if the light itself is destroyed.
+ * Turns off shadow rendering for the light. The associated shadow map is
+ * kept in memory and may later be reused by another light.
  *
  * @param id The ID of the light.
  */

--- a/include/r3d/r3d_lighting.h
+++ b/include/r3d/r3d_lighting.h
@@ -30,7 +30,8 @@
 typedef enum R3D_LightType {
     R3D_LIGHT_DIR,                      ///< Directional light, affects the entire scene with parallel rays.
     R3D_LIGHT_SPOT,                     ///< Spot light, emits light in a cone shape.
-    R3D_LIGHT_OMNI                      ///< Omni light, emits light in all directions from a single point.
+    R3D_LIGHT_OMNI,                     ///< Omni light, emits light in all directions from a single point.
+    R3D_LIGHT_TYPE_COUNT
 } R3D_LightType;
 
 /**

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -14,35 +14,11 @@
 
 /* === Includes === */
 
+#include "../include/blocks/light.glsl"
 #include "../include/blocks/view.glsl"
 #include "../include/light.glsl"
 #include "../include/math.glsl"
 #include "../include/pbr.glsl"
-
-/* === Structs === */
-
-struct Light
-{
-    mat4 viewProj;                  //< View/projection matrix of the light, used for directional and spot shadow projection
-    vec3 color;                     //< Light color modulation tint
-    vec3 position;                  //< Light position (spot/omni)
-    vec3 direction;                 //< Light direction (spot/dir)
-    float specular;                 //< Specular factor (not physically accurate but provides more flexibility)
-    float energy;                   //< Light energy factor
-    float range;                    //< Maximum distance the light can travel before being completely attenuated (spot/omni)
-    float near;                     //< Near plane for the shadow map projection
-    float far;                      //< Far plane for the shadow map projection
-    float attenuation;              //< Additional light attenuation factor (spot/omni)
-    float innerCutOff;              //< Spot light inner cutoff angle
-    float outerCutOff;              //< Spot light outer cutoff angle
-    float shadowSoftness;           //< Softness factor to simulate a penumbra
-    float shadowTexelSize;          //< Size of a texel in the 2D shadow map
-    float shadowDepthBias;          //< Constant depth bias applied to shadow mapping to reduce shadow acne
-    float shadowSlopeBias;          //< Additional bias scaled by surface slope to reduce artifacts on angled geometry
-    int shadowLayer;                //< Index of the layer to be sampled, relative to the light type
-    lowp int type;                  //< Light type (dir/spot/omni)
-    bool shadow;                    //< Indicates whether the light generates shadows
-};
 
 /* === Varyings === */
 
@@ -59,8 +35,6 @@ uniform sampler2D uOrmTex;
 uniform sampler2DArray uShadowDirTex;
 uniform sampler2DArray uShadowSpotTex;
 uniform samplerCubeArray uShadowOmniTex;
-
-uniform Light uLight;
 
 uniform float uSSAOLightAffect;
 

--- a/shaders/include/blocks/light.glsl
+++ b/shaders/include/blocks/light.glsl
@@ -6,8 +6,10 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-#include "./math.glsl"
-#include "./pbr.glsl"
+/* === Includes === */
+
+#include "../math.glsl"
+#include "../pbr.glsl"
 
 /* === Defines === */
 
@@ -17,6 +19,44 @@
 #define LIGHT_DIR   0
 #define LIGHT_SPOT  1
 #define LIGHT_OMNI  2
+
+/* === Structures === */
+
+struct Light {
+    mat4 viewProj;
+    vec3 color;
+    vec3 position;
+    vec3 direction;
+    float specular;
+    float energy;
+    float range;
+    float near;
+    float far;
+    float attenuation;
+    float innerCutOff;
+    float outerCutOff;
+    float shadowSoftness;
+    float shadowTexelSize;
+    float shadowDepthBias;
+    float shadowSlopeBias;
+    int shadowLayer;
+    bool enabled;
+    bool shadow;
+    int type;
+};
+
+/* === Uniform Block === */
+
+#ifdef NUM_FORWARD_LIGHTS
+layout(std140) uniform LightArrayBlock {
+    Light uLights[NUM_FORWARD_LIGHTS];
+    int uNumLights;
+};
+#else
+layout(std140) uniform LightBlock {
+    Light uLight;
+};
+#endif
 
 /* === Functions === */
 

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -14,34 +14,8 @@
 
 /* === Includes === */
 
-#include "../include/light.glsl"
 #include "../include/math.glsl"
 #include "../include/pbr.glsl"
-
-/* === Structs === */
-
-struct Light
-{
-    vec3 color;
-    vec3 position;
-    vec3 direction;
-    float specular;
-    float energy;
-    float range;
-    float near;
-    float far;
-    float attenuation;
-    float innerCutOff;
-    float outerCutOff;
-    float shadowSoftness;
-    float shadowTexelSize;
-    float shadowDepthBias;
-    float shadowSlopeBias;
-    int shadowLayer;
-    lowp int type;
-    bool enabled;
-    bool shadow;
-};
 
 /* === Varyings === */
 
@@ -79,10 +53,9 @@ uniform vec3 uViewPosition;
 uniform bool uProbeInterior;
 #endif // PROBE
 
-uniform Light uLights[NUM_FORWARD_LIGHTS];
-
 /* === Blocks === */
 
+#include "../include/blocks/light.glsl"
 #include "../include/blocks/env.glsl"
 
 /* === Constants === */
@@ -243,12 +216,8 @@ void main()
     vec3 diffuse = vec3(0.0);
     vec3 specular = vec3(0.0);
 
-    for (int i = 0; i < NUM_FORWARD_LIGHTS; i++)
+    for (int i = 0; i < uNumLights; i++)
     {
-        if (!uLights[i].enabled) {
-            continue;
-        }
-
         Light light = uLights[i];
 
         /* Compute light direction */

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -37,6 +37,7 @@ struct Light
     float shadowTexelSize;
     float shadowDepthBias;
     float shadowSlopeBias;
+    int shadowLayer;
     lowp int type;
     bool enabled;
     bool shadow;
@@ -59,8 +60,9 @@ uniform sampler2D uEmissionMap;
 uniform sampler2D uNormalMap;
 uniform sampler2D uOrmMap;
 
-uniform samplerCube uShadowMapCube[NUM_FORWARD_LIGHTS];
-uniform sampler2D uShadowMap2D[NUM_FORWARD_LIGHTS];
+uniform sampler2DArray uShadowDirTex;
+uniform sampler2DArray uShadowSpotTex;
+uniform samplerCubeArray uShadowOmniTex;
 
 uniform samplerCubeArray uIrradianceTex;
 uniform samplerCubeArray uPrefilterTex;
@@ -125,7 +127,7 @@ float ShadowDir(int i, float cNdotL, mat2 diskRot)
     float shadow = 0.0;
     for (int j = 0; j < SHADOW_SAMPLES; ++j) {
         vec2 offset = diskRot * VOGEL_DISK[j] * light.shadowSoftness;
-        shadow += step(currentDepth, texture(uShadowMap2D[i], projCoords.xy + offset).r);
+        shadow += step(currentDepth, texture(uShadowDirTex, vec3(projCoords.xy + offset, float(light.shadowLayer))).r);
     }
     shadow /= float(SHADOW_SAMPLES);
 
@@ -161,7 +163,7 @@ float ShadowSpot(int i, float cNdotL, mat2 diskRot)
     float shadow = 0.0;
     for (int j = 0; j < SHADOW_SAMPLES; ++j) {
         vec2 offset = diskRot * VOGEL_DISK[j] * light.shadowSoftness;
-        shadow += step(currentDepth, texture(uShadowMap2D[i], projCoords.xy + offset).r);
+        shadow += step(currentDepth, texture(uShadowSpotTex, vec3(projCoords.xy + offset, float(light.shadowLayer))).r);
     }
 
     /* --- Final Shadow Value --- */
@@ -195,7 +197,7 @@ float ShadowOmni(int i, float cNdotL, mat2 diskRot)
     for (int j = 0; j < SHADOW_SAMPLES; ++j) {
         vec2 diskOffset = diskRot * VOGEL_DISK[j] * light.shadowSoftness;
         vec3 sampleDir = normalize(OBN * vec3(diskOffset.xy, 1.0));
-        float sampleDepth = texture(uShadowMapCube[i], sampleDir).r * light.far;
+        float sampleDepth = texture(uShadowOmniTex, vec4(sampleDir, float(light.shadowLayer))).r * light.far;
         shadow += step(currentDepth, sampleDepth);
     }
 

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -16,6 +16,7 @@
 
 /* === Includes === */
 
+#include "../include/blocks/light.glsl"
 #include "../include/blocks/view.glsl"
 #include "../include/math.glsl"
 
@@ -51,10 +52,6 @@ uniform bool uInstancing;
 
 uniform bool uSkinning;
 uniform int uBillboard;
-
-#if defined(FORWARD) || defined(PROBE)
-uniform mat4 uLightViewProj[NUM_FORWARD_LIGHTS];
-#endif // FORWARD
 
 #if defined(DEPTH) || defined(DEPTH_CUBE) || defined(PROBE)
 uniform mat4 uMatInvView;   // inv view only for billboard modes
@@ -217,8 +214,8 @@ void main()
     vTBN = mat3(T, B, N);
 
 #if defined(FORWARD) || defined(PROBE)
-    for (int i = 0; i < NUM_FORWARD_LIGHTS; i++) {
-        vPosLightSpace[i] = uLightViewProj[i] * vec4(vPosition, 1.0);
+    for (int i = 0; i < uNumLights; i++) {
+        vPosLightSpace[i] = uLights[i].viewProj * vec4(vPosition, 1.0);
     }
 #endif // FORWARD
 

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -649,9 +649,9 @@ bool r3d_light_iter(r3d_light_t** light, r3d_light_array_enum_t array)
 {
     static int index = 0;
     index = (*light == NULL) ? 0 : index + 1;
-    
+
     if (index >= R3D_MOD_LIGHT.arrays[array].count) return false;
-    
+
     *light = &R3D_MOD_LIGHT.lights[R3D_MOD_LIGHT.arrays[array].lights[index]];
     return true;
 }
@@ -659,7 +659,7 @@ bool r3d_light_iter(r3d_light_t** light, r3d_light_array_enum_t array)
 void r3d_light_enable_shadows(r3d_light_t* light)
 {
     if (light->shadow) return;
-    
+
     int layer = -1;
     switch (light->type) {
     case R3D_LIGHT_DIR:
@@ -675,22 +675,22 @@ void r3d_light_enable_shadows(r3d_light_t* light)
         light->shadowTexelSize = 1.0f / R3D_LIGHT_SHADOW_OMNI_SIZE;
         break;
     }
-    
+
     if (layer < 0) {
         TraceLog(LOG_ERROR, "R3D: Failed to reserve shadow layer for light");
         return;
     }
-    
+
+    light->shadowSoftness = 4.0f * light->shadowTexelSize;
+    light->state.shadowShouldBeUpdated = true;
     light->shadowLayer = layer;
     light->shadow = true;
-    light->state.shadowShouldBeUpdated = true;
-    light->shadowSoftness = 4.0f * light->shadowTexelSize;
 }
 
 void r3d_light_disable_shadows(r3d_light_t* light)
 {
     if (!light->shadow) return;
-    
+
     release_shadow_layer(light);
     light->shadow = false;
 }

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -593,7 +593,7 @@ r3d_rect_t r3d_light_get_screen_rect(const r3d_light_t* light, const Matrix* vie
         y = (int)fmaxf((minNDC.y * 0.5f + 0.5f) * h, 0.0f);
         w = (int)fminf((maxNDC.x * 0.5f + 0.5f) * w, (float)w) - x;
         h = (int)fminf((maxNDC.y * 0.5f + 0.5f) * h, (float)h) - y;
-        assert(w > 0 && h > 0);
+        assert(w > 0 && h > 0); // should never happen if calculated for visible lights
     }
 
     return (r3d_rect_t) {x, y, w, h};

--- a/src/modules/r3d_light.h
+++ b/src/modules/r3d_light.h
@@ -25,7 +25,10 @@
 #define R3D_LIGHT_SHADOW_OMNI_SIZE      2048
 
 #define R3D_LIGHT_INITIAL_CAP           32
-#define R3D_LIGHT_SHADOW_INITIAL_CAP    4
+
+#define R3D_LIGHT_SHADOW_DIR_GROWTH     2
+#define R3D_LIGHT_SHADOW_SPOT_GROWTH    4
+#define R3D_LIGHT_SHADOW_OMNI_GROWTH    4
 
 // ========================================
 // HELPER MACROS

--- a/src/modules/r3d_light.h
+++ b/src/modules/r3d_light.h
@@ -17,6 +17,17 @@
 #include "../common/r3d_math.h"
 
 // ========================================
+// CONSTANTS
+// ========================================
+
+#define R3D_LIGHT_SHADOW_DIR_SIZE       4096
+#define R3D_LIGHT_SHADOW_SPOT_SIZE      2048
+#define R3D_LIGHT_SHADOW_OMNI_SIZE      2048
+
+#define R3D_LIGHT_INITIAL_CAP           32
+#define R3D_LIGHT_SHADOW_INITIAL_CAP    4
+
+// ========================================
 // HELPER MACROS
 // ========================================
 
@@ -25,7 +36,7 @@
          r3d_light_iter(&light, R3D_LIGHT_ARRAY_VISIBLE); )
 
 // ========================================
-// MODULE STRUCTURES
+// TYPES
 // ========================================
 
 typedef struct {
@@ -37,36 +48,35 @@ typedef struct {
 } r3d_light_state_t;
 
 typedef struct {
-    GLuint fbo, tex;
-    int resolution;
-} r3d_light_shadow_map_t;
 
-typedef struct {
-    Matrix matVP[6];                        //< View/projection matrix of the light (only [0] for dir/spot, 6 for omni lights)
-    r3d_frustum_t frustum[6];               //< Frustum of the light (only [0] for dir/spot, 6 for omni lights) (calculated only if shadows are enabled)
-    BoundingBox aabb;                       //< AABB in world space of the light volume
-    r3d_light_state_t state;                //< Light update config
-    r3d_light_shadow_map_t shadowMap;       //< 2D or Cube shadow map
-    GLuint shadowCubemap;                   //< Cube shadow map used for omni-directional shadow projection
-    Vector3 color;                          //< Light color modulation tint
-    Vector3 position;                       //< Light position (spot/omni)
-    Vector3 direction;                      //< Light direction (spot/dir)
-    float specular;                         //< Specular factor (not physically accurate but provides more flexibility)
-    float energy;                           //< Light energy factor
-    float range;                            //< Maximum distance the light can travel before being completely attenuated (spot/omni)
-    float size;                             //< Light size, currently used only for shadows (PCSS)
-    float near;                             //< Near plane for the shadow map projection
-    float far;                              //< Far plane for the shadow map projection
-    float attenuation;                      //< Additional light attenuation factor (spot/omni)
-    float innerCutOff;                      //< Spot light inner cutoff angle
-    float outerCutOff;                      //< Spot light outer cutoff angle
-    float shadowSoftness;                   //< Softness factor to simulate a penumbra
-    float shadowTexelSize;                  //< Size of a texel in the 2D shadow map
-    float shadowDepthBias;                  //< Constant depth bias applied to shadow mapping to reduce shadow acne
-    float shadowSlopeBias;                  //< Additional bias scaled by surface slope to reduce artifacts on angled geometry
-    R3D_LightType type;                     //< Light type (dir/spot/omni)
-    bool enabled;                           //< Indicates whether the light is on
-    bool shadow;                            //< Indicates whether the light generates shadows
+    r3d_frustum_t frustum[6];   // Frustum (only [0] for dir/spot, 6 for omni)
+    Matrix viewProj[6];         // View/projection matrix (only [0] for dir/spot, 6 for omni)
+    BoundingBox aabb;           // AABB in world space of the light volume
+
+    r3d_light_state_t state;    // Contains the current state useful for the update
+    int shadowLayer;            // Shadow map layer index, -1 if no shadow
+    
+    Vector3 color;
+    Vector3 position;           // Light position (spot/omni)
+    Vector3 direction;          // Light direction (spot/dir)
+    
+    float specular;
+    float energy;
+    float range;                // Maximum distance (spot/omni)
+    float near;                 // Near plane for shadow projection
+    float far;                  // Far plane for shadow projection
+    float attenuation;          // Additional attenuation (spot/omni)
+    float innerCutOff;          // Spot light inner cutoff angle
+    float outerCutOff;          // Spot light outer cutoff angle
+    float shadowSoftness;       // Softness factor for penumbra
+    float shadowTexelSize;      // Size of a texel in shadow map
+    float shadowDepthBias;      // Constant depth bias
+    float shadowSlopeBias;      // Slope-scaled depth bias
+    
+    R3D_LightType type;
+    bool enabled;
+    bool shadow;
+
 } r3d_light_t;
 
 typedef enum {
@@ -81,11 +91,32 @@ typedef struct {
     int count;
 } r3d_light_array_t;
 
+// Shadow layer pool
+typedef struct {
+    int* freeLayers;
+    int freeCount;
+    int freeCapacity;
+    int totalLayers;
+} r3d_light_shadow_pool_t;
+
 // ========================================
 // MODULE STATE
 // ========================================
 
 extern struct r3d_light {
+    GLuint workFramebuffer;
+    
+    // Shadow map arrays
+    GLuint shadowDirArray;      // 2D array for directional lights
+    GLuint shadowSpotArray;     // 2D array for spot lights
+    GLuint shadowOmniArray;     // Cube array for omni lights
+    
+    // Shadow layer pools
+    r3d_light_shadow_pool_t dirPool;
+    r3d_light_shadow_pool_t spotPool;
+    r3d_light_shadow_pool_t omniPool;
+    
+    // Light management
     r3d_light_array_t arrays[R3D_LIGHT_ARRAY_COUNT];
     r3d_light_t* lights;
     int capacityLights;
@@ -95,70 +126,47 @@ extern struct r3d_light {
 // MODULE FUNCTIONS
 // ========================================
 
-/*
- * Module initialization function.
- * Called once during `R3D_Init()`
- */
+/* Initialize module (called once during R3D_Init) */
 bool r3d_light_init(void);
 
-/*
- * Module deinitialization function.
- * Called once during `R3D_Close()`
- */
+/* Deinitialize module (called once during R3D_Close) */
 void r3d_light_quit(void);
 
-/*
- * Create a new light of the given type.
- * Allocates or reuses an internal slot and initializes default values.
- */
+/* Create a new light of the given type */
 R3D_Light r3d_light_new(R3D_LightType type);
 
-/*
- * Delete a light and return it to the free list.
- * The handle becomes invalid after this call.
- */
+/* Delete a light and return it to the free list */
 void r3d_light_delete(R3D_Light index);
 
-/*
- * Check whether a light handle refers to a valid light.
- */
+/* Check whether a light handle is valid */
 bool r3d_light_is_valid(R3D_Light index);
 
-/*
- * Retrieve the internal light structure from a handle.
- * Returns NULL if the handle is invalid.
- */
+/* Get internal light structure (returns NULL if invalid) */
 r3d_light_t* r3d_light_get(R3D_Light index);
 
-/*
- * Returns the screen-space rectangle covered by the light's influence.
- * Supports SPOT and OMNI lights only, asserts the light is not DIR.
- */
+/* Returns the screen-space rectangle covered by the light's influence */
 r3d_rect_t r3d_light_get_screen_rect(const r3d_light_t* light, const Matrix* viewProj, int w, int h);
 
-/*
- * Internal helper to iterate over lights by category.
- * Stateful and not thread-safe.
- */
+/* Iterator for lights by category (stateful, not thread-safe) */
 bool r3d_light_iter(r3d_light_t** light, r3d_light_array_enum_t array);
 
-/*
- * Enable shadows for a light and configure shadow parameters.
- * Creates or resizes the shadow map if necessary.
- */
-void r3d_light_enable_shadows(r3d_light_t* light, int resolution);
+/* Enable shadows for a light */
+void r3d_light_enable_shadows(r3d_light_t* light);
 
-/*
- * Update all lights, recompute state, and collect visible lights.
- * Performs frustum culling and shadow updates when needed.
- */
+/* Disable shadows for a light */
+void r3d_light_disable_shadows(r3d_light_t* light);
+
+/* Update all lights and collect visible ones */
 void r3d_light_update_and_cull(const r3d_frustum_t* viewFrustum, Vector3 viewPosition);
 
-/*
- * Indicate whether the shadow map should be rendered.
- * The internal update state can be reset after the query.
- */
+/* Check if shadow map should be rendered (updates state if willBeUpdated is true) */
 bool r3d_light_shadow_should_be_updated(r3d_light_t* light, bool willBeUpdated);
+
+/* Bind shadow framebuffer for a light type */
+void r3d_light_shadow_bind_fbo(R3D_LightType type, int layer, int face);
+
+/* Get a shadow map array texture ID */
+GLuint r3d_light_shadow_get(R3D_LightType type);
 
 // ========================================
 // INLINE QUERIES

--- a/src/modules/r3d_light.h
+++ b/src/modules/r3d_light.h
@@ -104,22 +104,19 @@ typedef struct {
 // ========================================
 
 extern struct r3d_light {
+
+    // Common framebuffer for rendering or copy
     GLuint workFramebuffer;
-    
-    // Shadow map arrays
-    GLuint shadowDirArray;      // 2D array for directional lights
-    GLuint shadowSpotArray;     // 2D array for spot lights
-    GLuint shadowOmniArray;     // Cube array for omni lights
-    
-    // Shadow layer pools
-    r3d_light_shadow_pool_t dirPool;
-    r3d_light_shadow_pool_t spotPool;
-    r3d_light_shadow_pool_t omniPool;
-    
+
+    // Shadow map arrays and layer pools
+    GLuint shadowArrays[R3D_LIGHT_TYPE_COUNT];
+    r3d_light_shadow_pool_t shadowPools[R3D_LIGHT_TYPE_COUNT];
+
     // Light management
     r3d_light_array_t arrays[R3D_LIGHT_ARRAY_COUNT];
     r3d_light_t* lights;
     int capacityLights;
+
 } R3D_MOD_LIGHT;
 
 // ========================================

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -126,6 +126,14 @@ struct r3d_shader R3D_MOD_SHADER;
     );                                                                          \
 } while(0)
 
+#define SET_SAMPLER_2D_ARRAY(shader_name, uniform, value) do {                  \
+    R3D_MOD_SHADER.shader_name.uniform.slot2DArr = (value);                     \
+    glUniform1i(                                                                \
+        R3D_MOD_SHADER.shader_name.uniform.loc,                                 \
+        R3D_MOD_SHADER.shader_name.uniform.slot2DArr                            \
+    );                                                                          \
+} while(0)
+
 #define SET_SAMPLER_CUBE_ARRAY(shader_name, uniform, value) do {                \
     R3D_MOD_SHADER.shader_name.uniform.slotCubeArr = (value);                   \
     glUniform1i(                                                                \
@@ -524,6 +532,9 @@ void r3d_shader_load_scene_forward(void)
     GET_LOCATION(scene.forward, uEmissionMap);
     GET_LOCATION(scene.forward, uNormalMap);
     GET_LOCATION(scene.forward, uOrmMap);
+    GET_LOCATION(scene.forward, uShadowDirTex);
+    GET_LOCATION(scene.forward, uShadowSpotTex);
+    GET_LOCATION(scene.forward, uShadowOmniTex);
     GET_LOCATION(scene.forward, uIrradianceTex);
     GET_LOCATION(scene.forward, uPrefilterTex);
     GET_LOCATION(scene.forward, uBrdfLutTex);
@@ -540,17 +551,15 @@ void r3d_shader_load_scene_forward(void)
     SET_SAMPLER_2D(scene.forward, uEmissionMap, 2);
     SET_SAMPLER_2D(scene.forward, uNormalMap, 3);
     SET_SAMPLER_2D(scene.forward, uOrmMap, 4);
-    SET_SAMPLER_CUBE_ARRAY(scene.forward, uIrradianceTex, 5);
-    SET_SAMPLER_CUBE_ARRAY(scene.forward, uPrefilterTex, 6);
-    SET_SAMPLER_2D(scene.forward, uBrdfLutTex, 7);
+    SET_SAMPLER_2D_ARRAY(scene.forward, uShadowDirTex, 5);
+    SET_SAMPLER_2D_ARRAY(scene.forward, uShadowSpotTex, 6);
+    SET_SAMPLER_CUBE_ARRAY(scene.forward, uShadowOmniTex, 7);
+    SET_SAMPLER_CUBE_ARRAY(scene.forward, uIrradianceTex, 8);
+    SET_SAMPLER_CUBE_ARRAY(scene.forward, uPrefilterTex, 9);
+    SET_SAMPLER_2D(scene.forward, uBrdfLutTex, 10);
 
-    int shadowMapSlot = 10;
-    for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++)
-    {
+    for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++) {
         GET_LOCATION_ARRAY(scene.forward, uLightViewProj, i);
-        GET_LOCATION_ARRAY(scene.forward, uShadowMapCube, i);
-        GET_LOCATION_ARRAY(scene.forward, uShadowMap2D, i);
-
         GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, color);
         GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, position);
         GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, direction);
@@ -566,12 +575,10 @@ void r3d_shader_load_scene_forward(void)
         GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadowTexelSize);
         GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadowDepthBias);
         GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadowSlopeBias);
+        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadowLayer);
         GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, type);
         GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, enabled);
         GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadow);
-
-        SET_SAMPLER_CUBE(scene.forward, uShadowMapCube[i], shadowMapSlot++);
-        SET_SAMPLER_2D(scene.forward, uShadowMap2D[i], shadowMapSlot++);
     }
 }
 
@@ -687,6 +694,9 @@ void r3d_shader_load_scene_probe(void)
     GET_LOCATION(scene.probe, uEmissionMap);
     GET_LOCATION(scene.probe, uNormalMap);
     GET_LOCATION(scene.probe, uOrmMap);
+    GET_LOCATION(scene.probe, uShadowDirTex);
+    GET_LOCATION(scene.probe, uShadowSpotTex);
+    GET_LOCATION(scene.probe, uShadowOmniTex);
     GET_LOCATION(scene.probe, uIrradianceTex);
     GET_LOCATION(scene.probe, uPrefilterTex);
     GET_LOCATION(scene.probe, uBrdfLutTex);
@@ -704,17 +714,16 @@ void r3d_shader_load_scene_probe(void)
     SET_SAMPLER_2D(scene.probe, uEmissionMap, 2);
     SET_SAMPLER_2D(scene.probe, uNormalMap, 3);
     SET_SAMPLER_2D(scene.probe, uOrmMap, 4);
-    SET_SAMPLER_CUBE_ARRAY(scene.probe, uIrradianceTex, 5);
-    SET_SAMPLER_CUBE_ARRAY(scene.probe, uPrefilterTex, 6);
-    SET_SAMPLER_2D(scene.probe, uBrdfLutTex, 7);
+    SET_SAMPLER_2D_ARRAY(scene.probe, uShadowDirTex, 5);
+    SET_SAMPLER_2D_ARRAY(scene.probe, uShadowSpotTex, 6);
+    SET_SAMPLER_CUBE_ARRAY(scene.probe, uShadowOmniTex, 7);
+    SET_SAMPLER_CUBE_ARRAY(scene.probe, uIrradianceTex, 8);
+    SET_SAMPLER_CUBE_ARRAY(scene.probe, uPrefilterTex, 9);
+    SET_SAMPLER_2D(scene.probe, uBrdfLutTex, 10);
 
     int shadowMapSlot = 10;
-    for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++)
-    {
+    for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++) {
         GET_LOCATION_ARRAY(scene.probe, uLightViewProj, i);
-        GET_LOCATION_ARRAY(scene.probe, uShadowMapCube, i);
-        GET_LOCATION_ARRAY(scene.probe, uShadowMap2D, i);
-
         GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, color);
         GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, position);
         GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, direction);
@@ -730,12 +739,10 @@ void r3d_shader_load_scene_probe(void)
         GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadowTexelSize);
         GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadowDepthBias);
         GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadowSlopeBias);
+        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadowLayer);
         GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, type);
         GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, enabled);
         GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadow);
-
-        SET_SAMPLER_CUBE(scene.probe, uShadowMapCube[i], shadowMapSlot++);
-        SET_SAMPLER_2D(scene.probe, uShadowMap2D[i], shadowMapSlot++);
     }
 }
 
@@ -827,11 +834,14 @@ void r3d_shader_load_deferred_lighting(void)
     GET_LOCATION(deferred.lighting, uDepthTex);
     GET_LOCATION(deferred.lighting, uSsaoTex);
     GET_LOCATION(deferred.lighting, uOrmTex);
+
+    GET_LOCATION(deferred.lighting, uShadowDirTex);
+    GET_LOCATION(deferred.lighting, uShadowSpotTex);
+    GET_LOCATION(deferred.lighting, uShadowOmniTex);
+
     GET_LOCATION(deferred.lighting, uSSAOLightAffect);
 
-    GET_LOCATION(deferred.lighting, uLight.matVP);
-    GET_LOCATION(deferred.lighting, uLight.shadowMap);
-    GET_LOCATION(deferred.lighting, uLight.shadowCubemap);
+    GET_LOCATION(deferred.lighting, uLight.viewProj);
     GET_LOCATION(deferred.lighting, uLight.color);
     GET_LOCATION(deferred.lighting, uLight.position);
     GET_LOCATION(deferred.lighting, uLight.direction);
@@ -847,6 +857,7 @@ void r3d_shader_load_deferred_lighting(void)
     GET_LOCATION(deferred.lighting, uLight.shadowTexelSize);
     GET_LOCATION(deferred.lighting, uLight.shadowDepthBias);
     GET_LOCATION(deferred.lighting, uLight.shadowSlopeBias);
+    GET_LOCATION(deferred.lighting, uLight.shadowLayer);
     GET_LOCATION(deferred.lighting, uLight.type);
     GET_LOCATION(deferred.lighting, uLight.shadow);
 
@@ -858,8 +869,9 @@ void r3d_shader_load_deferred_lighting(void)
     SET_SAMPLER_2D(deferred.lighting, uSsaoTex, 3);
     SET_SAMPLER_2D(deferred.lighting, uOrmTex, 4);
 
-    SET_SAMPLER_2D(deferred.lighting, uLight.shadowMap, 5);
-    SET_SAMPLER_CUBE(deferred.lighting, uLight.shadowCubemap, 6);
+    SET_SAMPLER_2D_ARRAY(deferred.lighting, uShadowDirTex, 5);
+    SET_SAMPLER_2D_ARRAY(deferred.lighting, uShadowSpotTex, 6);
+    SET_SAMPLER_CUBE_ARRAY(deferred.lighting, uShadowOmniTex, 7);
 }
 
 void r3d_shader_load_deferred_compose(void)

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -514,6 +514,7 @@ void r3d_shader_load_scene_forward(void)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
+    SET_UNIFORM_BUFFER(scene.forward, LightArrayBlock, R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT);
     SET_UNIFORM_BUFFER(scene.forward, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(scene.forward, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
@@ -557,29 +558,6 @@ void r3d_shader_load_scene_forward(void)
     SET_SAMPLER_CUBE_ARRAY(scene.forward, uIrradianceTex, 8);
     SET_SAMPLER_CUBE_ARRAY(scene.forward, uPrefilterTex, 9);
     SET_SAMPLER_2D(scene.forward, uBrdfLutTex, 10);
-
-    for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++) {
-        GET_LOCATION_ARRAY(scene.forward, uLightViewProj, i);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, color);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, position);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, direction);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, specular);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, energy);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, range);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, near);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, far);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, attenuation);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, innerCutOff);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, outerCutOff);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadowSoftness);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadowTexelSize);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadowDepthBias);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadowSlopeBias);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadowLayer);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, type);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, enabled);
-        GET_LOCATION_ARRAY_STRUCT(scene.forward, uLights, i, shadow);
-    }
 }
 
 void r3d_shader_load_scene_background(void)
@@ -674,6 +652,7 @@ void r3d_shader_load_scene_probe(void)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
+    SET_UNIFORM_BUFFER(scene.probe, LightArrayBlock, R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT);
     SET_UNIFORM_BUFFER(scene.probe, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(scene.probe, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
@@ -720,30 +699,6 @@ void r3d_shader_load_scene_probe(void)
     SET_SAMPLER_CUBE_ARRAY(scene.probe, uIrradianceTex, 8);
     SET_SAMPLER_CUBE_ARRAY(scene.probe, uPrefilterTex, 9);
     SET_SAMPLER_2D(scene.probe, uBrdfLutTex, 10);
-
-    int shadowMapSlot = 10;
-    for (int i = 0; i < R3D_SHADER_NUM_FORWARD_LIGHTS; i++) {
-        GET_LOCATION_ARRAY(scene.probe, uLightViewProj, i);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, color);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, position);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, direction);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, specular);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, energy);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, range);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, near);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, far);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, attenuation);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, innerCutOff);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, outerCutOff);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadowSoftness);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadowTexelSize);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadowDepthBias);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadowSlopeBias);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadowLayer);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, type);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, enabled);
-        GET_LOCATION_ARRAY_STRUCT(scene.probe, uLights, i, shadow);
-    }
 }
 
 void r3d_shader_load_scene_decal(void)
@@ -827,6 +782,7 @@ void r3d_shader_load_deferred_lighting(void)
 {
     LOAD_SHADER(deferred.lighting, SCREEN_VERT, LIGHTING_FRAG);
 
+    SET_UNIFORM_BUFFER(deferred.lighting, LightBlock, R3D_SHADER_BLOCK_LIGHT_SLOT);
     SET_UNIFORM_BUFFER(deferred.lighting, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
     GET_LOCATION(deferred.lighting, uAlbedoTex);
@@ -840,26 +796,6 @@ void r3d_shader_load_deferred_lighting(void)
     GET_LOCATION(deferred.lighting, uShadowOmniTex);
 
     GET_LOCATION(deferred.lighting, uSSAOLightAffect);
-
-    GET_LOCATION(deferred.lighting, uLight.viewProj);
-    GET_LOCATION(deferred.lighting, uLight.color);
-    GET_LOCATION(deferred.lighting, uLight.position);
-    GET_LOCATION(deferred.lighting, uLight.direction);
-    GET_LOCATION(deferred.lighting, uLight.specular);
-    GET_LOCATION(deferred.lighting, uLight.energy);
-    GET_LOCATION(deferred.lighting, uLight.range);
-    GET_LOCATION(deferred.lighting, uLight.near);
-    GET_LOCATION(deferred.lighting, uLight.far);
-    GET_LOCATION(deferred.lighting, uLight.attenuation);
-    GET_LOCATION(deferred.lighting, uLight.innerCutOff);
-    GET_LOCATION(deferred.lighting, uLight.outerCutOff);
-    GET_LOCATION(deferred.lighting, uLight.shadowSoftness);
-    GET_LOCATION(deferred.lighting, uLight.shadowTexelSize);
-    GET_LOCATION(deferred.lighting, uLight.shadowDepthBias);
-    GET_LOCATION(deferred.lighting, uLight.shadowSlopeBias);
-    GET_LOCATION(deferred.lighting, uLight.shadowLayer);
-    GET_LOCATION(deferred.lighting, uLight.type);
-    GET_LOCATION(deferred.lighting, uLight.shadow);
 
     USE_SHADER(deferred.lighting);
 
@@ -982,6 +918,8 @@ bool r3d_shader_init()
     const int UNIFORM_BUFFER_SIZES[R3D_SHADER_BLOCK_COUNT] = {
         [R3D_SHADER_BLOCK_VIEW] = sizeof(r3d_shader_block_view_t),
         [R3D_SHADER_BLOCK_ENV] = sizeof(r3d_shader_block_env_t),
+        [R3D_SHADER_BLOCK_LIGHT] = sizeof(r3d_shader_block_light_t),
+        [R3D_SHADER_BLOCK_LIGHT_ARRAY] = sizeof(r3d_shader_block_light_array_t),
     };
 
     glGenBuffers(R3D_SHADER_BLOCK_COUNT, R3D_MOD_SHADER.uniformBuffers);
@@ -1046,6 +984,14 @@ void r3d_shader_set_uniform_block(r3d_shader_block_t block, const void* data)
     case R3D_SHADER_BLOCK_ENV:
         blockSlot = R3D_SHADER_BLOCK_ENV_SLOT;
         blockSize = sizeof(r3d_shader_block_env_t);
+        break;
+    case R3D_SHADER_BLOCK_LIGHT:
+        blockSlot = R3D_SHADER_BLOCK_LIGHT_SLOT;
+        blockSize = sizeof(r3d_shader_block_light_t);
+        break;
+    case R3D_SHADER_BLOCK_LIGHT_ARRAY:
+        blockSlot = R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT;
+        blockSize = sizeof(r3d_shader_block_light_array_t);
         break;
     case R3D_SHADER_BLOCK_COUNT:
         return;

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -21,11 +21,13 @@
 // MODULE CONSTANTS
 // ========================================
 
-#define R3D_SHADER_NUM_FORWARD_LIGHTS   8
-#define R3D_SHADER_NUM_PROBES           4
+#define R3D_SHADER_NUM_FORWARD_LIGHTS       8
+#define R3D_SHADER_NUM_PROBES               4
 
-#define R3D_SHADER_BLOCK_VIEW_SLOT      0
-#define R3D_SHADER_BLOCK_ENV_SLOT       1
+#define R3D_SHADER_BLOCK_VIEW_SLOT          0
+#define R3D_SHADER_BLOCK_ENV_SLOT           1
+#define R3D_SHADER_BLOCK_LIGHT_SLOT         2
+#define R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT   3
 
 // ========================================
 // SHADER MANAGEMENT MACROS
@@ -199,6 +201,8 @@ typedef struct { int loc; } r3d_shader_uniform_mat4_t;
 typedef enum {
     R3D_SHADER_BLOCK_VIEW,
     R3D_SHADER_BLOCK_ENV,
+    R3D_SHADER_BLOCK_LIGHT,
+    R3D_SHADER_BLOCK_LIGHT_ARRAY,
     R3D_SHADER_BLOCK_COUNT
 } r3d_shader_block_t;
 
@@ -244,6 +248,34 @@ typedef struct {
     alignas(4) int32_t uNumPrefilterLevels;
 
 } r3d_shader_block_env_t;
+
+typedef struct {
+    alignas(16) Matrix viewProj;
+    alignas(16) Vector3 color;
+    alignas(16) Vector3 position;
+    alignas(16) Vector3 direction;
+    alignas(4) float specular;
+    alignas(4) float energy;
+    alignas(4) float range;
+    alignas(4) float near;
+    alignas(4) float far;
+    alignas(4) float attenuation;
+    alignas(4) float innerCutOff;
+    alignas(4) float outerCutOff;
+    alignas(4) float shadowSoftness;
+    alignas(4) float shadowTexelSize;
+    alignas(4) float shadowDepthBias;
+    alignas(4) float shadowSlopeBias;
+    alignas(4) int32_t shadowLayer;
+    alignas(4) int32_t enabled;
+    alignas(4) int32_t shadow;
+    alignas(4) int32_t type;
+} r3d_shader_block_light_t;
+
+typedef struct {
+    alignas(16) r3d_shader_block_light_t uLights[R3D_SHADER_NUM_FORWARD_LIGHTS];
+    alignas(4) int32_t uNumLights;
+} r3d_shader_block_light_array_t;
 
 // ========================================
 // SHADER STRUCTURES DECLARATIONS
@@ -407,7 +439,6 @@ typedef struct {
 typedef struct {
     unsigned int id;
     r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
-    r3d_shader_uniform_mat4_t uLightViewProj[R3D_SHADER_NUM_FORWARD_LIGHTS];
     r3d_shader_uniform_mat4_t uMatNormal;
     r3d_shader_uniform_mat4_t uMatModel;
     r3d_shader_uniform_col4_t uAlbedoColor;
@@ -433,27 +464,6 @@ typedef struct {
     r3d_shader_uniform_float_t uRoughness;
     r3d_shader_uniform_float_t uMetalness;
     r3d_shader_uniform_vec3_t uViewPosition;
-    struct {
-        r3d_shader_uniform_vec3_t color;
-        r3d_shader_uniform_vec3_t position;
-        r3d_shader_uniform_vec3_t direction;
-        r3d_shader_uniform_float_t specular;
-        r3d_shader_uniform_float_t energy;
-        r3d_shader_uniform_float_t range;
-        r3d_shader_uniform_float_t near;
-        r3d_shader_uniform_float_t far;
-        r3d_shader_uniform_float_t attenuation;
-        r3d_shader_uniform_float_t innerCutOff;
-        r3d_shader_uniform_float_t outerCutOff;
-        r3d_shader_uniform_float_t shadowSoftness;
-        r3d_shader_uniform_float_t shadowTexelSize;
-        r3d_shader_uniform_float_t shadowDepthBias;
-        r3d_shader_uniform_float_t shadowSlopeBias;
-        r3d_shader_uniform_int_t shadowLayer;
-        r3d_shader_uniform_int_t type;
-        r3d_shader_uniform_int_t enabled;
-        r3d_shader_uniform_int_t shadow;
-    } uLights[R3D_SHADER_NUM_FORWARD_LIGHTS];
 } r3d_shader_scene_forward_t;
 
 typedef struct {
@@ -493,7 +503,6 @@ typedef struct {
 typedef struct {
     unsigned int id;
     r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
-    r3d_shader_uniform_mat4_t uLightViewProj[R3D_SHADER_NUM_FORWARD_LIGHTS];
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatNormal;
     r3d_shader_uniform_mat4_t uMatModel;
@@ -522,27 +531,6 @@ typedef struct {
     r3d_shader_uniform_float_t uMetalness;
     r3d_shader_uniform_vec3_t uViewPosition;
     r3d_shader_uniform_int_t uProbeInterior;
-    struct {
-        r3d_shader_uniform_vec3_t color;
-        r3d_shader_uniform_vec3_t position;
-        r3d_shader_uniform_vec3_t direction;
-        r3d_shader_uniform_float_t specular;
-        r3d_shader_uniform_float_t energy;
-        r3d_shader_uniform_float_t range;
-        r3d_shader_uniform_float_t near;
-        r3d_shader_uniform_float_t far;
-        r3d_shader_uniform_float_t attenuation;
-        r3d_shader_uniform_float_t innerCutOff;
-        r3d_shader_uniform_float_t outerCutOff;
-        r3d_shader_uniform_float_t shadowSoftness;
-        r3d_shader_uniform_float_t shadowTexelSize;
-        r3d_shader_uniform_float_t shadowDepthBias;
-        r3d_shader_uniform_float_t shadowSlopeBias;
-        r3d_shader_uniform_int_t shadowLayer;
-        r3d_shader_uniform_int_t type;
-        r3d_shader_uniform_int_t enabled;
-        r3d_shader_uniform_int_t shadow;
-    } uLights[R3D_SHADER_NUM_FORWARD_LIGHTS];
 } r3d_shader_scene_probe_t;
 
 typedef struct {
@@ -598,27 +586,6 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    struct {
-        r3d_shader_uniform_mat4_t viewProj;
-        r3d_shader_uniform_vec3_t color;
-        r3d_shader_uniform_vec3_t position;
-        r3d_shader_uniform_vec3_t direction;
-        r3d_shader_uniform_float_t specular;
-        r3d_shader_uniform_float_t energy;
-        r3d_shader_uniform_float_t range;
-        r3d_shader_uniform_float_t near;
-        r3d_shader_uniform_float_t far;
-        r3d_shader_uniform_float_t attenuation;
-        r3d_shader_uniform_float_t innerCutOff;
-        r3d_shader_uniform_float_t outerCutOff;
-        r3d_shader_uniform_float_t shadowSoftness;
-        r3d_shader_uniform_float_t shadowTexelSize;
-        r3d_shader_uniform_float_t shadowDepthBias;
-        r3d_shader_uniform_float_t shadowSlopeBias;
-        r3d_shader_uniform_int_t shadowLayer;
-        r3d_shader_uniform_int_t type;
-        r3d_shader_uniform_int_t shadow;
-    } uLight;
     r3d_shader_uniform_sampler2D_t uAlbedoTex;
     r3d_shader_uniform_sampler2D_t uNormalTex;
     r3d_shader_uniform_sampler2D_t uDepthTex;

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -62,6 +62,11 @@
     glBindTexture(GL_TEXTURE_CUBE_MAP, (texId));                                                    \
 } while(0)
 
+#define R3D_SHADER_BIND_SAMPLER_2D_ARRAY(shader_name, uniform, texId) do {                          \
+    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slot2DArr);                    \
+    glBindTexture(GL_TEXTURE_2D_ARRAY, (texId));                                                    \
+} while(0)
+
 #define R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(shader_name, uniform, texId) do {                        \
     glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slotCubeArr);                  \
     glBindTexture(GL_TEXTURE_CUBE_MAP_ARRAY, (texId));                                              \
@@ -80,6 +85,11 @@
 #define R3D_SHADER_UNBIND_SAMPLER_CUBE(shader_name, uniform) do {                                   \
     glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slotCube);                     \
     glBindTexture(GL_TEXTURE_CUBE_MAP, 0);                                                          \
+} while(0)
+
+#define R3D_SHADER_UNBIND_SAMPLER_2D_ARRAY(shader_name, uniform) do {                               \
+    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slot2DArr);                    \
+    glBindTexture(GL_TEXTURE_2D_ARRAY, 0);                                                          \
 } while(0)
 
 #define R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(shader_name, uniform) do {                             \
@@ -168,6 +178,7 @@
 typedef struct { int slot1D; int loc; } r3d_shader_uniform_sampler1D_t;
 typedef struct { int slot2D; int loc; } r3d_shader_uniform_sampler2D_t;
 typedef struct { int slotCube; int loc; } r3d_shader_uniform_samplerCube_t;
+typedef struct { int slot2DArr; int loc; } r3d_shader_uniform_sampler2DArray_t;
 typedef struct { int slotCubeArr; int loc; } r3d_shader_uniform_samplerCubeArray_t;
 
 typedef struct { int val; int loc; } r3d_shader_uniform_int_t;
@@ -411,8 +422,9 @@ typedef struct {
     r3d_shader_uniform_sampler2D_t uEmissionMap;
     r3d_shader_uniform_sampler2D_t uNormalMap;
     r3d_shader_uniform_sampler2D_t uOrmMap;
-    r3d_shader_uniform_samplerCube_t uShadowMapCube[R3D_SHADER_NUM_FORWARD_LIGHTS];
-    r3d_shader_uniform_sampler2D_t uShadowMap2D[R3D_SHADER_NUM_FORWARD_LIGHTS];
+    r3d_shader_uniform_sampler2DArray_t uShadowDirTex;
+    r3d_shader_uniform_sampler2DArray_t uShadowSpotTex;
+    r3d_shader_uniform_samplerCubeArray_t uShadowOmniTex;
     r3d_shader_uniform_samplerCubeArray_t uIrradianceTex;
     r3d_shader_uniform_samplerCubeArray_t uPrefilterTex;
     r3d_shader_uniform_sampler2D_t uBrdfLutTex;
@@ -437,6 +449,7 @@ typedef struct {
         r3d_shader_uniform_float_t shadowTexelSize;
         r3d_shader_uniform_float_t shadowDepthBias;
         r3d_shader_uniform_float_t shadowSlopeBias;
+        r3d_shader_uniform_int_t shadowLayer;
         r3d_shader_uniform_int_t type;
         r3d_shader_uniform_int_t enabled;
         r3d_shader_uniform_int_t shadow;
@@ -497,8 +510,9 @@ typedef struct {
     r3d_shader_uniform_sampler2D_t uEmissionMap;
     r3d_shader_uniform_sampler2D_t uNormalMap;
     r3d_shader_uniform_sampler2D_t uOrmMap;
-    r3d_shader_uniform_samplerCube_t uShadowMapCube[R3D_SHADER_NUM_FORWARD_LIGHTS];
-    r3d_shader_uniform_sampler2D_t uShadowMap2D[R3D_SHADER_NUM_FORWARD_LIGHTS];
+    r3d_shader_uniform_sampler2DArray_t uShadowDirTex;
+    r3d_shader_uniform_sampler2DArray_t uShadowSpotTex;
+    r3d_shader_uniform_samplerCubeArray_t uShadowOmniTex;
     r3d_shader_uniform_samplerCubeArray_t uIrradianceTex;
     r3d_shader_uniform_samplerCubeArray_t uPrefilterTex;
     r3d_shader_uniform_sampler2D_t uBrdfLutTex;
@@ -524,6 +538,7 @@ typedef struct {
         r3d_shader_uniform_float_t shadowTexelSize;
         r3d_shader_uniform_float_t shadowDepthBias;
         r3d_shader_uniform_float_t shadowSlopeBias;
+        r3d_shader_uniform_int_t shadowLayer;
         r3d_shader_uniform_int_t type;
         r3d_shader_uniform_int_t enabled;
         r3d_shader_uniform_int_t shadow;
@@ -584,9 +599,7 @@ typedef struct {
 typedef struct {
     unsigned int id;
     struct {
-        r3d_shader_uniform_mat4_t matVP;
-        r3d_shader_uniform_sampler2D_t shadowMap;
-        r3d_shader_uniform_samplerCube_t shadowCubemap;
+        r3d_shader_uniform_mat4_t viewProj;
         r3d_shader_uniform_vec3_t color;
         r3d_shader_uniform_vec3_t position;
         r3d_shader_uniform_vec3_t direction;
@@ -602,6 +615,7 @@ typedef struct {
         r3d_shader_uniform_float_t shadowTexelSize;
         r3d_shader_uniform_float_t shadowDepthBias;
         r3d_shader_uniform_float_t shadowSlopeBias;
+        r3d_shader_uniform_int_t shadowLayer;
         r3d_shader_uniform_int_t type;
         r3d_shader_uniform_int_t shadow;
     } uLight;
@@ -610,6 +624,9 @@ typedef struct {
     r3d_shader_uniform_sampler2D_t uDepthTex;
     r3d_shader_uniform_sampler2D_t uSsaoTex;
     r3d_shader_uniform_sampler2D_t uOrmTex;
+    r3d_shader_uniform_sampler2DArray_t uShadowDirTex;
+    r3d_shader_uniform_sampler2DArray_t uShadowSpotTex;
+    r3d_shader_uniform_samplerCubeArray_t uShadowOmniTex;
     r3d_shader_uniform_float_t uSSAOLightAffect;
 } r3d_shader_deferred_lighting_t;
 

--- a/src/r3d_lighting.c
+++ b/src/r3d_lighting.c
@@ -256,10 +256,10 @@ void R3D_SetLightOuterCutOff(R3D_Light id, float degrees)
     light->outerCutOff = cosf(degrees * DEG2RAD);
 }
 
-void R3D_EnableShadow(R3D_Light id, int resolution)
+void R3D_EnableShadow(R3D_Light id)
 {
     GET_LIGHT_OR_RETURN(light, id);
-    r3d_light_enable_shadows(light, resolution);
+    r3d_light_enable_shadows(light);
 }
 
 void R3D_DisableShadow(R3D_Light id)


### PR DESCRIPTION
The lighting module has been completely reworked.

Shadows are now handled using texture arrays, and light data is sent to shaders through UBOs.

One drawback of the new shadow system is that resolution is no longer configurable per-light. In practice, this setting shouldn't be exposed anyway, at best it could be managed through an atlas, which may be revisited later.

The major benefit is that this finally removes the sampler limit issues that occurred on some devices.

By default, shadow map sizes are 2048 for spot and omni lights, and 4096 for directional lights (these values are configurable through defines).

Using UBOs significantly reduces code complexity, as well as the number of checks and API calls.

Several issues in the lighting module were also fixed. On my machine, I observed about a ~20 FPS improvement in the `lights.c` example, and the startup slowdowns have completely disappeared.

---

This PR finally concludes the roadmap, however there are still a few minor internal adjustments to be made, which I will try to complete as quickly as possible, then I will allow a little more time before the release of 0.7