### PR TITLE
[internal] Binding point review

### DIFF
--- a/src/common/r3d_pass.c
+++ b/src/common/r3d_pass.c
@@ -25,7 +25,7 @@ void r3d_pass_prepare_irradiance(int layerMap, GLuint srcCubemap, int srcSize)
     const Matrix matProj = MatrixPerspective(90.0 * DEG2RAD, 1.0, 0.1, 10.0);
 
     R3D_SHADER_USE(prepare.cubemapIrradiance);
-    R3D_SHADER_BIND_SAMPLER_CUBE(prepare.cubemapIrradiance, uSourceTex, srcCubemap);
+    R3D_SHADER_BIND_SAMPLER(prepare.cubemapIrradiance, uSourceTex, srcCubemap);
 
     R3D_SHADER_SET_MAT4(prepare.cubemapIrradiance, uMatProj, matProj);
 
@@ -38,7 +38,6 @@ void r3d_pass_prepare_irradiance(int layerMap, GLuint srcCubemap, int srcSize)
         R3D_PRIMITIVE_DRAW_CUBE();
     }
 
-    R3D_SHADER_UNBIND_SAMPLER_CUBE(prepare.cubemapIrradiance, uSourceTex);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     glViewport(0, 0, rlGetFramebufferWidth(), rlGetFramebufferHeight());
@@ -52,7 +51,7 @@ void r3d_pass_prepare_prefilter(int layerMap, GLuint srcCubemap, int srcSize)
     int srcNumLevels = 1 + (int)floor(log2(srcSize));
 
     R3D_SHADER_USE(prepare.cubemapPrefilter);
-    R3D_SHADER_BIND_SAMPLER_CUBE(prepare.cubemapPrefilter, uSourceTex, srcCubemap);
+    R3D_SHADER_BIND_SAMPLER(prepare.cubemapPrefilter, uSourceTex, srcCubemap);
 
     R3D_SHADER_SET_MAT4(prepare.cubemapPrefilter, uMatProj, matProj);
     R3D_SHADER_SET_FLOAT(prepare.cubemapPrefilter, uSourceNumLevels, srcNumLevels);
@@ -72,7 +71,6 @@ void r3d_pass_prepare_prefilter(int layerMap, GLuint srcCubemap, int srcSize)
         }
     }
 
-    R3D_SHADER_UNBIND_SAMPLER_CUBE(prepare.cubemapPrefilter, uSourceTex);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
     glViewport(0, 0, rlGetFramebufferWidth(), rlGetFramebufferHeight());

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -827,6 +827,7 @@ void r3d_shader_bind_sampler(r3d_shader_sampler_t sampler, GLuint texture)
         glActiveTexture(GL_TEXTURE0 + sampler);
         glBindTexture(R3D_MOD_SHADER_SAMPLER_TYPES[sampler], texture);
         R3D_MOD_SHADER.samplerBindings[sampler] = texture;
+        glActiveTexture(GL_TEXTURE0);
     }
 }
 

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -81,65 +81,10 @@ struct r3d_shader R3D_MOD_SHADER;
     );                                                                          \
 } while(0)
 
-#define GET_LOCATION_ARRAY(shader_name, uniform, index) do {                    \
-    char _name[64];                                                             \
-    snprintf(_name, sizeof(_name), "%s[%d]", #uniform, (int)(index));           \
-    R3D_MOD_SHADER.shader_name.uniform[index].loc =                             \
-        glGetUniformLocation(R3D_MOD_SHADER.shader_name.id, _name);             \
-} while (0)
-
-#define GET_LOCATION_ARRAY_STRUCT(shader_name, array, index, member) do {       \
-    char _name[96];                                                             \
-    snprintf(                                                                   \
-        _name, sizeof(_name),                                                   \
-        "%s[%d].%s",                                                            \
-        #array, (int)(index), #member                                           \
-    );                                                                          \
-    R3D_MOD_SHADER.shader_name.array[index].member.loc =                        \
-        glGetUniformLocation(                                                   \
-            R3D_MOD_SHADER.shader_name.id,                                      \
-            _name                                                               \
-        );                                                                      \
-} while (0)
-
-#define SET_SAMPLER_1D(shader_name, uniform, value) do {                        \
-    R3D_MOD_SHADER.shader_name.uniform.slot1D = (value);                        \
-    glUniform1i(                                                                \
-        R3D_MOD_SHADER.shader_name.uniform.loc,                                 \
-        R3D_MOD_SHADER.shader_name.uniform.slot1D                               \
-    );                                                                          \
-} while(0)
-
-#define SET_SAMPLER_2D(shader_name, uniform, value) do {                        \
-    R3D_MOD_SHADER.shader_name.uniform.slot2D = (value);                        \
-    glUniform1i(                                                                \
-        R3D_MOD_SHADER.shader_name.uniform.loc,                                 \
-        R3D_MOD_SHADER.shader_name.uniform.slot2D                               \
-    );                                                                          \
-} while(0)
-
-#define SET_SAMPLER_CUBE(shader_name, uniform, value) do {                      \
-    R3D_MOD_SHADER.shader_name.uniform.slotCube = (value);                      \
-    glUniform1i(                                                                \
-        R3D_MOD_SHADER.shader_name.uniform.loc,                                 \
-        R3D_MOD_SHADER.shader_name.uniform.slotCube                             \
-    );                                                                          \
-} while(0)
-
-#define SET_SAMPLER_2D_ARRAY(shader_name, uniform, value) do {                  \
-    R3D_MOD_SHADER.shader_name.uniform.slot2DArr = (value);                     \
-    glUniform1i(                                                                \
-        R3D_MOD_SHADER.shader_name.uniform.loc,                                 \
-        R3D_MOD_SHADER.shader_name.uniform.slot2DArr                            \
-    );                                                                          \
-} while(0)
-
-#define SET_SAMPLER_CUBE_ARRAY(shader_name, uniform, value) do {                \
-    R3D_MOD_SHADER.shader_name.uniform.slotCubeArr = (value);                   \
-    glUniform1i(                                                                \
-        R3D_MOD_SHADER.shader_name.uniform.loc,                                 \
-        R3D_MOD_SHADER.shader_name.uniform.slotCubeArr                          \
-    );                                                                          \
+#define SET_SAMPLER(shader_name, uniform, value) do {                           \
+    GLint loc = glGetUniformLocation(R3D_MOD_SHADER.shader_name.id, #uniform);  \
+    glUniform1i(loc, (int)(value));                                             \
+    R3D_MOD_SHADER.shader_name.uniform.slot = (int)(value);                     \
 } while(0)
 
 #define SET_UNIFORM_BUFFER(shader_name, uniform, slot) do {                     \
