### PR TITLE
store tangents in normal render target

### DIFF
--- a/shaders/scene/decal.frag
+++ b/shaders/scene/decal.frag
@@ -43,7 +43,7 @@ uniform vec2 uTexCoordScale;
 
 layout(location = 0) out vec4 FragAlbedo;
 layout(location = 1) out vec4 FragEmission;
-layout(location = 2) out vec2 FragNormal; // Unused - normal output placeholder
+layout(location = 2) out vec4 FragNormal; // Unused - normal output placeholder
 layout(location = 3) out vec3 FragORM;
 
 /* === Main function === */

--- a/shaders/scene/geometry.frag
+++ b/shaders/scene/geometry.frag
@@ -36,7 +36,7 @@ uniform float uMetalness;
 
 layout(location = 0) out vec3 FragAlbedo;
 layout(location = 1) out vec3 FragEmission;
-layout(location = 2) out vec2 FragNormal;
+layout(location = 2) out vec4 FragNormal;
 layout(location = 3) out vec3 FragORM;
 
 /* === Main function === */
@@ -47,11 +47,16 @@ void main()
     if (albedo.a < uAlphaCutoff) discard;
 
     vec3 N = normalize(vTBN * M_NormalScale(texture(uNormalMap, vTexCoord).rgb * 2.0 - 1.0, uNormalScale));
-    if (!gl_FrontFacing) N = -N; // Flip for back facing triangles with double sided meshes
+    vec3 T = vTBN[0];
+    if (!gl_FrontFacing) { // Flip for back facing triangles with double sided meshes
+        N = -N;
+        T = -T;
+    }
 
     FragAlbedo = albedo.rgb;
     FragEmission = vEmission * texture(uEmissionMap, vTexCoord).rgb;