@@ -242,37 +187,28 @@ GLuint load_shader(const char* vsCode, const char* fsCode)
 void r3d_shader_load_prepare_atrous_wavelet(void)
 {
     LOAD_SHADER(prepare.atrousWavelet, SCREEN_VERT, ATROUS_WAVELET_FRAG);
-
     SET_UNIFORM_BUFFER(prepare.atrousWavelet, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
-
-    GET_LOCATION(prepare.atrousWavelet, uSourceTex);
-    GET_LOCATION(prepare.atrousWavelet, uNormalTex);
-    GET_LOCATION(prepare.atrousWavelet, uDepthTex);
     GET_LOCATION(prepare.atrousWavelet, uStepSize);
-
     USE_SHADER(prepare.atrousWavelet);
-
-    SET_SAMPLER_2D(prepare.atrousWavelet, uSourceTex, 0);
-    SET_SAMPLER_2D(prepare.atrousWavelet, uNormalTex, 1);
-    SET_SAMPLER_2D(prepare.atrousWavelet, uDepthTex, 2);
+    SET_SAMPLER(prepare.atrousWavelet, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D);
+    SET_SAMPLER(prepare.atrousWavelet, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
+    SET_SAMPLER(prepare.atrousWavelet, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 }
 
 void r3d_shader_load_prepare_blur_down(void)
 {
     LOAD_SHADER(prepare.blurDown, SCREEN_VERT, BLUR_DOWN_FRAG);
-    GET_LOCATION(prepare.blurDown, uSourceTex);
     GET_LOCATION(prepare.blurDown, uSourceLod);
     USE_SHADER(prepare.blurDown);
-    SET_SAMPLER_2D(prepare.blurDown, uSourceTex, 0);
+    SET_SAMPLER(prepare.blurDown, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D);
 }
 
 void r3d_shader_load_prepare_blur_up(void)
 {
     LOAD_SHADER(prepare.blurUp, SCREEN_VERT, BLUR_UP_FRAG);
-    GET_LOCATION(prepare.blurUp, uSourceTex);
     GET_LOCATION(prepare.blurUp, uSourceLod);
     USE_SHADER(prepare.blurUp);
-    SET_SAMPLER_2D(prepare.blurUp, uSourceTex, 0);
+    SET_SAMPLER(prepare.blurUp, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D);
 }
 
 void r3d_shader_load_prepare_ssao(void)
@@ -281,8 +217,6 @@ void r3d_shader_load_prepare_ssao(void)
 
     SET_UNIFORM_BUFFER(prepare.ssao, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(prepare.ssao, uNormalTex);
-    GET_LOCATION(prepare.ssao, uDepthTex);
     GET_LOCATION(prepare.ssao, uSampleCount);
     GET_LOCATION(prepare.ssao, uRadius);
     GET_LOCATION(prepare.ssao, uBias);
@@ -291,8 +225,8 @@ void r3d_shader_load_prepare_ssao(void)
 
     USE_SHADER(prepare.ssao);
 
-    SET_SAMPLER_2D(prepare.ssao, uNormalTex, 0);
-    SET_SAMPLER_2D(prepare.ssao, uDepthTex, 1);
+    SET_SAMPLER(prepare.ssao, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
+    SET_SAMPLER(prepare.ssao, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 }
 
 void r3d_shader_load_prepare_ssil(void)
@@ -301,10 +235,6 @@ void r3d_shader_load_prepare_ssil(void)
 
     SET_UNIFORM_BUFFER(prepare.ssil, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(prepare.ssil, uLightingTex);
-    GET_LOCATION(prepare.ssil, uHistoryTex);
-    GET_LOCATION(prepare.ssil, uNormalTex);
-    GET_LOCATION(prepare.ssil, uDepthTex);
     GET_LOCATION(prepare.ssil, uSampleCount);
     GET_LOCATION(prepare.ssil, uSampleRadius);
     GET_LOCATION(prepare.ssil, uSliceCount);
@@ -316,10 +246,10 @@ void r3d_shader_load_prepare_ssil(void)
 
     USE_SHADER(prepare.ssil);
 
-    SET_SAMPLER_2D(prepare.ssil, uLightingTex, 0);
-    SET_SAMPLER_2D(prepare.ssil, uHistoryTex, 1);
-    SET_SAMPLER_2D(prepare.ssil, uNormalTex, 2);
-    SET_SAMPLER_2D(prepare.ssil, uDepthTex, 3);
+    SET_SAMPLER(prepare.ssil, uLightingTex, R3D_SHADER_SAMPLER_BUFFER_DIFFUSE);
+    SET_SAMPLER(prepare.ssil, uHistoryTex, R3D_SHADER_SAMPLER_BUFFER_SSIL);
+    SET_SAMPLER(prepare.ssil, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
+    SET_SAMPLER(prepare.ssil, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 }
 
 void r3d_shader_load_prepare_ssr(void)
@@ -328,11 +258,6 @@ void r3d_shader_load_prepare_ssr(void)
 
     SET_UNIFORM_BUFFER(prepare.ssr, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(prepare.ssr, uLightingTex);
-    GET_LOCATION(prepare.ssr, uAlbedoTex);
-    GET_LOCATION(prepare.ssr, uNormalTex);
-    GET_LOCATION(prepare.ssr, uOrmTex);
-    GET_LOCATION(prepare.ssr, uDepthTex);
     GET_LOCATION(prepare.ssr, uMaxRaySteps);
     GET_LOCATION(prepare.ssr, uBinarySearchSteps);
     GET_LOCATION(prepare.ssr, uRayMarchLength);
@@ -345,52 +270,49 @@ void r3d_shader_load_prepare_ssr(void)
 
     USE_SHADER(prepare.ssr);
 
-    SET_SAMPLER_2D(prepare.ssr, uLightingTex, 0);
-    SET_SAMPLER_2D(prepare.ssr, uAlbedoTex, 1);
-    SET_SAMPLER_2D(prepare.ssr, uNormalTex, 2);
-    SET_SAMPLER_2D(prepare.ssr, uOrmTex, 3);
-    SET_SAMPLER_2D(prepare.ssr, uDepthTex, 4);
+    SET_SAMPLER(prepare.ssr, uLightingTex, R3D_SHADER_SAMPLER_BUFFER_DIFFUSE);
+    SET_SAMPLER(prepare.ssr, uAlbedoTex, R3D_SHADER_SAMPLER_BUFFER_ALBEDO);
+    SET_SAMPLER(prepare.ssr, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
+    SET_SAMPLER(prepare.ssr, uOrmTex, R3D_SHADER_SAMPLER_BUFFER_ORM);
+    SET_SAMPLER(prepare.ssr, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 }
 
 void r3d_shader_load_prepare_bloom_down(void)
 {
     LOAD_SHADER(prepare.bloomDown, SCREEN_VERT, BLOOM_DOWN_FRAG);
 
-    GET_LOCATION(prepare.bloomDown, uTexture);
     GET_LOCATION(prepare.bloomDown, uTexelSize);
     GET_LOCATION(prepare.bloomDown, uPrefilter);
     GET_LOCATION(prepare.bloomDown, uDstLevel);
 
     USE_SHADER(prepare.bloomDown);
 
-    SET_SAMPLER_2D(prepare.bloomDown, uTexture, 0);
+    SET_SAMPLER(prepare.bloomDown, uTexture, R3D_SHADER_SAMPLER_BUFFER_BLOOM);
 }
 
 void r3d_shader_load_prepare_bloom_up(void)
 {
     LOAD_SHADER(prepare.bloomUp, SCREEN_VERT, BLOOM_UP_FRAG);
 
-    GET_LOCATION(prepare.bloomUp, uTexture);
     GET_LOCATION(prepare.bloomUp, uFilterRadius);
     GET_LOCATION(prepare.bloomUp, uSrcLevel);
 
     USE_SHADER(prepare.bloomUp);
 
-    SET_SAMPLER_2D(prepare.bloomUp, uTexture, 0);
+    SET_SAMPLER(prepare.bloomUp, uTexture, R3D_SHADER_SAMPLER_BUFFER_BLOOM);
 }
 
 void r3d_shader_load_prepare_cubeface_down(void)
 {
     LOAD_SHADER(prepare.cubefaceDown, SCREEN_VERT, CUBEFACE_DOWN_FRAG);
 
-    GET_LOCATION(prepare.cubefaceDown, uSourceTex);
     GET_LOCATION(prepare.cubefaceDown, uSourceTexel);
     GET_LOCATION(prepare.cubefaceDown, uSourceLod);
     GET_LOCATION(prepare.cubefaceDown, uSourceFace);
 
     USE_SHADER(prepare.cubefaceDown);
 
-    SET_SAMPLER_CUBE(prepare.cubefaceDown, uSourceTex, 0);
+    SET_SAMPLER(prepare.cubefaceDown, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_CUBE);
 }
 
 void r3d_shader_load_prepare_cubemap_from_equirectangular(void)
@@ -399,11 +321,10 @@ void r3d_shader_load_prepare_cubemap_from_equirectangular(void)
 
     GET_LOCATION(prepare.cubemapFromEquirectangular, uMatProj);
     GET_LOCATION(prepare.cubemapFromEquirectangular, uMatView);
-    GET_LOCATION(prepare.cubemapFromEquirectangular, uPanoramaTex);
 
     USE_SHADER(prepare.cubemapFromEquirectangular);
 
-    SET_SAMPLER_2D(prepare.cubemapFromEquirectangular, uPanoramaTex, 0);
+    SET_SAMPLER(prepare.cubemapFromEquirectangular, uPanoramaTex, R3D_SHADER_SAMPLER_SOURCE_CUBE);
 }
 
 void r3d_shader_load_prepare_cubemap_irradiance(void)
@@ -412,11 +333,10 @@ void r3d_shader_load_prepare_cubemap_irradiance(void)
 
     GET_LOCATION(prepare.cubemapIrradiance, uMatProj);
     GET_LOCATION(prepare.cubemapIrradiance, uMatView);
-    GET_LOCATION(prepare.cubemapIrradiance, uSourceTex);
 
     USE_SHADER(prepare.cubemapIrradiance);
 
-    SET_SAMPLER_CUBE(prepare.cubemapIrradiance, uSourceTex, 0);
+    SET_SAMPLER(prepare.cubemapIrradiance, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_CUBE);
 }
 
 void r3d_shader_load_prepare_cubemap_prefilter(void)
@@ -425,14 +345,13 @@ void r3d_shader_load_prepare_cubemap_prefilter(void)
 
     GET_LOCATION(prepare.cubemapPrefilter, uMatProj);
     GET_LOCATION(prepare.cubemapPrefilter, uMatView);
-    GET_LOCATION(prepare.cubemapPrefilter, uSourceTex);
     GET_LOCATION(prepare.cubemapPrefilter, uSourceNumLevels);
     GET_LOCATION(prepare.cubemapPrefilter, uSourceFaceSize);
     GET_LOCATION(prepare.cubemapPrefilter, uRoughness);
 
     USE_SHADER(prepare.cubemapPrefilter);
 
-    SET_SAMPLER_CUBE(prepare.cubemapPrefilter, uSourceTex, 0);
+    SET_SAMPLER(prepare.cubemapPrefilter, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_CUBE);
 }
 
 void r3d_shader_load_prepare_cubemap_skybox(void)
@@ -467,7 +386,6 @@ void r3d_shader_load_scene_geometry(void)
 
     SET_UNIFORM_BUFFER(scene.geometry, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(scene.geometry, uBoneMatricesTex);
     GET_LOCATION(scene.geometry, uMatNormal);
     GET_LOCATION(scene.geometry, uMatModel);
     GET_LOCATION(scene.geometry, uAlbedoColor);
@@ -478,10 +396,6 @@ void r3d_shader_load_scene_geometry(void)
     GET_LOCATION(scene.geometry, uInstancing);
     GET_LOCATION(scene.geometry, uSkinning);
     GET_LOCATION(scene.geometry, uBillboard);
-    GET_LOCATION(scene.geometry, uAlbedoMap);
-    GET_LOCATION(scene.geometry, uNormalMap);
-    GET_LOCATION(scene.geometry, uEmissionMap);
-    GET_LOCATION(scene.geometry, uOrmMap);
     GET_LOCATION(scene.geometry, uAlphaCutoff);
     GET_LOCATION(scene.geometry, uNormalScale);
     GET_LOCATION(scene.geometry, uOcclusion);
@@ -490,11 +404,11 @@ void r3d_shader_load_scene_geometry(void)
 
     USE_SHADER(scene.geometry);
 
-    SET_SAMPLER_1D(scene.geometry, uBoneMatricesTex, 0);
-    SET_SAMPLER_2D(scene.geometry, uAlbedoMap, 1);
-    SET_SAMPLER_2D(scene.geometry, uNormalMap, 2);
-    SET_SAMPLER_2D(scene.geometry, uEmissionMap, 3);
-    SET_SAMPLER_2D(scene.geometry, uOrmMap, 4);
+    SET_SAMPLER(scene.geometry, uBoneMatricesTex, R3D_SHADER_SAMPLER_BONE_MATRICES);
+    SET_SAMPLER(scene.geometry, uAlbedoMap, R3D_SHADER_SAMPLER_MAP_ALBEDO);
+    SET_SAMPLER(scene.geometry, uNormalMap, R3D_SHADER_SAMPLER_MAP_NORMAL);
+    SET_SAMPLER(scene.geometry, uEmissionMap, R3D_SHADER_SAMPLER_MAP_EMISSION);
+    SET_SAMPLER(scene.geometry, uOrmMap, R3D_SHADER_SAMPLER_MAP_ORM);
 }
 
 void r3d_shader_load_scene_forward(void)
@@ -518,7 +432,6 @@ void r3d_shader_load_scene_forward(void)
     SET_UNIFORM_BUFFER(scene.forward, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(scene.forward, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
-    GET_LOCATION(scene.forward, uBoneMatricesTex);
     GET_LOCATION(scene.forward, uMatNormal);
     GET_LOCATION(scene.forward, uMatModel);
     GET_LOCATION(scene.forward, uAlbedoColor);
@@ -529,16 +442,6 @@ void r3d_shader_load_scene_forward(void)
     GET_LOCATION(scene.forward, uInstancing);
     GET_LOCATION(scene.forward, uSkinning);
     GET_LOCATION(scene.forward, uBillboard);
-    GET_LOCATION(scene.forward, uAlbedoMap);
-    GET_LOCATION(scene.forward, uEmissionMap);
-    GET_LOCATION(scene.forward, uNormalMap);
-    GET_LOCATION(scene.forward, uOrmMap);
-    GET_LOCATION(scene.forward, uShadowDirTex);
-    GET_LOCATION(scene.forward, uShadowSpotTex);
-    GET_LOCATION(scene.forward, uShadowOmniTex);
-    GET_LOCATION(scene.forward, uIrradianceTex);
-    GET_LOCATION(scene.forward, uPrefilterTex);
-    GET_LOCATION(scene.forward, uBrdfLutTex);
     GET_LOCATION(scene.forward, uNormalScale);
     GET_LOCATION(scene.forward, uOcclusion);
     GET_LOCATION(scene.forward, uRoughness);
@@ -547,17 +450,17 @@ void r3d_shader_load_scene_forward(void)
 
     USE_SHADER(scene.forward);
 
-    SET_SAMPLER_1D(scene.forward, uBoneMatricesTex, 0);
-    SET_SAMPLER_2D(scene.forward, uAlbedoMap, 1);
-    SET_SAMPLER_2D(scene.forward, uEmissionMap, 2);
-    SET_SAMPLER_2D(scene.forward, uNormalMap, 3);
-    SET_SAMPLER_2D(scene.forward, uOrmMap, 4);
-    SET_SAMPLER_2D_ARRAY(scene.forward, uShadowDirTex, 5);
-    SET_SAMPLER_2D_ARRAY(scene.forward, uShadowSpotTex, 6);
-    SET_SAMPLER_CUBE_ARRAY(scene.forward, uShadowOmniTex, 7);
-    SET_SAMPLER_CUBE_ARRAY(scene.forward, uIrradianceTex, 8);
-    SET_SAMPLER_CUBE_ARRAY(scene.forward, uPrefilterTex, 9);
-    SET_SAMPLER_2D(scene.forward, uBrdfLutTex, 10);
+    SET_SAMPLER(scene.forward, uBoneMatricesTex, R3D_SHADER_SAMPLER_BONE_MATRICES);
+    SET_SAMPLER(scene.forward, uAlbedoMap, R3D_SHADER_SAMPLER_MAP_ALBEDO);
+    SET_SAMPLER(scene.forward, uEmissionMap, R3D_SHADER_SAMPLER_MAP_EMISSION);
+    SET_SAMPLER(scene.forward, uNormalMap, R3D_SHADER_SAMPLER_MAP_NORMAL);
+    SET_SAMPLER(scene.forward, uOrmMap, R3D_SHADER_SAMPLER_MAP_ORM);
+    SET_SAMPLER(scene.forward, uShadowDirTex, R3D_SHADER_SAMPLER_SHADOW_DIR);
+    SET_SAMPLER(scene.forward, uShadowSpotTex, R3D_SHADER_SAMPLER_SHADOW_SPOT);
+    SET_SAMPLER(scene.forward, uShadowOmniTex, R3D_SHADER_SAMPLER_SHADOW_OMNI);
+    SET_SAMPLER(scene.forward, uIrradianceTex, R3D_SHADER_SAMPLER_IBL_IRRADIANCE);
+    SET_SAMPLER(scene.forward, uPrefilterTex, R3D_SHADER_SAMPLER_IBL_PREFILTER);
+    SET_SAMPLER(scene.forward, uBrdfLutTex, R3D_SHADER_SAMPLER_IBL_BRDF_LUT);
 }
 
 void r3d_shader_load_scene_background(void)
@@ -573,12 +476,11 @@ void r3d_shader_load_scene_skybox(void)
     GET_LOCATION(scene.skybox, uRotation);
     GET_LOCATION(scene.skybox, uMatView);
     GET_LOCATION(scene.skybox, uMatProj);
-    GET_LOCATION(scene.skybox, uSkyMap);
     GET_LOCATION(scene.skybox, uSkyEnergy);
 
     USE_SHADER(scene.skybox);
 
-    SET_SAMPLER_CUBE(scene.skybox, uSkyMap, 0);
+    SET_SAMPLER(scene.skybox, uSkyMap, R3D_SHADER_SAMPLER_SOURCE_CUBE);
 }
 
 void r3d_shader_load_scene_depth(void)
@@ -588,7 +490,6 @@ void r3d_shader_load_scene_depth(void)
     LOAD_SHADER(scene.depth, vsCode, DEPTH_FRAG);
     RL_FREE(vsCode);
 
-    GET_LOCATION(scene.depth, uBoneMatricesTex);
     GET_LOCATION(scene.depth, uMatInvView);
     GET_LOCATION(scene.depth, uMatModel);
     GET_LOCATION(scene.depth, uMatViewProj);
@@ -598,13 +499,12 @@ void r3d_shader_load_scene_depth(void)
     GET_LOCATION(scene.depth, uInstancing);
     GET_LOCATION(scene.depth, uSkinning);
     GET_LOCATION(scene.depth, uBillboard);
-    GET_LOCATION(scene.depth, uAlbedoMap);
     GET_LOCATION(scene.depth, uAlphaCutoff);
 
     USE_SHADER(scene.depth);
 
-    SET_SAMPLER_1D(scene.depth, uBoneMatricesTex, 0);
-    SET_SAMPLER_2D(scene.depth, uAlbedoMap, 1);
+    SET_SAMPLER(scene.depth, uBoneMatricesTex, R3D_SHADER_SAMPLER_BONE_MATRICES);
+    SET_SAMPLER(scene.depth, uAlbedoMap, R3D_SHADER_SAMPLER_MAP_ALBEDO);
 }
 
 void r3d_shader_load_scene_depth_cube(void)
@@ -614,7 +514,6 @@ void r3d_shader_load_scene_depth_cube(void)
     LOAD_SHADER(scene.depthCube, vsCode, DEPTH_CUBE_FRAG);
     RL_FREE(vsCode);
 
-    GET_LOCATION(scene.depthCube, uBoneMatricesTex);
     GET_LOCATION(scene.depthCube, uMatInvView);
     GET_LOCATION(scene.depthCube, uMatModel);
     GET_LOCATION(scene.depthCube, uMatViewProj);
@@ -624,15 +523,14 @@ void r3d_shader_load_scene_depth_cube(void)
     GET_LOCATION(scene.depthCube, uInstancing);
     GET_LOCATION(scene.depthCube, uSkinning);
     GET_LOCATION(scene.depthCube, uBillboard);
-    GET_LOCATION(scene.depthCube, uAlbedoMap);
     GET_LOCATION(scene.depthCube, uAlphaCutoff);
     GET_LOCATION(scene.depthCube, uViewPosition);
     GET_LOCATION(scene.depthCube, uFar);
 
     USE_SHADER(scene.depthCube);
 
-    SET_SAMPLER_1D(scene.depthCube, uBoneMatricesTex, 0);
-    SET_SAMPLER_2D(scene.depthCube, uAlbedoMap, 1);
+    SET_SAMPLER(scene.depthCube, uBoneMatricesTex, R3D_SHADER_SAMPLER_BONE_MATRICES);
+    SET_SAMPLER(scene.depthCube, uAlbedoMap, R3D_SHADER_SAMPLER_MAP_ALBEDO);
 }
 
 void r3d_shader_load_scene_probe(void)
@@ -656,7 +554,6 @@ void r3d_shader_load_scene_probe(void)
     SET_UNIFORM_BUFFER(scene.probe, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(scene.probe, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
-    GET_LOCATION(scene.probe, uBoneMatricesTex);
     GET_LOCATION(scene.probe, uMatInvView);
     GET_LOCATION(scene.probe, uMatNormal);
     GET_LOCATION(scene.probe, uMatModel);
@@ -669,16 +566,6 @@ void r3d_shader_load_scene_probe(void)
     GET_LOCATION(scene.probe, uInstancing);
     GET_LOCATION(scene.probe, uSkinning);
     GET_LOCATION(scene.probe, uBillboard);
-    GET_LOCATION(scene.probe, uAlbedoMap);
-    GET_LOCATION(scene.probe, uEmissionMap);
-    GET_LOCATION(scene.probe, uNormalMap);
-    GET_LOCATION(scene.probe, uOrmMap);
-    GET_LOCATION(scene.probe, uShadowDirTex);
-    GET_LOCATION(scene.probe, uShadowSpotTex);
-    GET_LOCATION(scene.probe, uShadowOmniTex);
-    GET_LOCATION(scene.probe, uIrradianceTex);
-    GET_LOCATION(scene.probe, uPrefilterTex);
-    GET_LOCATION(scene.probe, uBrdfLutTex);
     GET_LOCATION(scene.probe, uNormalScale);
     GET_LOCATION(scene.probe, uOcclusion);
     GET_LOCATION(scene.probe, uRoughness);
@@ -688,17 +575,17 @@ void r3d_shader_load_scene_probe(void)
 
     USE_SHADER(scene.probe);
 
-    SET_SAMPLER_1D(scene.probe, uBoneMatricesTex, 0);
-    SET_SAMPLER_2D(scene.probe, uAlbedoMap, 1);
-    SET_SAMPLER_2D(scene.probe, uEmissionMap, 2);
-    SET_SAMPLER_2D(scene.probe, uNormalMap, 3);
-    SET_SAMPLER_2D(scene.probe, uOrmMap, 4);
-    SET_SAMPLER_2D_ARRAY(scene.probe, uShadowDirTex, 5);
-    SET_SAMPLER_2D_ARRAY(scene.probe, uShadowSpotTex, 6);
-    SET_SAMPLER_CUBE_ARRAY(scene.probe, uShadowOmniTex, 7);
-    SET_SAMPLER_CUBE_ARRAY(scene.probe, uIrradianceTex, 8);
-    SET_SAMPLER_CUBE_ARRAY(scene.probe, uPrefilterTex, 9);
-    SET_SAMPLER_2D(scene.probe, uBrdfLutTex, 10);
+    SET_SAMPLER(scene.probe, uBoneMatricesTex, R3D_SHADER_SAMPLER_BONE_MATRICES);
+    SET_SAMPLER(scene.probe, uAlbedoMap, R3D_SHADER_SAMPLER_MAP_ALBEDO);
+    SET_SAMPLER(scene.probe, uEmissionMap, R3D_SHADER_SAMPLER_MAP_EMISSION);
+    SET_SAMPLER(scene.probe, uNormalMap, R3D_SHADER_SAMPLER_MAP_NORMAL);
+    SET_SAMPLER(scene.probe, uOrmMap, R3D_SHADER_SAMPLER_MAP_ORM);
+    SET_SAMPLER(scene.probe, uShadowDirTex, R3D_SHADER_SAMPLER_SHADOW_DIR);
+    SET_SAMPLER(scene.probe, uShadowSpotTex, R3D_SHADER_SAMPLER_SHADOW_SPOT);
+    SET_SAMPLER(scene.probe, uShadowOmniTex, R3D_SHADER_SAMPLER_SHADOW_OMNI);
+    SET_SAMPLER(scene.probe, uIrradianceTex, R3D_SHADER_SAMPLER_IBL_IRRADIANCE);
+    SET_SAMPLER(scene.probe, uPrefilterTex, R3D_SHADER_SAMPLER_IBL_PREFILTER);
+    SET_SAMPLER(scene.probe, uBrdfLutTex, R3D_SHADER_SAMPLER_IBL_BRDF_LUT);
 }
 
 void r3d_shader_load_scene_decal(void)
@@ -718,11 +605,6 @@ void r3d_shader_load_scene_decal(void)
     GET_LOCATION(scene.decal, uTexCoordOffset);
     GET_LOCATION(scene.decal, uTexCoordScale);
     GET_LOCATION(scene.decal, uInstancing);
-    GET_LOCATION(scene.decal, uAlbedoMap);
-    GET_LOCATION(scene.decal, uNormalMap);
-    GET_LOCATION(scene.decal, uEmissionMap);
-    GET_LOCATION(scene.decal, uOrmMap);
-    GET_LOCATION(scene.decal, uDepthTex);
     GET_LOCATION(scene.decal, uAlphaCutoff);
     GET_LOCATION(scene.decal, uNormalScale);
     GET_LOCATION(scene.decal, uOcclusion);
@@ -731,11 +613,11 @@ void r3d_shader_load_scene_decal(void)
 
     USE_SHADER(scene.decal);
 
-    SET_SAMPLER_2D(scene.decal, uAlbedoMap, 0);
-    SET_SAMPLER_2D(scene.decal, uNormalMap, 1);
-    SET_SAMPLER_2D(scene.decal, uEmissionMap, 2);
-    SET_SAMPLER_2D(scene.decal, uOrmMap, 3);
-    SET_SAMPLER_2D(scene.decal, uDepthTex, 4);
+    SET_SAMPLER(scene.decal, uAlbedoMap, R3D_SHADER_SAMPLER_MAP_ALBEDO);
+    SET_SAMPLER(scene.decal, uNormalMap, R3D_SHADER_SAMPLER_MAP_NORMAL);
+    SET_SAMPLER(scene.decal, uEmissionMap, R3D_SHADER_SAMPLER_MAP_EMISSION);
+    SET_SAMPLER(scene.decal, uOrmMap, R3D_SHADER_SAMPLER_MAP_ORM);
+    SET_SAMPLER(scene.decal, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 }
 
 void r3d_shader_load_deferred_ambient(void)
@@ -751,31 +633,21 @@ void r3d_shader_load_deferred_ambient(void)
     SET_UNIFORM_BUFFER(deferred.ambient, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(deferred.ambient, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
-    GET_LOCATION(deferred.ambient, uAlbedoTex);
-    GET_LOCATION(deferred.ambient, uNormalTex);
-    GET_LOCATION(deferred.ambient, uDepthTex);
-    GET_LOCATION(deferred.ambient, uSsaoTex);
-    GET_LOCATION(deferred.ambient, uSsilTex);
-    GET_LOCATION(deferred.ambient, uSsrTex);
-    GET_LOCATION(deferred.ambient, uOrmTex);
-    GET_LOCATION(deferred.ambient, uIrradianceTex);
-    GET_LOCATION(deferred.ambient, uPrefilterTex);
-    GET_LOCATION(deferred.ambient, uBrdfLutTex);
     GET_LOCATION(deferred.ambient, uMipCountSSR);
 
     USE_SHADER(deferred.ambient);
 
-    SET_SAMPLER_2D(deferred.ambient, uAlbedoTex, 0);
-    SET_SAMPLER_2D(deferred.ambient, uNormalTex, 1);
-    SET_SAMPLER_2D(deferred.ambient, uDepthTex, 2);
-    SET_SAMPLER_2D(deferred.ambient, uSsaoTex, 3);
-    SET_SAMPLER_2D(deferred.ambient, uSsilTex, 4);
-    SET_SAMPLER_2D(deferred.ambient, uSsrTex, 5);
-    SET_SAMPLER_2D(deferred.ambient, uOrmTex, 6);
+    SET_SAMPLER(deferred.ambient, uAlbedoTex, R3D_SHADER_SAMPLER_BUFFER_ALBEDO);
+    SET_SAMPLER(deferred.ambient, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
+    SET_SAMPLER(deferred.ambient, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+    SET_SAMPLER(deferred.ambient, uSsaoTex, R3D_SHADER_SAMPLER_BUFFER_SSAO);
+    SET_SAMPLER(deferred.ambient, uSsilTex, R3D_SHADER_SAMPLER_BUFFER_SSIL);
+    SET_SAMPLER(deferred.ambient, uSsrTex, R3D_SHADER_SAMPLER_BUFFER_SSR);
+    SET_SAMPLER(deferred.ambient, uOrmTex, R3D_SHADER_SAMPLER_BUFFER_ORM);
 
-    SET_SAMPLER_CUBE_ARRAY(deferred.ambient, uIrradianceTex, 7);
-    SET_SAMPLER_CUBE_ARRAY(deferred.ambient, uPrefilterTex, 8);
-    SET_SAMPLER_2D(deferred.ambient, uBrdfLutTex, 9);
+    SET_SAMPLER(deferred.ambient, uIrradianceTex, R3D_SHADER_SAMPLER_IBL_IRRADIANCE);
+    SET_SAMPLER(deferred.ambient, uPrefilterTex, R3D_SHADER_SAMPLER_IBL_PREFILTER);
+    SET_SAMPLER(deferred.ambient, uBrdfLutTex, R3D_SHADER_SAMPLER_IBL_BRDF_LUT);
 }
 
 void r3d_shader_load_deferred_lighting(void)
@@ -785,57 +657,42 @@ void r3d_shader_load_deferred_lighting(void)
     SET_UNIFORM_BUFFER(deferred.lighting, LightBlock, R3D_SHADER_BLOCK_LIGHT_SLOT);
     SET_UNIFORM_BUFFER(deferred.lighting, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(deferred.lighting, uAlbedoTex);
-    GET_LOCATION(deferred.lighting, uNormalTex);
-    GET_LOCATION(deferred.lighting, uDepthTex);
-    GET_LOCATION(deferred.lighting, uSsaoTex);
-    GET_LOCATION(deferred.lighting, uOrmTex);
-
-    GET_LOCATION(deferred.lighting, uShadowDirTex);
-    GET_LOCATION(deferred.lighting, uShadowSpotTex);
-    GET_LOCATION(deferred.lighting, uShadowOmniTex);
-
     GET_LOCATION(deferred.lighting, uSSAOLightAffect);
 
     USE_SHADER(deferred.lighting);
 
-    SET_SAMPLER_2D(deferred.lighting, uAlbedoTex, 0);
-    SET_SAMPLER_2D(deferred.lighting, uNormalTex, 1);
-    SET_SAMPLER_2D(deferred.lighting, uDepthTex, 2);
-    SET_SAMPLER_2D(deferred.lighting, uSsaoTex, 3);
-    SET_SAMPLER_2D(deferred.lighting, uOrmTex, 4);
+    SET_SAMPLER(deferred.lighting, uAlbedoTex, R3D_SHADER_SAMPLER_BUFFER_ALBEDO);
+    SET_SAMPLER(deferred.lighting, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
+    SET_SAMPLER(deferred.lighting, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+    SET_SAMPLER(deferred.lighting, uSsaoTex, R3D_SHADER_SAMPLER_BUFFER_SSAO);
+    SET_SAMPLER(deferred.lighting, uOrmTex, R3D_SHADER_SAMPLER_BUFFER_ORM);
 
-    SET_SAMPLER_2D_ARRAY(deferred.lighting, uShadowDirTex, 5);
-    SET_SAMPLER_2D_ARRAY(deferred.lighting, uShadowSpotTex, 6);
-    SET_SAMPLER_CUBE_ARRAY(deferred.lighting, uShadowOmniTex, 7);
+    SET_SAMPLER(deferred.lighting, uShadowDirTex, R3D_SHADER_SAMPLER_SHADOW_DIR);
+    SET_SAMPLER(deferred.lighting, uShadowSpotTex, R3D_SHADER_SAMPLER_SHADOW_SPOT);
+    SET_SAMPLER(deferred.lighting, uShadowOmniTex, R3D_SHADER_SAMPLER_SHADOW_OMNI);
 }
 
 void r3d_shader_load_deferred_compose(void)
 {
     LOAD_SHADER(deferred.compose, SCREEN_VERT, COMPOSE_FRAG);
 
-    GET_LOCATION(deferred.compose, uDiffuseTex);
-    GET_LOCATION(deferred.compose, uSpecularTex);
-
     USE_SHADER(deferred.compose);
 
-    SET_SAMPLER_2D(deferred.compose, uDiffuseTex, 0);
-    SET_SAMPLER_2D(deferred.compose, uSpecularTex, 1);
+    SET_SAMPLER(deferred.compose, uDiffuseTex, R3D_SHADER_SAMPLER_BUFFER_DIFFUSE);
+    SET_SAMPLER(deferred.compose, uSpecularTex, R3D_SHADER_SAMPLER_BUFFER_SPECULAR);
 }
 
 void r3d_shader_load_post_bloom(void)
 {
     LOAD_SHADER(post.bloom, SCREEN_VERT, BLOOM_FRAG);
 
-    GET_LOCATION(post.bloom, uSceneTex);
-    GET_LOCATION(post.bloom, uBloomTex);
     GET_LOCATION(post.bloom, uBloomMode);
     GET_LOCATION(post.bloom, uBloomIntensity);
 
     USE_SHADER(post.bloom);
 
-    SET_SAMPLER_2D(post.bloom, uSceneTex, 0);
-    SET_SAMPLER_2D(post.bloom, uBloomTex, 1);
+    SET_SAMPLER(post.bloom, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
+    SET_SAMPLER(post.bloom, uBloomTex, R3D_SHADER_SAMPLER_BUFFER_BLOOM);
 }
 
 void r3d_shader_load_post_fog(void)
@@ -844,8 +701,6 @@ void r3d_shader_load_post_fog(void)
 
     SET_UNIFORM_BUFFER(post.fog, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(post.fog, uSceneTex);
-    GET_LOCATION(post.fog, uDepthTex);
     GET_LOCATION(post.fog, uFogMode);
     GET_LOCATION(post.fog, uFogColor);
     GET_LOCATION(post.fog, uFogStart);
@@ -855,8 +710,8 @@ void r3d_shader_load_post_fog(void)
 
     USE_SHADER(post.fog);
 
-    SET_SAMPLER_2D(post.fog, uSceneTex, 0);
-    SET_SAMPLER_2D(post.fog, uDepthTex, 1);
+    SET_SAMPLER(post.fog, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
+    SET_SAMPLER(post.fog, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 }
 
 void r3d_shader_load_post_dof(void)
@@ -865,8 +720,6 @@ void r3d_shader_load_post_dof(void)
 
     SET_UNIFORM_BUFFER(post.dof, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(post.dof, uSceneTex);
-    GET_LOCATION(post.dof, uDepthTex);
     GET_LOCATION(post.dof, uFocusPoint);
     GET_LOCATION(post.dof, uFocusScale);
     GET_LOCATION(post.dof, uMaxBlurSize);
@@ -874,15 +727,14 @@ void r3d_shader_load_post_dof(void)
 
     USE_SHADER(post.dof);
 
-    SET_SAMPLER_2D(post.dof, uSceneTex, 0);
-    SET_SAMPLER_2D(post.dof, uDepthTex, 1);
+    SET_SAMPLER(post.dof, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
+    SET_SAMPLER(post.dof, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 }
 
 void r3d_shader_load_post_output(void)
 {
     LOAD_SHADER(post.output, SCREEN_VERT, OUTPUT_FRAG);
 
-    GET_LOCATION(post.output, uSceneTex);
     GET_LOCATION(post.output, uTonemapExposure);
     GET_LOCATION(post.output, uTonemapWhite);
     GET_LOCATION(post.output, uTonemapMode);
@@ -892,19 +744,15 @@ void r3d_shader_load_post_output(void)
 
     USE_SHADER(post.output);
 
-    SET_SAMPLER_2D(post.output, uSceneTex, 0);
+    SET_SAMPLER(post.output, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
 }
 
 void r3d_shader_load_post_fxaa(void)
 {
     LOAD_SHADER(post.fxaa, SCREEN_VERT, FXAA_FRAG);
-
-    GET_LOCATION(post.fxaa, uSourceTex);
     GET_LOCATION(post.fxaa, uSourceTexel);
-
     USE_SHADER(post.fxaa);
-
-    SET_SAMPLER_2D(post.fxaa, uSourceTex, 0);
+    SET_SAMPLER(post.fxaa, uSourceTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
 }
 
 // ========================================
@@ -969,6 +817,29 @@ void r3d_shader_quit()
     UNLOAD_SHADER(post.dof);
     UNLOAD_SHADER(post.output);
     UNLOAD_SHADER(post.fxaa);
+}
+
+void r3d_shader_bind_sampler(r3d_shader_sampler_t sampler, GLuint texture)
+{
+    assert(R3D_MOD_SHADER_SAMPLER_TYPES[sampler] != GL_NONE);
+
+    if (texture != R3D_MOD_SHADER.samplerBindings[sampler]) {
+        glActiveTexture(GL_TEXTURE0 + sampler);
+        glBindTexture(R3D_MOD_SHADER_SAMPLER_TYPES[sampler], texture);
+        R3D_MOD_SHADER.samplerBindings[sampler] = texture;
+    }
+}
+
+void r3d_shader_unbind_samplers(void)
+{
+    for (int iSampler = 0; iSampler < R3D_SHADER_SAMPLER_COUNT; iSampler++) {
+        if (R3D_MOD_SHADER.samplerBindings[iSampler] != 0) {
+            glActiveTexture(GL_TEXTURE0 + iSampler);
+            glBindTexture(R3D_MOD_SHADER_SAMPLER_TYPES[iSampler], 0);
+            R3D_MOD_SHADER.samplerBindings[iSampler] = 0;
+        }
+    }
+    glActiveTexture(GL_TEXTURE0);
 }
 
 void r3d_shader_set_uniform_block(r3d_shader_block_t block, const void* data)

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -125,8 +125,11 @@
 // SAMPLER ENUMS
 // ========================================
 
-// NOTE: Slot '0' is reserved for everything else
-
+/*
+ * Slot '0' is reserved for texture operations exclusively on the client side.
+ * Note that the specification guarantees at least 80 binding slots for textures.
+ * See: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glActiveTexture.xhtml
+ */
 typedef enum {
 
     // Material maps

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -884,9 +884,16 @@ bool r3d_shader_init();
  */
 void r3d_shader_quit();
 
-
+/*
+ * Binds the texture to the specified sampler.
+ * Called by `R3D_SHADER_BIND_SAMPLER`, no need to call it manually.
+ */
 void r3d_shader_bind_sampler(r3d_shader_sampler_t sampler, GLuint texture);
 
+/*
+ * Iterates through all samplers to unbind any textures that were bound.
+ * Must be called at the end of each frame to avoid leaving a dirty state to raylib.
+ */
 void r3d_shader_unbind_samplers(void);
 
 /*

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -40,63 +40,11 @@
     glUseProgram(R3D_MOD_SHADER.shader_name.id);                                                    \
 } while(0)
 
-#define R3D_SHADER_SLOT_SAMPLER_1D(shader_name, uniform)                                            \
-    R3D_MOD_SHADER.shader_name.uniform.slot1D                                                       \
+#define R3D_SHADER_SLOT_SAMPLER(shader_name, uniform)                                               \
+    R3D_MOD_SHADER.shader_name.uniform.slot                                                         \
 
-#define R3D_SHADER_SLOT_SAMPLER_2D(shader_name, uniform)                                            \
-    R3D_MOD_SHADER.shader_name.uniform.slot2D                                                       \
-
-#define R3D_SHADER_SLOT_SAMPLER_CUBE(shader_name, uniform)                                          \
-    R3D_MOD_SHADER.shader_name.uniform.slotCube                                                     \
-
-#define R3D_SHADER_BIND_SAMPLER_1D(shader_name, uniform, texId) do {                                \
-    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slot1D);                       \
-    glBindTexture(GL_TEXTURE_1D, (texId));                                                          \
-} while(0)
-
-#define R3D_SHADER_BIND_SAMPLER_2D(shader_name, uniform, texId) do {                                \
-    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slot2D);                       \
-    glBindTexture(GL_TEXTURE_2D, (texId));                                                          \
-} while(0)
-
-#define R3D_SHADER_BIND_SAMPLER_CUBE(shader_name, uniform, texId) do {                              \
-    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slotCube);                     \
-    glBindTexture(GL_TEXTURE_CUBE_MAP, (texId));                                                    \
-} while(0)
-
-#define R3D_SHADER_BIND_SAMPLER_2D_ARRAY(shader_name, uniform, texId) do {                          \
-    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slot2DArr);                    \
-    glBindTexture(GL_TEXTURE_2D_ARRAY, (texId));                                                    \
-} while(0)
-
-#define R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(shader_name, uniform, texId) do {                        \
-    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slotCubeArr);                  \
-    glBindTexture(GL_TEXTURE_CUBE_MAP_ARRAY, (texId));                                              \
-} while(0)
-
-#define R3D_SHADER_UNBIND_SAMPLER_1D(shader_name, uniform) do {                                     \
-    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slot1D);                       \
-    glBindTexture(GL_TEXTURE_1D, 0);                                                                \
-} while(0)
-
-#define R3D_SHADER_UNBIND_SAMPLER_2D(shader_name, uniform) do {                                     \
-    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slot2D);                       \
-    glBindTexture(GL_TEXTURE_2D, 0);                                                                \
-} while(0)
-
-#define R3D_SHADER_UNBIND_SAMPLER_CUBE(shader_name, uniform) do {                                   \
-    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slotCube);                     \
-    glBindTexture(GL_TEXTURE_CUBE_MAP, 0);                                                          \
-} while(0)
-
-#define R3D_SHADER_UNBIND_SAMPLER_2D_ARRAY(shader_name, uniform) do {                               \
-    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slot2DArr);                    \
-    glBindTexture(GL_TEXTURE_2D_ARRAY, 0);                                                          \
-} while(0)
-
-#define R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(shader_name, uniform) do {                             \
-    glActiveTexture(GL_TEXTURE0 + R3D_MOD_SHADER.shader_name.uniform.slotCubeArr);                  \
-    glBindTexture(GL_TEXTURE_CUBE_MAP_ARRAY, 0);                                                    \
+#define R3D_SHADER_BIND_SAMPLER(shader_name, uniform, texId) do {                                   \
+    r3d_shader_bind_sampler(R3D_MOD_SHADER.shader_name.uniform.slot, (texId));                      \
 } while(0)
 
 #define R3D_SHADER_SET_INT(shader_name, uniform, value) do {                                        \
@@ -174,24 +122,107 @@
 } while(0)
 
 // ========================================
+// SAMPLER ENUMS
+// ========================================
+
+// NOTE: Slot '0' is reserved for everything else
+
+typedef enum {
+
+    // Material maps
+    R3D_SHADER_SAMPLER_MAP_ALBEDO       = 1,
+    R3D_SHADER_SAMPLER_MAP_EMISSION     = 2,
+    R3D_SHADER_SAMPLER_MAP_NORMAL       = 3,
+    R3D_SHADER_SAMPLER_MAP_ORM          = 4,
+
+    // Shadow maps
+    R3D_SHADER_SAMPLER_SHADOW_DIR       = 10,
+    R3D_SHADER_SAMPLER_SHADOW_SPOT      = 11,
+    R3D_SHADER_SAMPLER_SHADOW_OMNI      = 12,
+
+    // IBL maps
+    R3D_SHADER_SAMPLER_IBL_IRRADIANCE   = 15,
+    R3D_SHADER_SAMPLER_IBL_PREFILTER    = 16,
+    R3D_SHADER_SAMPLER_IBL_BRDF_LUT     = 17,
+
+    // Scene miscs
+    R3D_SHADER_SAMPLER_BONE_MATRICES    = 20,
+
+    // Buffers
+    R3D_SHADER_SAMPLER_BUFFER_DEPTH     = 25,
+    R3D_SHADER_SAMPLER_BUFFER_ALBEDO    = 26,
+    R3D_SHADER_SAMPLER_BUFFER_NORMAL    = 27,
+    R3D_SHADER_SAMPLER_BUFFER_ORM       = 28,
+    R3D_SHADER_SAMPLER_BUFFER_DIFFUSE   = 29,
+    R3D_SHADER_SAMPLER_BUFFER_SPECULAR  = 30,
+    R3D_SHADER_SAMPLER_BUFFER_SSAO      = 31,
+    R3D_SHADER_SAMPLER_BUFFER_SSIL      = 32,
+    R3D_SHADER_SAMPLER_BUFFER_SSR       = 33,
+    R3D_SHADER_SAMPLER_BUFFER_BLOOM     = 34,
+    R3D_SHADER_SAMPLER_BUFFER_SCENE     = 35,
+
+    // Unamed for special passes
+    R3D_SHADER_SAMPLER_SOURCE_2D        = 50,
+    R3D_SHADER_SAMPLER_SOURCE_CUBE      = 55,
+
+    // Sentinel
+    R3D_SHADER_SAMPLER_COUNT
+
+} r3d_shader_sampler_t;
+
+// ========================================
+// SAMPLER TYPES
+// ========================================
+
+static const GLenum R3D_MOD_SHADER_SAMPLER_TYPES[R3D_SHADER_SAMPLER_COUNT] =
+{
+    [R3D_SHADER_SAMPLER_MAP_ALBEDO]       = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_MAP_EMISSION]     = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_MAP_NORMAL]       = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_MAP_ORM]          = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_SHADOW_DIR]       = GL_TEXTURE_2D_ARRAY,
+    [R3D_SHADER_SAMPLER_SHADOW_SPOT]      = GL_TEXTURE_2D_ARRAY,
+    [R3D_SHADER_SAMPLER_SHADOW_OMNI]      = GL_TEXTURE_CUBE_MAP_ARRAY,
+    [R3D_SHADER_SAMPLER_IBL_IRRADIANCE]   = GL_TEXTURE_CUBE_MAP_ARRAY,
+    [R3D_SHADER_SAMPLER_IBL_PREFILTER]    = GL_TEXTURE_CUBE_MAP_ARRAY,
+    [R3D_SHADER_SAMPLER_IBL_BRDF_LUT]     = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BONE_MATRICES]    = GL_TEXTURE_1D,
+    [R3D_SHADER_SAMPLER_BUFFER_DEPTH]     = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_ALBEDO]    = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_NORMAL]    = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_ORM]       = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_DIFFUSE]   = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_SPECULAR]  = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_SSAO]      = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_SSIL]      = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_SSR]       = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_BLOOM]     = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_SCENE]     = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_SOURCE_2D]        = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_SOURCE_CUBE]      = GL_TEXTURE_CUBE_MAP,
+};
+
+// ========================================
 // UNIFORMS TYPES
 // ========================================
 
-typedef struct { int slot1D; int loc; } r3d_shader_uniform_sampler1D_t;
-typedef struct { int slot2D; int loc; } r3d_shader_uniform_sampler2D_t;
-typedef struct { int slotCube; int loc; } r3d_shader_uniform_samplerCube_t;
-typedef struct { int slot2DArr; int loc; } r3d_shader_uniform_sampler2DArray_t;
-typedef struct { int slotCubeArr; int loc; } r3d_shader_uniform_samplerCubeArray_t;
+/* Represents any sampler type, stores only the corresponding texture slot */
+typedef struct { int slot; } r3d_shader_uniform_sampler_t;
 
+/* Represents scalars (bool/int and float), stores the value and uniform location */
 typedef struct { int val; int loc; } r3d_shader_uniform_int_t;
 typedef struct { float val; int loc; } r3d_shader_uniform_float_t;
+
+/* Represents vectors, stores the value and uniform location */
 typedef struct { Vector2 val; int loc; } r3d_shader_uniform_vec2_t;
 typedef struct { Vector3 val; int loc; } r3d_shader_uniform_vec3_t;
 typedef struct { Vector4 val; int loc; } r3d_shader_uniform_vec4_t;
 
-typedef struct { Color val; R3D_ColorSpace colorSpace; int loc; } r3d_shader_uniform_col3_t; //< Represents a vec3
-typedef struct { Color val; R3D_ColorSpace colorSpace; int loc; } r3d_shader_uniform_col4_t; //< Represents a vec4
+/* Represents SDR color vectors plus the color space they should be interpreted in */
+typedef struct { Color val; R3D_ColorSpace colorSpace; int loc; } r3d_shader_uniform_col3_t;
+typedef struct { Color val; R3D_ColorSpace colorSpace; int loc; } r3d_shader_uniform_col4_t;
 
+/* Represents matrices, stores only the uniform location for efficiency */
 typedef struct { int loc; } r3d_shader_uniform_mat4_t;
 
 // ========================================
@@ -283,28 +314,28 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uSourceTex;
-    r3d_shader_uniform_sampler2D_t uNormalTex;
-    r3d_shader_uniform_sampler2D_t uDepthTex;
+    r3d_shader_uniform_sampler_t uSourceTex;
+    r3d_shader_uniform_sampler_t uNormalTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_int_t uStepSize;
 } r3d_shader_prepare_atrous_wavelet_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uSourceTex;
+    r3d_shader_uniform_sampler_t uSourceTex;
     r3d_shader_uniform_int_t uSourceLod;
 } r3d_shader_prepare_blur_down_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uSourceTex;
+    r3d_shader_uniform_sampler_t uSourceTex;
     r3d_shader_uniform_int_t uSourceLod;
 } r3d_shader_prepare_blur_up_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uNormalTex;
-    r3d_shader_uniform_sampler2D_t uDepthTex;
+    r3d_shader_uniform_sampler_t uNormalTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_int_t uSampleCount;
     r3d_shader_uniform_float_t uRadius;
     r3d_shader_uniform_float_t uBias;
@@ -314,10 +345,10 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uLightingTex;
-    r3d_shader_uniform_sampler2D_t uHistoryTex;
-    r3d_shader_uniform_sampler2D_t uNormalTex;
-    r3d_shader_uniform_sampler2D_t uDepthTex;
+    r3d_shader_uniform_sampler_t uLightingTex;
+    r3d_shader_uniform_sampler_t uHistoryTex;
+    r3d_shader_uniform_sampler_t uNormalTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_float_t uSampleCount;
     r3d_shader_uniform_float_t uSampleRadius;
     r3d_shader_uniform_float_t uSliceCount;
@@ -330,11 +361,11 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uLightingTex;
-    r3d_shader_uniform_sampler2D_t uAlbedoTex;
-    r3d_shader_uniform_sampler2D_t uNormalTex;
-    r3d_shader_uniform_sampler2D_t uOrmTex;
-    r3d_shader_uniform_sampler2D_t uDepthTex;
+    r3d_shader_uniform_sampler_t uLightingTex;
+    r3d_shader_uniform_sampler_t uAlbedoTex;
+    r3d_shader_uniform_sampler_t uNormalTex;
+    r3d_shader_uniform_sampler_t uOrmTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_int_t uMaxRaySteps;
     r3d_shader_uniform_int_t uBinarySearchSteps;
     r3d_shader_uniform_float_t uRayMarchLength;
@@ -348,7 +379,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexture;
+    r3d_shader_uniform_sampler_t uTexture;
     r3d_shader_uniform_vec2_t uTexelSize;
     r3d_shader_uniform_vec4_t uPrefilter;
     r3d_shader_uniform_int_t uDstLevel;
@@ -356,14 +387,14 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uTexture;
+    r3d_shader_uniform_sampler_t uTexture;
     r3d_shader_uniform_vec2_t uFilterRadius;
     r3d_shader_uniform_float_t uSrcLevel;
 } r3d_shader_prepare_bloom_up_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_samplerCube_t uSourceTex;
+    r3d_shader_uniform_sampler_t uSourceTex;
     r3d_shader_uniform_float_t uSourceTexel;
     r3d_shader_uniform_float_t uSourceLod;
     r3d_shader_uniform_int_t uSourceFace;
@@ -373,21 +404,21 @@ typedef struct {
     unsigned int id;
     r3d_shader_uniform_mat4_t uMatProj;
     r3d_shader_uniform_mat4_t uMatView;
-    r3d_shader_uniform_sampler2D_t uPanoramaTex;
+    r3d_shader_uniform_sampler_t uPanoramaTex;
 } r3d_shader_prepare_cubemap_from_equirectangular_t;
 
 typedef struct {
     unsigned int id;
     r3d_shader_uniform_mat4_t uMatProj;
     r3d_shader_uniform_mat4_t uMatView;
-    r3d_shader_uniform_samplerCube_t uSourceTex;
+    r3d_shader_uniform_sampler_t uSourceTex;
 } r3d_shader_prepare_cubemap_irradiance_t;
 
 typedef struct {
     unsigned int id;
     r3d_shader_uniform_mat4_t uMatProj;
     r3d_shader_uniform_mat4_t uMatView;
-    r3d_shader_uniform_samplerCube_t uSourceTex;
+    r3d_shader_uniform_sampler_t uSourceTex;
     r3d_shader_uniform_float_t uSourceNumLevels;
     r3d_shader_uniform_float_t uSourceFaceSize;
     r3d_shader_uniform_float_t uRoughness;
@@ -414,7 +445,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
+    r3d_shader_uniform_sampler_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatNormal;
     r3d_shader_uniform_mat4_t uMatModel;
     r3d_shader_uniform_col4_t uAlbedoColor;
@@ -425,10 +456,10 @@ typedef struct {
     r3d_shader_uniform_int_t uInstancing;
     r3d_shader_uniform_int_t uSkinning;
     r3d_shader_uniform_int_t uBillboard;
-    r3d_shader_uniform_sampler2D_t uAlbedoMap;
-    r3d_shader_uniform_sampler2D_t uNormalMap;
-    r3d_shader_uniform_sampler2D_t uEmissionMap;
-    r3d_shader_uniform_sampler2D_t uOrmMap;
+    r3d_shader_uniform_sampler_t uAlbedoMap;
+    r3d_shader_uniform_sampler_t uNormalMap;
+    r3d_shader_uniform_sampler_t uEmissionMap;
+    r3d_shader_uniform_sampler_t uOrmMap;
     r3d_shader_uniform_float_t uAlphaCutoff;
     r3d_shader_uniform_float_t uNormalScale;
     r3d_shader_uniform_float_t uOcclusion;
@@ -438,7 +469,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
+    r3d_shader_uniform_sampler_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatNormal;
     r3d_shader_uniform_mat4_t uMatModel;
     r3d_shader_uniform_col4_t uAlbedoColor;
@@ -449,16 +480,16 @@ typedef struct {
     r3d_shader_uniform_int_t uInstancing;
     r3d_shader_uniform_int_t uSkinning;
     r3d_shader_uniform_int_t uBillboard;
-    r3d_shader_uniform_sampler2D_t uAlbedoMap;
-    r3d_shader_uniform_sampler2D_t uEmissionMap;
-    r3d_shader_uniform_sampler2D_t uNormalMap;
-    r3d_shader_uniform_sampler2D_t uOrmMap;
-    r3d_shader_uniform_sampler2DArray_t uShadowDirTex;
-    r3d_shader_uniform_sampler2DArray_t uShadowSpotTex;
-    r3d_shader_uniform_samplerCubeArray_t uShadowOmniTex;
-    r3d_shader_uniform_samplerCubeArray_t uIrradianceTex;
-    r3d_shader_uniform_samplerCubeArray_t uPrefilterTex;
-    r3d_shader_uniform_sampler2D_t uBrdfLutTex;
+    r3d_shader_uniform_sampler_t uAlbedoMap;
+    r3d_shader_uniform_sampler_t uEmissionMap;
+    r3d_shader_uniform_sampler_t uNormalMap;
+    r3d_shader_uniform_sampler_t uOrmMap;
+    r3d_shader_uniform_sampler_t uShadowDirTex;
+    r3d_shader_uniform_sampler_t uShadowSpotTex;
+    r3d_shader_uniform_sampler_t uShadowOmniTex;
+    r3d_shader_uniform_sampler_t uIrradianceTex;
+    r3d_shader_uniform_sampler_t uPrefilterTex;
+    r3d_shader_uniform_sampler_t uBrdfLutTex;
     r3d_shader_uniform_float_t uNormalScale;
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
@@ -468,7 +499,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
+    r3d_shader_uniform_sampler_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatModel;
     r3d_shader_uniform_mat4_t uMatViewProj;
@@ -478,13 +509,13 @@ typedef struct {
     r3d_shader_uniform_int_t uInstancing;
     r3d_shader_uniform_int_t uSkinning;
     r3d_shader_uniform_int_t uBillboard;
-    r3d_shader_uniform_sampler2D_t uAlbedoMap;
+    r3d_shader_uniform_sampler_t uAlbedoMap;
     r3d_shader_uniform_float_t uAlphaCutoff;
 } r3d_shader_scene_depth_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
+    r3d_shader_uniform_sampler_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatModel;
     r3d_shader_uniform_mat4_t uMatViewProj;
@@ -494,7 +525,7 @@ typedef struct {
     r3d_shader_uniform_int_t uInstancing;
     r3d_shader_uniform_int_t uSkinning;
     r3d_shader_uniform_int_t uBillboard;
-    r3d_shader_uniform_sampler2D_t uAlbedoMap;
+    r3d_shader_uniform_sampler_t uAlbedoMap;
     r3d_shader_uniform_float_t uAlphaCutoff;
     r3d_shader_uniform_vec3_t uViewPosition;
     r3d_shader_uniform_float_t uFar;
@@ -502,7 +533,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler1D_t uBoneMatricesTex;
+    r3d_shader_uniform_sampler_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatNormal;
     r3d_shader_uniform_mat4_t uMatModel;
@@ -515,16 +546,16 @@ typedef struct {
     r3d_shader_uniform_int_t uInstancing;
     r3d_shader_uniform_int_t uSkinning;
     r3d_shader_uniform_int_t uBillboard;
-    r3d_shader_uniform_sampler2D_t uAlbedoMap;
-    r3d_shader_uniform_sampler2D_t uEmissionMap;
-    r3d_shader_uniform_sampler2D_t uNormalMap;
-    r3d_shader_uniform_sampler2D_t uOrmMap;
-    r3d_shader_uniform_sampler2DArray_t uShadowDirTex;
-    r3d_shader_uniform_sampler2DArray_t uShadowSpotTex;
-    r3d_shader_uniform_samplerCubeArray_t uShadowOmniTex;
-    r3d_shader_uniform_samplerCubeArray_t uIrradianceTex;
-    r3d_shader_uniform_samplerCubeArray_t uPrefilterTex;
-    r3d_shader_uniform_sampler2D_t uBrdfLutTex;
+    r3d_shader_uniform_sampler_t uAlbedoMap;
+    r3d_shader_uniform_sampler_t uEmissionMap;
+    r3d_shader_uniform_sampler_t uNormalMap;
+    r3d_shader_uniform_sampler_t uOrmMap;
+    r3d_shader_uniform_sampler_t uShadowDirTex;
+    r3d_shader_uniform_sampler_t uShadowSpotTex;
+    r3d_shader_uniform_sampler_t uShadowOmniTex;
+    r3d_shader_uniform_sampler_t uIrradianceTex;
+    r3d_shader_uniform_sampler_t uPrefilterTex;
+    r3d_shader_uniform_sampler_t uBrdfLutTex;
     r3d_shader_uniform_float_t uNormalScale;
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
@@ -543,11 +574,11 @@ typedef struct {
     r3d_shader_uniform_vec2_t uTexCoordOffset;
     r3d_shader_uniform_vec2_t uTexCoordScale;
     r3d_shader_uniform_int_t uInstancing;
-    r3d_shader_uniform_sampler2D_t uAlbedoMap;
-    r3d_shader_uniform_sampler2D_t uNormalMap;
-    r3d_shader_uniform_sampler2D_t uEmissionMap;
-    r3d_shader_uniform_sampler2D_t uOrmMap;
-    r3d_shader_uniform_sampler2D_t uDepthTex;
+    r3d_shader_uniform_sampler_t uAlbedoMap;
+    r3d_shader_uniform_sampler_t uNormalMap;
+    r3d_shader_uniform_sampler_t uEmissionMap;
+    r3d_shader_uniform_sampler_t uOrmMap;
+    r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_float_t uAlphaCutoff;
     r3d_shader_uniform_float_t uNormalScale;
     r3d_shader_uniform_float_t uOcclusion;
@@ -565,56 +596,56 @@ typedef struct {
     r3d_shader_uniform_vec4_t uRotation;
     r3d_shader_uniform_mat4_t uMatView;
     r3d_shader_uniform_mat4_t uMatProj;
-    r3d_shader_uniform_samplerCube_t uSkyMap;
+    r3d_shader_uniform_sampler_t uSkyMap;
     r3d_shader_uniform_float_t uSkyEnergy;
 } r3d_shader_scene_skybox_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uAlbedoTex;
-    r3d_shader_uniform_sampler2D_t uNormalTex;
-    r3d_shader_uniform_sampler2D_t uDepthTex;
-    r3d_shader_uniform_sampler2D_t uSsaoTex;
-    r3d_shader_uniform_sampler2D_t uSsilTex;
-    r3d_shader_uniform_sampler2D_t uSsrTex;
-    r3d_shader_uniform_sampler2D_t uOrmTex;
-    r3d_shader_uniform_samplerCubeArray_t uIrradianceTex;
-    r3d_shader_uniform_samplerCubeArray_t uPrefilterTex;
-    r3d_shader_uniform_sampler2D_t uBrdfLutTex;
+    r3d_shader_uniform_sampler_t uAlbedoTex;
+    r3d_shader_uniform_sampler_t uNormalTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
+    r3d_shader_uniform_sampler_t uSsaoTex;
+    r3d_shader_uniform_sampler_t uSsilTex;
+    r3d_shader_uniform_sampler_t uSsrTex;
+    r3d_shader_uniform_sampler_t uOrmTex;
+    r3d_shader_uniform_sampler_t uIrradianceTex;
+    r3d_shader_uniform_sampler_t uPrefilterTex;
+    r3d_shader_uniform_sampler_t uBrdfLutTex;
     r3d_shader_uniform_float_t uMipCountSSR;
 } r3d_shader_deferred_ambient_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uAlbedoTex;
-    r3d_shader_uniform_sampler2D_t uNormalTex;
-    r3d_shader_uniform_sampler2D_t uDepthTex;
-    r3d_shader_uniform_sampler2D_t uSsaoTex;
-    r3d_shader_uniform_sampler2D_t uOrmTex;
-    r3d_shader_uniform_sampler2DArray_t uShadowDirTex;
-    r3d_shader_uniform_sampler2DArray_t uShadowSpotTex;
-    r3d_shader_uniform_samplerCubeArray_t uShadowOmniTex;
+    r3d_shader_uniform_sampler_t uAlbedoTex;
+    r3d_shader_uniform_sampler_t uNormalTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
+    r3d_shader_uniform_sampler_t uSsaoTex;
+    r3d_shader_uniform_sampler_t uOrmTex;
+    r3d_shader_uniform_sampler_t uShadowDirTex;
+    r3d_shader_uniform_sampler_t uShadowSpotTex;
+    r3d_shader_uniform_sampler_t uShadowOmniTex;
     r3d_shader_uniform_float_t uSSAOLightAffect;
 } r3d_shader_deferred_lighting_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uDiffuseTex;
-    r3d_shader_uniform_sampler2D_t uSpecularTex;
+    r3d_shader_uniform_sampler_t uDiffuseTex;
+    r3d_shader_uniform_sampler_t uSpecularTex;
 } r3d_shader_deferred_compose_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uSceneTex;
-    r3d_shader_uniform_sampler2D_t uBloomTex;
+    r3d_shader_uniform_sampler_t uSceneTex;
+    r3d_shader_uniform_sampler_t uBloomTex;
     r3d_shader_uniform_int_t uBloomMode;
     r3d_shader_uniform_float_t uBloomIntensity;
 } r3d_shader_post_bloom_t;
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uSceneTex;
-    r3d_shader_uniform_sampler2D_t uDepthTex;
+    r3d_shader_uniform_sampler_t uSceneTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_int_t uFogMode;
     r3d_shader_uniform_col3_t uFogColor;
     r3d_shader_uniform_float_t uFogStart;
@@ -625,8 +656,8 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uSceneTex;
-    r3d_shader_uniform_sampler2D_t uDepthTex;
+    r3d_shader_uniform_sampler_t uSceneTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_float_t uFocusPoint;
     r3d_shader_uniform_float_t uFocusScale;
     r3d_shader_uniform_float_t uMaxBlurSize;
@@ -635,7 +666,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uSceneTex;
+    r3d_shader_uniform_sampler_t uSceneTex;
     r3d_shader_uniform_float_t uTonemapExposure;
     r3d_shader_uniform_float_t uTonemapWhite;
     r3d_shader_uniform_int_t uTonemapMode;
@@ -646,7 +677,7 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
-    r3d_shader_uniform_sampler2D_t uSourceTex;
+    r3d_shader_uniform_sampler_t uSourceTex;
     r3d_shader_uniform_vec2_t uSourceTexel;
 } r3d_shader_post_fxaa_t;
 
@@ -655,6 +686,9 @@ typedef struct {
 // ========================================
 
 extern struct r3d_shader {
+
+    // Samplers state
+    GLuint samplerBindings[R3D_SHADER_SAMPLER_COUNT];
 
     // Uniform buffers
     GLuint uniformBuffers[R3D_SHADER_BLOCK_COUNT];
@@ -849,6 +883,11 @@ bool r3d_shader_init();
  * Called once during `R3D_Close()`
  */
 void r3d_shader_quit();
+
+
+void r3d_shader_bind_sampler(r3d_shader_sampler_t sampler, GLuint texture);
+
+void r3d_shader_unbind_samplers(void);
 
 /*
  * Upload and bind the specified uniform block with the provided data.

--- a/src/r3d_cubemap.c
+++ b/src/r3d_cubemap.c
@@ -120,7 +120,7 @@ static R3D_Cubemap load_cubemap_from_panorama(Image image, int size)
 
     R3D_SHADER_USE(prepare.cubemapFromEquirectangular);
     R3D_SHADER_SET_MAT4(prepare.cubemapFromEquirectangular, uMatProj, matProj);
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.cubemapFromEquirectangular, uPanoramaTex, panorama.id);
+    R3D_SHADER_BIND_SAMPLER(prepare.cubemapFromEquirectangular, uPanoramaTex, panorama.id);
 
     glBindFramebuffer(GL_FRAMEBUFFER, cubemap.fbo);
     glViewport(0, 0, size, size);
@@ -134,7 +134,6 @@ static R3D_Cubemap load_cubemap_from_panorama(Image image, int size)
         R3D_PRIMITIVE_DRAW_CUBE();
     }
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.cubemapFromEquirectangular, uPanoramaTex);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     UnloadTexture(panorama);
 
@@ -196,8 +195,8 @@ static Image alloc_work_faces_image(Image source, int size)
 
 static R3D_Cubemap load_cubemap_from_line_horizontal(Image image, int size)
 {
-    Image faces = alloc_work_faces_image(image, size);  // ← Passe l'image source
-    
+    Image faces = alloc_work_faces_image(image, size);
+
     for (int i = 0; i < 6; i++) {
         Rectangle srcRect = {(float)i * size, 0, (float)size, (float)size};
         Rectangle dstRect = {0, (float)i * size, (float)size, (float)size};

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -623,7 +623,7 @@ void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* viewPr
     /* --- Send skinning related data --- */
 
     if (group->texPose > 0) {
-        R3D_SHADER_BIND_SAMPLER_1D(scene.depth, uBoneMatricesTex, group->texPose);
+        R3D_SHADER_BIND_SAMPLER(scene.depth, uBoneMatricesTex, group->texPose);
         R3D_SHADER_SET_INT(scene.depth, uSkinning, true);
     }
     else {
@@ -644,7 +644,7 @@ void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* viewPr
 
     /* --- Set transparency material data --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.depth, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.depth, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
     R3D_SHADER_SET_COL4(scene.depth, uAlbedoColor, R3D.colorSpace, call->material.albedo.color);
 
     if (call->material.transparencyMode == R3D_TRANSPARENCY_PREPASS) {
@@ -673,10 +673,6 @@ void raster_depth(const r3d_draw_call_t* call, bool shadow, const Matrix* viewPr
         R3D_SHADER_SET_INT(scene.depth, uInstancing, false);
         r3d_draw(call);
     }
-
-    /* --- Unbind samplers --- */
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.depth, uAlbedoMap);
 }
 
 void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* viewProj)
@@ -691,7 +687,7 @@ void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* v
     /* --- Send skinning related data --- */
 
     if (group->texPose > 0) {
-        R3D_SHADER_BIND_SAMPLER_1D(scene.depthCube, uBoneMatricesTex, group->texPose);
+        R3D_SHADER_BIND_SAMPLER(scene.depthCube, uBoneMatricesTex, group->texPose);
         R3D_SHADER_SET_INT(scene.depthCube, uSkinning, true);
     }
     else {
@@ -712,7 +708,7 @@ void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* v
 
     /* --- Set transparency material data --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.depthCube, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.depthCube, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
     R3D_SHADER_SET_COL4(scene.depthCube, uAlbedoColor, R3D.colorSpace, call->material.albedo.color);
 
     if (call->material.transparencyMode == R3D_TRANSPARENCY_PREPASS) {
@@ -747,10 +743,6 @@ void raster_depth_cube(const r3d_draw_call_t* call, bool shadow, const Matrix* v
     rlDisableVertexArray();
     rlDisableVertexBuffer();
     rlDisableVertexBufferElement();
-
-    /* --- Unbind samplers --- */
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.depthCube, uAlbedoMap);
 }
 
 void raster_probe(const r3d_draw_call_t* call, const Matrix* invView, const Matrix* viewProj)
@@ -769,7 +761,7 @@ void raster_probe(const r3d_draw_call_t* call, const Matrix* invView, const Matr
     /* --- Send skinning related data --- */
 
     if (group->texPose > 0) {
-        R3D_SHADER_BIND_SAMPLER_1D(scene.probe, uBoneMatricesTex, group->texPose);
+        R3D_SHADER_BIND_SAMPLER(scene.probe, uBoneMatricesTex, group->texPose);
         R3D_SHADER_SET_INT(scene.probe, uSkinning, true);
     }
     else {
@@ -800,10 +792,10 @@ void raster_probe(const r3d_draw_call_t* call, const Matrix* invView, const Matr
 
     /* --- Bind active texture maps --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.probe, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.probe, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
+    R3D_SHADER_BIND_SAMPLER(scene.probe, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.probe, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */
 
@@ -820,13 +812,6 @@ void raster_probe(const r3d_draw_call_t* call, const Matrix* invView, const Matr
         R3D_SHADER_SET_INT(scene.probe, uInstancing, false);
         r3d_draw(call);
     }
-
-    /* --- Unbind all bound texture maps --- */
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uAlbedoMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uNormalMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uEmissionMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uOrmMap);
 }
 
 void raster_geometry(const r3d_draw_call_t* call)
@@ -843,7 +828,7 @@ void raster_geometry(const r3d_draw_call_t* call)
     /* --- Send skinning related data --- */
 
     if (group->texPose > 0) {
-        R3D_SHADER_BIND_SAMPLER_1D(scene.geometry, uBoneMatricesTex, group->texPose);
+        R3D_SHADER_BIND_SAMPLER(scene.geometry, uBoneMatricesTex, group->texPose);
         R3D_SHADER_SET_INT(scene.geometry, uSkinning, true);
     }
     else {
@@ -878,10 +863,10 @@ void raster_geometry(const r3d_draw_call_t* call)
 
     /* --- Bind active texture maps --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.geometry, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.geometry, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.geometry, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
+    R3D_SHADER_BIND_SAMPLER(scene.geometry, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.geometry, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */
 
@@ -897,13 +882,6 @@ void raster_geometry(const r3d_draw_call_t* call)
         R3D_SHADER_SET_INT(scene.geometry, uInstancing, false);
         r3d_draw(call);
     }
-
-    /* --- Unbind all bound texture maps --- */
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uAlbedoMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uNormalMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uEmissionMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.geometry, uOrmMap);
 }
 
 void raster_decal(const r3d_draw_call_t* call)
@@ -941,10 +919,10 @@ void raster_decal(const r3d_draw_call_t* call)
 
     /* --- Bind active texture maps --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.decal, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.decal, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
+    R3D_SHADER_BIND_SAMPLER(scene.decal, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.decal, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */
 
@@ -965,13 +943,6 @@ void raster_decal(const r3d_draw_call_t* call)
         R3D_SHADER_SET_INT(scene.decal, uInstancing, false);
         r3d_primitive_draw(R3D_PRIMITIVE_CUBE);
     }
-
-    /* --- Unbind all bound texture maps --- */
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uAlbedoMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uNormalMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uEmissionMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uOrmMap);
 }
 
 void raster_forward(const r3d_draw_call_t* call)
@@ -988,7 +959,7 @@ void raster_forward(const r3d_draw_call_t* call)
     /* --- Send skinning related data --- */
 
     if (group->texPose > 0) {
-        R3D_SHADER_BIND_SAMPLER_1D(scene.forward, uBoneMatricesTex, group->texPose);
+        R3D_SHADER_BIND_SAMPLER(scene.forward, uBoneMatricesTex, group->texPose);
         R3D_SHADER_SET_INT(scene.forward, uSkinning, true);
     }
     else {
@@ -1019,10 +990,10 @@ void raster_forward(const r3d_draw_call_t* call)
 
     /* --- Bind active texture maps --- */
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.forward, uAlbedoMap, R3D_TEXTURE_SELECT(call->material.albedo.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.forward, uNormalMap, R3D_TEXTURE_SELECT(call->material.normal.texture.id, NORMAL));
+    R3D_SHADER_BIND_SAMPLER(scene.forward, uEmissionMap, R3D_TEXTURE_SELECT(call->material.emission.texture.id, WHITE));
+    R3D_SHADER_BIND_SAMPLER(scene.forward, uOrmMap, R3D_TEXTURE_SELECT(call->material.orm.texture.id, WHITE));
 
     /* --- Applying material parameters that are independent of shaders --- */
 
@@ -1039,13 +1010,6 @@ void raster_forward(const r3d_draw_call_t* call)
         R3D_SHADER_SET_INT(scene.forward, uInstancing, false);
         r3d_draw(call);
     }
-
-    /* --- Unbind all bound texture maps --- */
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uAlbedoMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uNormalMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uEmissionMap);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uOrmMap);
 }
 
 void pass_scene_shadow(void)
@@ -1078,9 +1042,6 @@ void pass_scene_shadow(void)
                 }
                 #undef COND
             }
-
-            // The bone matrices texture may have been bind during drawcalls, so UNBIND!
-            R3D_SHADER_UNBIND_SAMPLER_1D(scene.depthCube, uBoneMatricesTex);
         }
         else {
             r3d_light_shadow_bind_fbo(light->type, light->shadowLayer, 0);
@@ -1095,9 +1056,6 @@ void pass_scene_shadow(void)
                 raster_depth(call, true, &light->viewProj[0]);
             }
             #undef COND
-
-            // The bone matrices texture may have been bind during drawcalls, so UNBIND!
-            R3D_SHADER_UNBIND_SAMPLER_1D(scene.depth, uBoneMatricesTex);
         }
     }
 }
@@ -1137,13 +1095,13 @@ void pass_scene_probes(void)
             glDepthMask(GL_TRUE);
             glEnable(GL_BLEND);
 
-            R3D_SHADER_BIND_SAMPLER_2D_ARRAY(scene.probe, uShadowDirTex, r3d_light_shadow_get(R3D_LIGHT_DIR));
-            R3D_SHADER_BIND_SAMPLER_2D_ARRAY(scene.probe, uShadowSpotTex, r3d_light_shadow_get(R3D_LIGHT_SPOT));
-            R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.probe, uShadowOmniTex, r3d_light_shadow_get(R3D_LIGHT_OMNI));
+            R3D_SHADER_BIND_SAMPLER(scene.probe, uShadowDirTex, r3d_light_shadow_get(R3D_LIGHT_DIR));
+            R3D_SHADER_BIND_SAMPLER(scene.probe, uShadowSpotTex, r3d_light_shadow_get(R3D_LIGHT_SPOT));
+            R3D_SHADER_BIND_SAMPLER(scene.probe, uShadowOmniTex, r3d_light_shadow_get(R3D_LIGHT_OMNI));
 
-            R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.probe, uIrradianceTex, r3d_env_irradiance_get());
-            R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.probe, uPrefilterTex, r3d_env_prefilter_get());
-            R3D_SHADER_BIND_SAMPLER_2D(scene.probe, uBrdfLutTex, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
+            R3D_SHADER_BIND_SAMPLER(scene.probe, uIrradianceTex, r3d_env_irradiance_get());
+            R3D_SHADER_BIND_SAMPLER(scene.probe, uPrefilterTex, r3d_env_prefilter_get());
+            R3D_SHADER_BIND_SAMPLER(scene.probe, uBrdfLutTex, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
 
             R3D_SHADER_SET_VEC3(scene.probe, uViewPosition, probe->position);
             R3D_SHADER_SET_INT(scene.probe, uProbeInterior, probe->interior);
@@ -1156,17 +1114,6 @@ void pass_scene_probes(void)
                 raster_probe(call, &invView, &viewProj);
             }
 
-            R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.probe, uIrradianceTex);
-            R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.probe, uPrefilterTex);
-            R3D_SHADER_UNBIND_SAMPLER_2D(scene.probe, uBrdfLutTex);
-
-            R3D_SHADER_UNBIND_SAMPLER_2D_ARRAY(scene.probe, uShadowDirTex);
-            R3D_SHADER_UNBIND_SAMPLER_2D_ARRAY(scene.probe, uShadowSpotTex);
-            R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.probe, uShadowOmniTex);
-
-            // NOTE: The storage texture of the matrices may have been bind during drawcalls
-            R3D_SHADER_UNBIND_SAMPLER_1D(scene.probe, uBoneMatricesTex);
-
             /* --- Render background --- */
 
             glDepthMask(GL_FALSE);