-    FragNormal = M_EncodeOctahedral(N);
+    FragNormal.rg = M_EncodeOctahedral(N);
+    FragNormal.ba = M_EncodeOctahedral(T);
 
     vec3 orm = texture(uOrmMap, vTexCoord).rgb;
 

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -41,7 +41,7 @@ typedef struct {
 
 static const target_config_t TARGET_CONFIG[] = {
     [R3D_TARGET_ALBEDO]     = { GL_RGB8,              GL_RGB,             GL_UNSIGNED_BYTE,  1.0f, GL_NEAREST,               GL_NEAREST, false },
-    [R3D_TARGET_NORMAL]     = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },
+    [R3D_TARGET_NORM_TAN]   = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },
     [R3D_TARGET_ORM]        = { GL_RGB8,              GL_RGB,             GL_UNSIGNED_BYTE,  1.0f, GL_NEAREST,               GL_NEAREST, false },
     [R3D_TARGET_DIFFUSE]    = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },
     [R3D_TARGET_SPECULAR]   = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -41,7 +41,7 @@ typedef struct {
 
 static const target_config_t TARGET_CONFIG[] = {
     [R3D_TARGET_ALBEDO]     = { GL_RGB8,              GL_RGB,             GL_UNSIGNED_BYTE,  1.0f, GL_NEAREST,               GL_NEAREST, false },
-    [R3D_TARGET_NORMAL]     = { GL_RG16F,             GL_RG,              GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },
+    [R3D_TARGET_NORMAL]     = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },
     [R3D_TARGET_ORM]        = { GL_RGB8,              GL_RGB,             GL_UNSIGNED_BYTE,  1.0f, GL_NEAREST,               GL_NEAREST, false },
     [R3D_TARGET_DIFFUSE]    = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },
     [R3D_TARGET_SPECULAR]   = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -25,7 +25,7 @@
 typedef enum {
     R3D_TARGET_INVALID = -1,
     R3D_TARGET_ALBEDO,          //< Full - Mip 1 - RGB[8|8|8]
-    R3D_TARGET_NORMAL,          //< Full - Mip 1 - RGBA[16|16|16|16]
+    R3D_TARGET_NORM_TAN,        //< Full - Mip 1 - RGBA[16|16|16|16]
     R3D_TARGET_ORM,             //< Full - Mip 1 - RGB[8|8|8]
     R3D_TARGET_DIFFUSE,         //< Full - Mip 1 - RGB[16|16|16]
     R3D_TARGET_SPECULAR,        //< Full - Mip 1 - RGB[16|16|16]
@@ -48,7 +48,7 @@ typedef enum {
 
 #define R3D_TARGET_ALL_DEFERRED \
     R3D_TARGET_ALBEDO,          \
-    R3D_TARGET_NORMAL,          \
+    R3D_TARGET_NORM_TAN,          \
     R3D_TARGET_ORM,             \
     R3D_TARGET_DIFFUSE,         \
     R3D_TARGET_SPECULAR,        \
@@ -57,7 +57,7 @@ typedef enum {
 #define R3D_TARGET_GBUFFER      \
     R3D_TARGET_ALBEDO,          \
     R3D_TARGET_DIFFUSE,         \
-    R3D_TARGET_NORMAL,          \
+    R3D_TARGET_NORM_TAN,          \
     R3D_TARGET_ORM,             \
     R3D_TARGET_DEPTH            \
 

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -25,7 +25,7 @@
 typedef enum {
     R3D_TARGET_INVALID = -1,
     R3D_TARGET_ALBEDO,          //< Full - Mip 1 - RGB[8|8|8]
-    R3D_TARGET_NORMAL,          //< Full - Mip 1 - RG[16|16]
+    R3D_TARGET_NORMAL,          //< Full - Mip 1 - RGBA[16|16|16|16]
     R3D_TARGET_ORM,             //< Full - Mip 1 - RGB[8|8|8]
     R3D_TARGET_DIFFUSE,         //< Full - Mip 1 - RGB[16|16|16]
     R3D_TARGET_SPECULAR,        //< Full - Mip 1 - RGB[16|16|16]

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1254,7 +1254,7 @@ r3d_target_t pass_prepare_ssao(void)
     R3D_SHADER_SET_FLOAT(prepare.ssao, uIntensity, R3D.environment.ssao.intensity);
     R3D_SHADER_SET_FLOAT(prepare.ssao, uPower, R3D.environment.ssao.power);
 
-    R3D_SHADER_BIND_SAMPLER(prepare.ssao, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssao, uNormalTex, r3d_target_get(R3D_TARGET_NORM_TAN));
     R3D_SHADER_BIND_SAMPLER(prepare.ssao, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_PRIMITIVE_DRAW_SCREEN();
@@ -1263,7 +1263,7 @@ r3d_target_t pass_prepare_ssao(void)
 
     R3D_SHADER_USE(prepare.atrousWavelet);
 
-    R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uNormalTex, r3d_target_get(R3D_TARGET_NORM_TAN));
     R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     for (int i = 0; i < 3; i++) {
@@ -1305,7 +1305,7 @@ r3d_target_t pass_prepare_ssil(void)
 
     R3D_SHADER_BIND_SAMPLER(prepare.ssil, uLightingTex, r3d_target_get(R3D_TARGET_DIFFUSE));
     R3D_SHADER_BIND_SAMPLER(prepare.ssil, uHistoryTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(SSIL_HISTORY), BLACK));
-    R3D_SHADER_BIND_SAMPLER(prepare.ssil, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssil, uNormalTex, r3d_target_get(R3D_TARGET_NORM_TAN));
     R3D_SHADER_BIND_SAMPLER(prepare.ssil, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
     R3D_SHADER_SET_FLOAT(prepare.ssil, uSampleCount, (float)R3D.environment.ssil.sampleCount);
@@ -1382,7 +1382,7 @@ r3d_target_t pass_prepare_ssr(void)
 
     R3D_SHADER_BIND_SAMPLER(prepare.ssr, uLightingTex, r3d_target_get(R3D_TARGET_DIFFUSE));
     R3D_SHADER_BIND_SAMPLER(prepare.ssr, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
-    R3D_SHADER_BIND_SAMPLER(prepare.ssr, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(prepare.ssr, uNormalTex, r3d_target_get(R3D_TARGET_NORM_TAN));
     R3D_SHADER_BIND_SAMPLER(prepare.ssr, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
     R3D_SHADER_BIND_SAMPLER(prepare.ssr, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
@@ -1425,7 +1425,7 @@ void pass_deferred_lights(r3d_target_t ssaoSource)
     R3D_SHADER_USE(deferred.lighting);
 
     R3D_SHADER_BIND_SAMPLER(deferred.lighting, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
-    R3D_SHADER_BIND_SAMPLER(deferred.lighting, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(deferred.lighting, uNormalTex, r3d_target_get(R3D_TARGET_NORM_TAN));
     R3D_SHADER_BIND_SAMPLER(deferred.lighting, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
     R3D_SHADER_BIND_SAMPLER(deferred.lighting, uSsaoTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssaoSource), WHITE));
     R3D_SHADER_BIND_SAMPLER(deferred.lighting, uOrmTex, r3d_target_get(R3D_TARGET_ORM));
@@ -1496,7 +1496,7 @@ void pass_deferred_ambient(r3d_target_t ssaoSource, r3d_target_t ssilSource, r3d
     R3D_SHADER_USE(deferred.ambient);
 
     R3D_SHADER_BIND_SAMPLER(deferred.ambient, uAlbedoTex, r3d_target_get(R3D_TARGET_ALBEDO));
-    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
+    R3D_SHADER_BIND_SAMPLER(deferred.ambient, uNormalTex, r3d_target_get(R3D_TARGET_NORM_TAN));
     R3D_SHADER_BIND_SAMPLER(deferred.ambient, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
     R3D_SHADER_BIND_SAMPLER(deferred.ambient, uSsaoTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssaoSource), WHITE));
     R3D_SHADER_BIND_SAMPLER(deferred.ambient, uSsilTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(ssilSource), BLACK));

--- a/src/r3d_utils.c
+++ b/src/r3d_utils.c
@@ -52,7 +52,7 @@ Texture2D R3D_GetNormalTexture(void)
 Texture2D R3D_GetBufferNormal(void)
 {
     Texture2D texture = { 0 };
-    texture.id = r3d_target_get(R3D_TARGET_NORMAL);
+    texture.id = r3d_target_get(R3D_TARGET_NORM_TAN);
     texture.width = R3D_TARGET_WIDTH;
     texture.height = R3D_TARGET_HEIGHT;
     texture.mipmaps = 1;
@@ -114,7 +114,7 @@ void R3D_DrawBufferAlbedo(float x, float y, float w, float h)
 void R3D_DrawBufferNormal(float x, float y, float w, float h)
 {
     Texture2D tex = {
-        .id = r3d_target_get(R3D_TARGET_NORMAL),
+        .id = r3d_target_get(R3D_TARGET_NORM_TAN),
         .width = R3D_TARGET_WIDTH,
         .height = R3D_TARGET_HEIGHT
     };


### PR DESCRIPTION
I felt it was worth making this a separate PR ahead of it's coming use in adding normal mapping to decals. I checked through the other shaders to see if it could cause any issues and everything looks ok. Let me know any feedback.

I could see there now possibly being a more accurate name for `R3D_TARGET_NORMAL` or at least some indication of how it is arranged to store both the normals and tangents.

Note this does make `R3D_DrawBufferNormal` behave in basically a broken way. This can be addressed if this way of storing the normals/tangents is alright to merge.