@@ -1176,15 +1123,13 @@ void pass_scene_probes(void)
                 R3D_SHADER_USE(scene.skybox);
                 glDisable(GL_CULL_FACE);
 
-                R3D_SHADER_BIND_SAMPLER_CUBE(scene.skybox, uSkyMap, R3D.environment.background.sky.texture);
+                R3D_SHADER_BIND_SAMPLER(scene.skybox, uSkyMap, R3D.environment.background.sky.texture);
                 R3D_SHADER_SET_FLOAT(scene.skybox, uSkyEnergy, R3D.environment.background.energy);
                 R3D_SHADER_SET_VEC4(scene.skybox, uRotation, R3D.environment.background.rotation);
                 R3D_SHADER_SET_MAT4(scene.skybox, uMatView, probe->view[iFace]);
                 R3D_SHADER_SET_MAT4(scene.skybox, uMatProj, probe->proj[iFace]);
 
                 R3D_PRIMITIVE_DRAW_CUBE();
-
-                R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.skybox, uSkyMap);
             }
             else {
                 Vector4 background = r3d_color_to_linear_scaled_vec4(
@@ -1203,7 +1148,7 @@ void pass_scene_probes(void)
             glDisable(GL_DEPTH_TEST);
             glDisable(GL_BLEND);
 
-            R3D_SHADER_BIND_SAMPLER_CUBE(prepare.cubefaceDown, uSourceTex, r3d_env_capture_get());
+            R3D_SHADER_BIND_SAMPLER(prepare.cubefaceDown, uSourceTex, r3d_env_capture_get());
             R3D_SHADER_SET_INT(prepare.cubefaceDown, uSourceFace, iFace);
 
             for (int mipLevel = 1; mipLevel < R3D_ENV_CAPTURE_MIPS; mipLevel++) {
@@ -1212,8 +1157,6 @@ void pass_scene_probes(void)
                 R3D_SHADER_SET_FLOAT(prepare.cubefaceDown, uSourceLod, mipLevel - 1);
                 R3D_PRIMITIVE_DRAW_SCREEN();
             }
-
-            R3D_SHADER_UNBIND_SAMPLER_CUBE(prepare.cubefaceDown, uSourceTex);
         }
 
         /* --- Generate irradiance and prefilter maps --- */
@@ -1242,9 +1185,6 @@ void pass_scene_geometry(void)
     R3D_DRAW_FOR_EACH(call, true, frustum, R3D_DRAW_DEFERRED_INST, R3D_DRAW_DEFERRED) {
         raster_geometry(call);
     }
-
-    // The bone matrices texture may have been bind during drawcalls, so UNBIND!
-    R3D_SHADER_UNBIND_SAMPLER_1D(scene.geometry, uBoneMatricesTex);
 }
 
 void pass_scene_prepass(void)
@@ -1275,9 +1215,6 @@ void pass_scene_prepass(void)
     R3D_DRAW_FOR_EACH(call, true, frustum, R3D_DRAW_PREPASS_INST, R3D_DRAW_PREPASS) {
         raster_geometry(call);
     }
-
-    // NOTE: The storage texture of the matrices may have been bind during drawcalls
-    R3D_SHADER_UNBIND_SAMPLER_1D(scene.forward, uBoneMatricesTex);
 }
 
 void pass_scene_decals(void)
@@ -1290,14 +1227,12 @@ void pass_scene_decals(void)
     glDepthMask(GL_FALSE);
     glEnable(GL_BLEND);
 
-    R3D_SHADER_BIND_SAMPLER_2D(scene.decal, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER(scene.decal, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     const r3d_frustum_t* frustum = &R3D.viewState.frustum;
     R3D_DRAW_FOR_EACH(call, true, frustum, R3D_DRAW_DECAL_INST, R3D_DRAW_DECAL) {
         raster_decal(call);
     }
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.decal, uDepthTex);
 }
 
 r3d_target_t pass_prepare_ssao(void)
@@ -1319,31 +1254,24 @@ r3d_target_t pass_prepare_ssao(void)
     R3D_SHADER_SET_FLOAT(prepare.ssao, uIntensity, R3D.environment.ssao.intensity);
     R3D_SHADER_SET_FLOAT(prepare.ssao, uPower, R3D.environment.ssao.power);
 
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssao, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssao, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssao, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssao, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_PRIMITIVE_DRAW_SCREEN();
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssao, uNormalTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssao, uDepthTex);
 
     /* --- Denoise SSAO --- */
 
     R3D_SHADER_USE(prepare.atrousWavelet);
 
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.atrousWavelet, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.atrousWavelet, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     for (int i = 0; i < 3; i++) {
         R3D_TARGET_BIND_AND_SWAP_SSAO(ssaoTarget);
-        R3D_SHADER_BIND_SAMPLER_2D(prepare.atrousWavelet, uSourceTex, r3d_target_get(ssaoTarget));
+        R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uSourceTex, r3d_target_get(ssaoTarget));
         R3D_SHADER_SET_INT(prepare.atrousWavelet, uStepSize, 1 << i);
         R3D_PRIMITIVE_DRAW_SCREEN();
     }
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.atrousWavelet, uSourceTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.atrousWavelet, uNormalTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.atrousWavelet, uDepthTex);
 
     return r3d_target_swap_ssao(ssaoTarget);
 }
@@ -1375,10 +1303,10 @@ r3d_target_t pass_prepare_ssil(void)
     R3D_TARGET_BIND(SSIL_CURRENT);
     R3D_SHADER_USE(prepare.ssil);
 
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uLightingTex, r3d_target_get(R3D_TARGET_DIFFUSE));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uHistoryTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(SSIL_HISTORY), BLACK));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssil, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssil, uLightingTex, r3d_target_get(R3D_TARGET_DIFFUSE));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssil, uHistoryTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(SSIL_HISTORY), BLACK));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssil, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssil, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_SHADER_SET_FLOAT(prepare.ssil, uSampleCount, (float)R3D.environment.ssil.sampleCount);
     R3D_SHADER_SET_FLOAT(prepare.ssil, uSampleRadius, R3D.environment.ssil.sampleRadius);
@@ -1391,11 +1319,6 @@ r3d_target_t pass_prepare_ssil(void)
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uLightingTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uHistoryTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uNormalTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssil, uDepthTex);
-
     /* --- Blur SSIL (Dual Filtering) --- */
 
     r3d_target_t SSIL_MIP = R3D_TARGET_SSIL_MIP;
@@ -1407,7 +1330,7 @@ r3d_target_t pass_prepare_ssil(void)
 
     // Downsample
     R3D_SHADER_USE(prepare.blurDown);
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.blurDown, uSourceTex, r3d_target_get(SSIL_CURRENT));
+    R3D_SHADER_BIND_SAMPLER(prepare.blurDown, uSourceTex, r3d_target_get(SSIL_CURRENT));
     for (int mipLevel = 1; mipLevel < mipMax; mipLevel++)
     {
         int dstW, dstH;
@@ -1419,14 +1342,13 @@ r3d_target_t pass_prepare_ssil(void)
         R3D_PRIMITIVE_DRAW_SCREEN();
 
         if (mipLevel == 1) {
-            R3D_SHADER_BIND_SAMPLER_2D(prepare.blurDown, uSourceTex, r3d_target_get(SSIL_MIP));
+            R3D_SHADER_BIND_SAMPLER(prepare.blurDown, uSourceTex, r3d_target_get(SSIL_MIP));
         }
     }
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.blurDown, uSourceTex);
 
     // Upsample
     R3D_SHADER_USE(prepare.blurUp);
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.blurUp, uSourceTex, r3d_target_get(SSIL_MIP));
+    R3D_SHADER_BIND_SAMPLER(prepare.blurUp, uSourceTex, r3d_target_get(SSIL_MIP));
     for (int mipLevel = mipMax - 2; mipLevel >= 0; mipLevel--)
     {
         int dstW, dstH;
@@ -1437,7 +1359,6 @@ r3d_target_t pass_prepare_ssil(void)
         R3D_SHADER_SET_INT(prepare.blurUp, uSourceLod, mipLevel + 1);
         R3D_PRIMITIVE_DRAW_SCREEN();
     }
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.blurUp, uSourceTex);
 
     /* --- Swap history --- */
 
@@ -1459,11 +1380,11 @@ r3d_target_t pass_prepare_ssr(void)
     R3D_TARGET_BIND(R3D_TARGET_SSR);
     R3D_SHADER_USE(prepare.ssr);
 
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uLightingTex, r3d_target_get(R3D_TARGET_DIFFUSE));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.ssr, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssr, uLightingTex, r3d_target_get(R3D_TARGET_DIFFUSE));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssr, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssr, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssr, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssr, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_SHADER_SET_INT(prepare.ssr, uMaxRaySteps, R3D.environment.ssr.maxRaySteps);
     R3D_SHADER_SET_INT(prepare.ssr, uBinarySearchSteps, R3D.environment.ssr.binarySearchSteps);
@@ -1477,12 +1398,6 @@ r3d_target_t pass_prepare_ssr(void)
     R3D_SHADER_SET_FLOAT(prepare.ssr, uAmbientEnergy, R3D.environment.ambient.energy);
 
     R3D_PRIMITIVE_DRAW_SCREEN();
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uLightingTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uAlbedoTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uNormalTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uOrmTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.ssr, uDepthTex);
 
     r3d_target_gen_mipmap(R3D_TARGET_SSR);
 
@@ -1509,15 +1424,15 @@ void pass_deferred_lights(r3d_target_t ssaoSource)
 
     R3D_SHADER_USE(deferred.lighting);
 
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uSsaoTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssaoSource), WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.lighting, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
+    R3D_SHADER_BIND_SAMPLER(deferred.lighting, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
+    R3D_SHADER_BIND_SAMPLER(deferred.lighting, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(deferred.lighting, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER(deferred.lighting, uSsaoTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssaoSource), WHITE));
+    R3D_SHADER_BIND_SAMPLER(deferred.lighting, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
 
-    R3D_SHADER_BIND_SAMPLER_2D_ARRAY(deferred.lighting, uShadowDirTex, r3d_light_shadow_get(R3D_LIGHT_DIR));
-    R3D_SHADER_BIND_SAMPLER_2D_ARRAY(deferred.lighting, uShadowSpotTex, r3d_light_shadow_get(R3D_LIGHT_SPOT));
-    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(deferred.lighting, uShadowOmniTex, r3d_light_shadow_get(R3D_LIGHT_OMNI));
+    R3D_SHADER_BIND_SAMPLER(deferred.lighting, uShadowDirTex, r3d_light_shadow_get(R3D_LIGHT_DIR));
+    R3D_SHADER_BIND_SAMPLER(deferred.lighting, uShadowSpotTex, r3d_light_shadow_get(R3D_LIGHT_SPOT));
+    R3D_SHADER_BIND_SAMPLER(deferred.lighting, uShadowOmniTex, r3d_light_shadow_get(R3D_LIGHT_OMNI));
 
     R3D_SHADER_SET_FLOAT(deferred.lighting, uSSAOLightAffect, R3D.environment.ssao.lightAffect);
 
@@ -1561,17 +1476,6 @@ void pass_deferred_lights(r3d_target_t ssaoSource)
         R3D_PRIMITIVE_DRAW_SCREEN();
     }
 
-    /* --- Unbind all textures --- */
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uAlbedoTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uNormalTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uDepthTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.lighting, uOrmTex);
-
-    R3D_SHADER_UNBIND_SAMPLER_2D_ARRAY(deferred.lighting, uShadowDirTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D_ARRAY(deferred.lighting, uShadowSpotTex);
-    R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(deferred.lighting, uShadowOmniTex);
-
     /* --- Reset undesired state --- */
 
     glDisable(GL_SCISSOR_TEST);
@@ -1591,30 +1495,19 @@ void pass_deferred_ambient(r3d_target_t ssaoSource, r3d_target_t ssilSource, r3d
     R3D_TARGET_BIND(R3D_TARGET_LIGHTING);
     R3D_SHADER_USE(deferred.ambient);
 
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uSsaoTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssaoSource), WHITE));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uSsilTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssilSource), BLACK));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uSsrTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssrSource), BLANK));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
-    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uIrradianceTex, r3d_env_irradiance_get());
-    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uPrefilterTex, r3d_env_prefilter_get());
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.ambient, uBrdfLutTex, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uSsaoTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssaoSource), WHITE));
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uSsilTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssilSource), BLACK));
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uSsrTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssrSource), BLANK));
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uIrradianceTex, r3d_env_irradiance_get());
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uPrefilterTex, r3d_env_prefilter_get());
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uBrdfLutTex, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
     R3D_SHADER_SET_FLOAT(deferred.ambient, uMipCountSSR, (float)r3d_target_get_mip_count(R3D_TARGET_SSR));
 
     R3D_PRIMITIVE_DRAW_SCREEN();
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uAlbedoTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uNormalTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uDepthTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uSsaoTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uSsilTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uSsrTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uOrmTex);
-    R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uIrradianceTex);
-    R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(deferred.ambient, uPrefilterTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.ambient, uBrdfLutTex);
 }
 
 void pass_deferred_compose(r3d_target_t sceneTarget)
@@ -1628,13 +1521,10 @@ void pass_deferred_compose(r3d_target_t sceneTarget)
 
     R3D_SHADER_USE(deferred.compose);
 
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.compose, uDiffuseTex, r3d_target_get(R3D_TARGET_DIFFUSE));
-    R3D_SHADER_BIND_SAMPLER_2D(deferred.compose, uSpecularTex, r3d_target_get(R3D_TARGET_SPECULAR));
+    R3D_SHADER_BIND_SAMPLER(deferred.compose, uDiffuseTex, r3d_target_get(R3D_TARGET_DIFFUSE));
+    R3D_SHADER_BIND_SAMPLER(deferred.compose, uSpecularTex, r3d_target_get(R3D_TARGET_SPECULAR));
 
     R3D_PRIMITIVE_DRAW_SCREEN();
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.compose, uDiffuseTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(deferred.compose, uSpecularTex);
 }
 
 void pass_scene_forward(r3d_target_t sceneTarget)
@@ -1647,13 +1537,13 @@ void pass_scene_forward(r3d_target_t sceneTarget)
     glDepthMask(GL_FALSE);
     glEnable(GL_BLEND);
 
-    R3D_SHADER_BIND_SAMPLER_2D_ARRAY(scene.forward, uShadowDirTex, r3d_light_shadow_get(R3D_LIGHT_DIR));
-    R3D_SHADER_BIND_SAMPLER_2D_ARRAY(scene.forward, uShadowSpotTex, r3d_light_shadow_get(R3D_LIGHT_SPOT));
-    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.forward, uShadowOmniTex, r3d_light_shadow_get(R3D_LIGHT_OMNI));
+    R3D_SHADER_BIND_SAMPLER(scene.forward, uShadowDirTex, r3d_light_shadow_get(R3D_LIGHT_DIR));
+    R3D_SHADER_BIND_SAMPLER(scene.forward, uShadowSpotTex, r3d_light_shadow_get(R3D_LIGHT_SPOT));
+    R3D_SHADER_BIND_SAMPLER(scene.forward, uShadowOmniTex, r3d_light_shadow_get(R3D_LIGHT_OMNI));
 
-    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.forward, uIrradianceTex, r3d_env_irradiance_get());
-    R3D_SHADER_BIND_SAMPLER_CUBE_ARRAY(scene.forward, uPrefilterTex, r3d_env_prefilter_get());
-    R3D_SHADER_BIND_SAMPLER_2D(scene.forward, uBrdfLutTex, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
+    R3D_SHADER_BIND_SAMPLER(scene.forward, uIrradianceTex, r3d_env_irradiance_get());
+    R3D_SHADER_BIND_SAMPLER(scene.forward, uPrefilterTex, r3d_env_prefilter_get());
+    R3D_SHADER_BIND_SAMPLER(scene.forward, uBrdfLutTex, r3d_texture_get(R3D_TEXTURE_IBL_BRDF_LUT));
 
     R3D_SHADER_SET_VEC3(scene.forward, uViewPosition, R3D.viewState.viewPosition);
 
@@ -1662,17 +1552,6 @@ void pass_scene_forward(r3d_target_t sceneTarget)
         upload_light_array_block_for_mesh(call, true);
         raster_forward(call);
     }
-
-    R3D_SHADER_UNBIND_SAMPLER_2D_ARRAY(scene.forward, uShadowDirTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D_ARRAY(scene.forward, uShadowSpotTex);
-    R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.forward, uShadowOmniTex);
-
-    R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.forward, uIrradianceTex);
-    R3D_SHADER_UNBIND_SAMPLER_CUBE_ARRAY(scene.forward, uPrefilterTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(scene.forward, uBrdfLutTex);
-
-    // NOTE: The storage texture of the matrices may have been bind during drawcalls
-    R3D_SHADER_UNBIND_SAMPLER_1D(scene.forward, uBoneMatricesTex);
 }
 
 void pass_scene_background(r3d_target_t sceneTarget)
@@ -1688,15 +1567,13 @@ void pass_scene_background(r3d_target_t sceneTarget)
         R3D_SHADER_USE(scene.skybox);
         glDisable(GL_CULL_FACE);
 
-        R3D_SHADER_BIND_SAMPLER_CUBE(scene.skybox, uSkyMap, R3D.environment.background.sky.texture);
+        R3D_SHADER_BIND_SAMPLER(scene.skybox, uSkyMap, R3D.environment.background.sky.texture);
         R3D_SHADER_SET_FLOAT(scene.skybox, uSkyEnergy, R3D.environment.background.energy);
         R3D_SHADER_SET_VEC4(scene.skybox, uRotation, R3D.environment.background.rotation);
         R3D_SHADER_SET_MAT4(scene.skybox, uMatView, R3D.viewState.view);
         R3D_SHADER_SET_MAT4(scene.skybox, uMatProj, R3D.viewState.proj);
 
         R3D_PRIMITIVE_DRAW_CUBE();
-
-        R3D_SHADER_UNBIND_SAMPLER_CUBE(scene.skybox, uSkyMap);
     }
     else {
         Vector4 background = r3d_color_to_linear_scaled_vec4(
@@ -1723,8 +1600,8 @@ r3d_target_t pass_post_fog(r3d_target_t sceneTarget)
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
     R3D_SHADER_USE(post.fog);
 
-    R3D_SHADER_BIND_SAMPLER_2D(post.fog, uSceneTex, r3d_target_get(sceneTarget));
-    R3D_SHADER_BIND_SAMPLER_2D(post.fog, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER(post.fog, uSceneTex, r3d_target_get(sceneTarget));
+    R3D_SHADER_BIND_SAMPLER(post.fog, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_SHADER_SET_INT(post.fog, uFogMode, R3D.environment.fog.mode);
     R3D_SHADER_SET_COL3(post.fog, uFogColor, R3D.colorSpace, R3D.environment.fog.color);
@@ -1735,9 +1612,6 @@ r3d_target_t pass_post_fog(r3d_target_t sceneTarget)
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.fog, uSceneTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.fog, uDepthTex);
-
     return sceneTarget;
 }
 
@@ -1746,8 +1620,8 @@ r3d_target_t pass_post_dof(r3d_target_t sceneTarget)
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
     R3D_SHADER_USE(post.dof);
 
-    R3D_SHADER_BIND_SAMPLER_2D(post.dof, uSceneTex, r3d_target_get(sceneTarget));
-    R3D_SHADER_BIND_SAMPLER_2D(post.dof, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
+    R3D_SHADER_BIND_SAMPLER(post.dof, uSceneTex, r3d_target_get(sceneTarget));
+    R3D_SHADER_BIND_SAMPLER(post.dof, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_SHADER_SET_FLOAT(post.dof, uFocusPoint, R3D.environment.dof.focusPoint);
     R3D_SHADER_SET_FLOAT(post.dof, uFocusScale, R3D.environment.dof.focusScale);
@@ -1755,9 +1629,6 @@ r3d_target_t pass_post_dof(r3d_target_t sceneTarget)
     R3D_SHADER_SET_INT(post.dof, uDebugMode, R3D.environment.dof.debugMode);
 
     R3D_PRIMITIVE_DRAW_SCREEN();
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.dof, uSceneTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.dof, uDepthTex);
 
     return sceneTarget;
 }
@@ -1800,7 +1671,7 @@ r3d_target_t pass_post_bloom(r3d_target_t sceneTarget)
     r3d_target_get_texel_size(&txSrcW, &txSrcH, R3D_TARGET_BLOOM, 0);
     r3d_target_set_mip_level(0, 0);
 
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.bloomDown, uTexture, sceneSourceID);
+    R3D_SHADER_BIND_SAMPLER(prepare.bloomDown, uTexture, sceneSourceID);
 
     R3D_SHADER_SET_VEC2(prepare.bloomDown, uTexelSize, (Vector2) {txSrcW, txSrcH});
     R3D_SHADER_SET_VEC4(prepare.bloomDown, uPrefilter, prefilter);
@@ -1812,7 +1683,7 @@ r3d_target_t pass_post_bloom(r3d_target_t sceneTarget)
 
     // It's okay to sample the target here
     // Given that we'll be sampling a different level from where we're writing
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.bloomDown, uTexture, r3d_target_get(R3D_TARGET_BLOOM));
+    R3D_SHADER_BIND_SAMPLER(prepare.bloomDown, uTexture, r3d_target_get(R3D_TARGET_BLOOM));
 
     for (int dstLevel = 1; dstLevel < maxLevel; dstLevel++)
     {
@@ -1829,8 +1700,6 @@ r3d_target_t pass_post_bloom(r3d_target_t sceneTarget)
         R3D_PRIMITIVE_DRAW_SCREEN();
     }
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.bloomDown, uTexture);
-
     /* --- Bloom Upsampling --- */
 
     R3D_SHADER_USE(prepare.bloomUp);
@@ -1839,7 +1708,7 @@ r3d_target_t pass_post_bloom(r3d_target_t sceneTarget)
     glBlendFunc(GL_ONE, GL_ONE);
     glBlendEquation(GL_FUNC_ADD);
 
-    R3D_SHADER_BIND_SAMPLER_2D(prepare.bloomUp, uTexture, r3d_target_get(R3D_TARGET_BLOOM));
+    R3D_SHADER_BIND_SAMPLER(prepare.bloomUp, uTexture, r3d_target_get(R3D_TARGET_BLOOM));
 
     for (int dstLevel = maxLevel - 2; dstLevel >= 0; dstLevel--)
     {
@@ -1857,8 +1726,6 @@ r3d_target_t pass_post_bloom(r3d_target_t sceneTarget)
         R3D_PRIMITIVE_DRAW_SCREEN();
     }
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(prepare.bloomUp, uTexture);
-
     glDisable(GL_BLEND);
 
     /* --- Apply bloom to the scene --- */
@@ -1866,16 +1733,13 @@ r3d_target_t pass_post_bloom(r3d_target_t sceneTarget)
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
     R3D_SHADER_USE(post.bloom);
 
-    R3D_SHADER_BIND_SAMPLER_2D(post.bloom, uSceneTex, sceneSourceID);
-    R3D_SHADER_BIND_SAMPLER_2D(post.bloom, uBloomTex, r3d_target_get(R3D_TARGET_BLOOM));
+    R3D_SHADER_BIND_SAMPLER(post.bloom, uSceneTex, sceneSourceID);
+    R3D_SHADER_BIND_SAMPLER(post.bloom, uBloomTex, r3d_target_get(R3D_TARGET_BLOOM));
 
     R3D_SHADER_SET_INT(post.bloom, uBloomMode, R3D.environment.bloom.mode);
     R3D_SHADER_SET_FLOAT(post.bloom, uBloomIntensity, R3D.environment.bloom.intensity);
 
     R3D_PRIMITIVE_DRAW_SCREEN();
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.bloom, uSceneTex);
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.bloom, uBloomTex);
 
     return sceneTarget;
 }
@@ -1885,7 +1749,7 @@ r3d_target_t pass_post_output(r3d_target_t sceneTarget)
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
     R3D_SHADER_USE(post.output);
 
-    R3D_SHADER_BIND_SAMPLER_2D(post.output, uSceneTex, r3d_target_get(sceneTarget));
+    R3D_SHADER_BIND_SAMPLER(post.output, uSceneTex, r3d_target_get(sceneTarget));
 
     R3D_SHADER_SET_FLOAT(post.output, uTonemapExposure, R3D.environment.tonemap.exposure);
     R3D_SHADER_SET_FLOAT(post.output, uTonemapWhite, R3D.environment.tonemap.white);
@@ -1896,8 +1760,6 @@ r3d_target_t pass_post_output(r3d_target_t sceneTarget)
 
     R3D_PRIMITIVE_DRAW_SCREEN();
 
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.output, uSceneTex);
-
     return sceneTarget;
 }
 
@@ -1906,18 +1768,18 @@ r3d_target_t pass_post_fxaa(r3d_target_t sceneTarget)
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
     R3D_SHADER_USE(post.fxaa);
 
-    R3D_SHADER_BIND_SAMPLER_2D(post.fxaa, uSourceTex, r3d_target_get(sceneTarget));
+    R3D_SHADER_BIND_SAMPLER(post.fxaa, uSourceTex, r3d_target_get(sceneTarget));
 
     R3D_SHADER_SET_VEC2(post.fxaa, uSourceTexel, (Vector2) {R3D_TARGET_TEXEL_SIZE});
     R3D_PRIMITIVE_DRAW_SCREEN();
-
-    R3D_SHADER_UNBIND_SAMPLER_2D(post.fxaa, uSourceTex);
 
     return sceneTarget;
 }
 
 void reset_raylib_state(void)
 {
+    r3d_shader_unbind_samplers();
+
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glBindVertexArray(0);
     glUseProgram(0);


### PR DESCRIPTION
The management of binding points for samplers has been revised.

The goal was to stop having to unbind textures after each pass, in order to avoid potentially having multiple targets on the same binding point used in a shader.

So, I created an enum for each sampler type (I intentionally left gaps to make editing easier):

```c
typedef enum {

    // Material maps
    R3D_SHADER_SAMPLER_MAP_ALBEDO       = 1,
    R3D_SHADER_SAMPLER_MAP_EMISSION     = 2,
    R3D_SHADER_SAMPLER_MAP_NORMAL       = 3,
    R3D_SHADER_SAMPLER_MAP_ORM          = 4,

    // Shadow maps
    R3D_SHADER_SAMPLER_SHADOW_DIR       = 10,
    R3D_SHADER_SAMPLER_SHADOW_SPOT      = 11,
    R3D_SHADER_SAMPLER_SHADOW_OMNI      = 12,

    // IBL maps
    R3D_SHADER_SAMPLER_IBL_IRRADIANCE   = 15,
    R3D_SHADER_SAMPLER_IBL_PREFILTER    = 16,
    R3D_SHADER_SAMPLER_IBL_BRDF_LUT     = 17,

    // Scene miscs
    R3D_SHADER_SAMPLER_BONE_MATRICES    = 20,

    // Buffers
    R3D_SHADER_SAMPLER_BUFFER_DEPTH     = 25,
    R3D_SHADER_SAMPLER_BUFFER_ALBEDO    = 26,
    R3D_SHADER_SAMPLER_BUFFER_NORMAL    = 27,
    R3D_SHADER_SAMPLER_BUFFER_ORM       = 28,
    R3D_SHADER_SAMPLER_BUFFER_DIFFUSE   = 29,
    R3D_SHADER_SAMPLER_BUFFER_SPECULAR  = 30,
    R3D_SHADER_SAMPLER_BUFFER_SSAO      = 31,
    R3D_SHADER_SAMPLER_BUFFER_SSIL      = 32,
    R3D_SHADER_SAMPLER_BUFFER_SSR       = 33,
    R3D_SHADER_SAMPLER_BUFFER_BLOOM     = 34,
    R3D_SHADER_SAMPLER_BUFFER_SCENE     = 35,

    // Unnamed for special passes
    R3D_SHADER_SAMPLER_SOURCE_2D        = 50,
    R3D_SHADER_SAMPLER_SOURCE_CUBE      = 55,

    // Sentinel
    R3D_SHADER_SAMPLER_COUNT

} r3d_shader_sampler_t;
```

This enum is only explicitly used during shader loading. There is also an array that contains the texture target type for each sampler (and zero, or `GL_NONE` if you want, for undefined ones).

Next, I modified the sampler uniform types on the client side. There is now only one type `r3d_shader_uniform_sampler_t` which only contains the slot defined at loading.

We could technically avoid this and use the enum above directly, but that would be error-prone and require too many changes. Continuing to use macros with the real uniform names is easier to maintain.

Also, it is now no longer necessary to get the sampler location before defining its binding point. You just call the `SET_SAMPLER` macro after `USE_SHADER` during loading, for example:

```c
void r3d_shader_load_prepare_blur_down(void)
{
    // Load
    LOAD_SHADER(prepare.blurDown, SCREEN_VERT, BLUR_DOWN_FRAG);
    
    // Get uniform locations
    GET_LOCATION(prepare.blurDown, uSourceLod);
    
    // Use and set binding points
    USE_SHADER(prepare.blurDown);
    SET_SAMPLER(prepare.blurDown, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D);
}
```

I also removed all the macro "overloads" for binding textures. There is now only `R3D_SHADER_BIND_SAMPLER`, which works the same way as before. There are no unbind macros anymore, since everything is safe now.

Additionally, the macro calls a function that checks if the provided texture is already bound to the slot. If it is, it skips the binding.

However, since this state needs to be reset at some point (because we don't know what happens outside of R3D) and it's safer to leave a clean state when handing control back to raylib, there is still a function `r3d_shader_unbind_samplers` that unbinds all bound textures and resets the state in the process.

Finally, binding point 0 (`GL_TEXTURE0`) is not used for samplers and is reserved for operations on textures like parameter setting, mipmap generation, etc.

For safety, the function called by `R3D_SHADER_BIND_SAMPLER` always resets the active slot to `GL_TEXTURE0`. Of course, this could be improved further, but it's impossible in our context to always guarantee the complete state. So the best approach is to reset the slot each time. Even with this, the number of API calls has been drastically reduced, so we're still in the clear!

Obviously, this wasn't the most expensive operation, _clearly not_, but it simplified the code quite a bit, so it's a WIN WIN :D