### PR TITLE
Linear depth buffer + Target module review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,7 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/generic/color.frag"
     "${R3D_ROOT_PATH}/shaders/generic/screen.vert"
     "${R3D_ROOT_PATH}/shaders/generic/cubemap.vert"
+    "${R3D_ROOT_PATH}/shaders/prepare/buffer_down.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/atrous_wavelet.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/bicubic_up.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/lanczos_up.frag"

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -70,7 +70,6 @@
             .power = 1.5f,                              \
             .radius = 0.35f,                            \
             .bias = 0.007f,                             \
-            .lightAffect = 0.0f,                        \
             .enabled = false,                           \
         },                                              \
         .ssil = {                                       \
@@ -214,7 +213,6 @@ typedef struct R3D_EnvSSAO {
     float power;            ///< Exponential falloff for sharper darkening (default: 1.5)
     float radius;           ///< Sampling radius in world space (default: 0.25)
     float bias;             ///< Depth bias to prevent self-shadowing, good value is ~2% of the radius (default: 0.007)
-    float lightAffect;      ///< How much SSAO affects direct lighting [0.0-1.0] (default: 0.0)
     bool enabled;           ///< Enable/disable SSAO effect (default: false)
 } R3D_EnvSSAO;
 

--- a/shaders/deferred/ambient.frag
+++ b/shaders/deferred/ambient.frag
@@ -52,8 +52,8 @@ layout(location = 1) out vec4 FragSpecular;
 
 void main()
 {
-    vec3 albedo = texture(uAlbedoTex, vTexCoord).rgb;
-    vec3 orm = texture(uOrmTex, vTexCoord).rgb;
+    vec3 albedo = texelFetch(uAlbedoTex, ivec2(gl_FragCoord.xy), 0).rgb;
+    vec3 orm = texelFetch(uOrmTex, ivec2(gl_FragCoord).xy, 0).rgb;
 
     vec4 ssr = textureLod(uSsrTex, vTexCoord, orm.g * uSsrNumLevels);
     float ssao = texture(uSsaoTex, vTexCoord).r;
@@ -62,8 +62,8 @@ void main()
     orm.x *= ssao * ssil.w;
 
     vec3 F0 = PBR_ComputeF0(orm.z, 0.5, albedo);
-    vec3 P = V_GetWorldPosition(uDepthTex, vTexCoord);
-    vec3 N = V_GetWorldNormal(uNormalTex, vTexCoord);
+    vec3 P = V_GetWorldPosition(uDepthTex, ivec2(gl_FragCoord.xy));
+    vec3 N = V_GetWorldNormal(uNormalTex, ivec2(gl_FragCoord.xy));
     vec3 V = normalize(uView.position - P);
     float NdotV = max(dot(N, V), 0.0);
 

--- a/shaders/deferred/ambient.frag
+++ b/shaders/deferred/ambient.frag
@@ -35,7 +35,7 @@ uniform samplerCubeArray uIrradianceTex;
 uniform samplerCubeArray uPrefilterTex;
 uniform sampler2D uBrdfLutTex;
 
-uniform float uMipCountSSR;
+uniform float uSsrNumLevels;
 uniform float uSsilEnergy;
 
 /* === Blocks === */
@@ -55,7 +55,7 @@ void main()
     vec3 albedo = texture(uAlbedoTex, vTexCoord).rgb;
     vec3 orm = texture(uOrmTex, vTexCoord).rgb;
 
-    vec4 ssr = textureLod(uSsrTex, vTexCoord, orm.g * uMipCountSSR);
+    vec4 ssr = textureLod(uSsrTex, vTexCoord, orm.g * uSsrNumLevels);
     float ssao = texture(uSsaoTex, vTexCoord).r;
     vec4 ssil = texture(uSsilTex, vTexCoord);
 

--- a/shaders/deferred/compose.frag
+++ b/shaders/deferred/compose.frag
@@ -28,8 +28,8 @@ layout(location = 0) out vec3 FragColor;
 
 void main()
 {
-    vec3 diffuse = texture(uDiffuseTex, vTexCoord).rgb;
-    vec3 specular = texture(uSpecularTex, vTexCoord).rgb;
+    vec3 diffuse = texelFetch(uDiffuseTex, ivec2(gl_FragCoord.xy), 0).rgb;
+    vec3 specular = texelFetch(uSpecularTex, ivec2(gl_FragCoord.xy), 0).rgb;
 
     FragColor = diffuse + specular;
 }

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -29,14 +29,11 @@ noperspective in vec2 vTexCoord;
 uniform sampler2D uAlbedoTex;
 uniform sampler2D uNormalTex;
 uniform sampler2D uDepthTex;
-uniform sampler2D uSsaoTex;
 uniform sampler2D uOrmTex;
 
 uniform sampler2DArray uShadowDirTex;
 uniform sampler2DArray uShadowSpotTex;
 uniform samplerCubeArray uShadowOmniTex;
-
-uniform float uSSAOLightAffect;
 
 /* === Fragments === */
 
@@ -246,10 +243,6 @@ void main()
         float epsilon = (uLight.innerCutOff - uLight.outerCutOff);
         shadow *= smoothstep(0.0, 1.0, (theta - uLight.outerCutOff) / epsilon);
     }
-
-	/* Apply SSAO to diffuse lighting (accordingly to light affect) */
-
-    diffuse *= mix(1.0, texture(uSsaoTex, vTexCoord).r, uSSAOLightAffect);
 
     /* Compute final lighting contribution */
 

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -155,8 +155,8 @@ void main()
 {
     /* Sample albedo and ORM texture and extract values */
     
-    vec3 albedo = texture(uAlbedoTex, vTexCoord).rgb;
-    vec3 orm = texture(uOrmTex, vTexCoord).rgb;
+    vec3 albedo = texelFetch(uAlbedoTex, ivec2(gl_FragCoord).xy, 0).rgb;
+    vec3 orm = texelFetch(uOrmTex, ivec2(gl_FragCoord).xy, 0).rgb;
     float roughness = orm.g;
     float metalness = orm.b;
 
@@ -166,8 +166,8 @@ void main()
 
     /* Get position and normal in world space */
 
-    vec3 position = V_GetWorldPosition(uDepthTex, vTexCoord);
-    vec3 N = V_GetWorldNormal(uNormalTex, vTexCoord);
+    vec3 position = V_GetWorldPosition(uDepthTex, ivec2(gl_FragCoord.xy));
+    vec3 N = V_GetWorldNormal(uNormalTex, ivec2(gl_FragCoord.xy));
 
     /* Compute view direction and the dot product of the normal and view direction */
     

--- a/shaders/include/blocks/view.glsl
+++ b/shaders/include/blocks/view.glsl
@@ -27,12 +27,15 @@ layout(std140) uniform ViewBlock {
 vec3 V_GetViewPosition(vec2 texCoord, float linearDepth)
 {
     vec2 ndc = texCoord * 2.0 - 1.0;
-
     float tanHalfFov = 1.0 / uView.proj[1][1];
-    float aspect = uView.proj[1][1] / uView.proj[0][0];
-    vec3 viewRay = vec3(ndc.x * tanHalfFov * aspect, ndc.y * tanHalfFov, -1.0);
 
-    return viewRay * (linearDepth / abs(viewRay.z));
+    vec3 viewRay = vec3(
+        ndc.x * tanHalfFov * uView.aspect,
+        ndc.y * tanHalfFov,
+        -1.0
+    );
+
+    return viewRay * linearDepth;
 }
 
 vec3 V_GetViewPosition(sampler2D texLinearDepth, vec2 texCoord)

--- a/shaders/post/dof.frag
+++ b/shaders/post/dof.frag
@@ -59,7 +59,7 @@ void main()
     vec2 texelSize = 1.0 / vec2(textureSize(uSceneTex, 0));
 
     // Center depth and CoC
-    float centerDepth = texture(uDepthTex, vTexCoord).r;
+    float centerDepth = texelFetch(uDepthTex, ivec2(gl_FragCoord.xy), 0).r;
     float centerSize  = GetBlurSize(centerDepth);
 
     //scatter as gather

--- a/shaders/post/dof.frag
+++ b/shaders/post/dof.frag
@@ -59,7 +59,7 @@ void main()
     vec3 color = texture(uSceneTex, vTexCoord).rgb;
 
     // Center depth and CoC
-    float centerDepth = V_GetLinearDepth(uDepthTex, vTexCoord);
+    float centerDepth = texture(uDepthTex, vTexCoord).r;
     float centerSize  = GetBlurSize(centerDepth);
 
     //scatter as gather
@@ -71,7 +71,7 @@ void main()
         vec2 tc = vTexCoord + vec2(cos(ang), sin(ang)) * texelSize * radius;
 
         vec3 sampleColor = texture(uSceneTex, tc).rgb;
-        float sampleDepth = V_GetLinearDepth(uDepthTex, tc);
+        float sampleDepth = texture(uDepthTex, tc).r;
         float sampleSize  = GetBlurSize(sampleDepth);
 
         if (sampleDepth > centerDepth) {

--- a/shaders/post/dof.frag
+++ b/shaders/post/dof.frag
@@ -55,8 +55,8 @@ float GetBlurSize(float depth)
 
 void main()
 {
+    vec3 color = texelFetch(uSceneTex, ivec2(gl_FragCoord.xy), 0).rgb;
     vec2 texelSize = 1.0 / vec2(textureSize(uSceneTex, 0));
-    vec3 color = texture(uSceneTex, vTexCoord).rgb;
 
     // Center depth and CoC
     float centerDepth = texture(uDepthTex, vTexCoord).r;

--- a/shaders/post/fog.frag
+++ b/shaders/post/fog.frag
@@ -70,11 +70,11 @@ float FogFactor(float dist, int mode, float density, float start, float end)
 
 void main()
 {
-    float depth = V_GetLinearDepth(uDepthTex, vTexCoord);
-    vec3 color = texture(uSceneTex, vTexCoord).rgb;
+    vec3 color = texelFetch(uSceneTex, ivec2(gl_FragCoord.xy), 0).rgb;
+    float depth = texelFetch(uDepthTex, ivec2(gl_FragCoord.xy), 0).r;
 
     float fogFactor = FogFactor(depth, uFogMode, uFogDensity, uFogStart, uFogEnd);
-    fogFactor *= uSkyAffect * step(depth, uView.far);
+    fogFactor *= mix(1.0, uSkyAffect, step(uView.far, depth));
     color = mix(color, uFogColor, fogFactor);
 
     FragColor = vec4(color, 1.0);

--- a/shaders/post/output.frag
+++ b/shaders/post/output.frag
@@ -219,7 +219,7 @@ vec3 LinearToSRGB(vec3 color)
 
 void main()
 {
-    vec3 color = texture(uSceneTex, vTexCoord).rgb;
+    vec3 color = texelFetch(uSceneTex, ivec2(gl_FragCoord.xy), 0).rgb;
 
     color = Tonemapping(color, uTonemapExposure, uTonemapWhite);
     color = Adjustments(color, uBrightness, uContrast, uSaturation);

--- a/shaders/post/visualizer.frag
+++ b/shaders/post/visualizer.frag
@@ -42,7 +42,7 @@ out vec4 FragColor;
 
 void main()
 {
-    FragColor = textureLod(uSourceTex, vTexCoord, 1.0);
+    FragColor = texture(uSourceTex, vTexCoord);
 
     switch (uOutputMode) {
     case OUTPUT_ALBEDO:

--- a/shaders/prepare/atrous_wavelet.frag
+++ b/shaders/prepare/atrous_wavelet.frag
@@ -91,18 +91,17 @@ void main()
     vec4 result = vec4(0.0);
     float totalWeight = 0.0;
 
-    vec2 texelSize = 1.0 / vec2(textureSize(uSourceTex, 0));
-    vec3 centerNormal = V_GetViewNormal(uNormalTex, vTexCoord);
-    float centerDepth = V_GetLinearDepth(uDepthTex, vTexCoord);
+    vec3 centerNormal = V_GetViewNormal(uNormalTex, ivec2(gl_FragCoord.xy));
+    float centerDepth = texelFetch(uDepthTex, ivec2(gl_FragCoord.xy), 0).r;
 
     for (int i = 0; i < KERNEL_SIZE; ++i)
     {
-        vec2 offset = vec2(OFFSETS[i] * uStepSize) * texelSize;
-        vec2 uv = vTexCoord + offset;
+        ivec2 offset = OFFSETS[i] * uStepSize;
+        ivec2 pixCoord = ivec2(gl_FragCoord.xy) + offset;
 
-        vec4 sampleValue = texture(uSourceTex, uv);
-        vec3 sampleNormal = V_GetViewNormal(uNormalTex, uv);
-        float sampleDepth = V_GetLinearDepth(uDepthTex, uv);
+        vec4 sampleValue = texelFetch(uSourceTex, pixCoord, 0);
+        vec3 sampleNormal = V_GetViewNormal(uNormalTex, pixCoord);
+        float sampleDepth = texelFetch(uDepthTex, pixCoord, 0).r;
 
         float wNormal = NormalWeight(centerNormal, sampleNormal);
         float wDepth = DepthWeight(centerDepth, sampleDepth);

--- a/shaders/prepare/buffer_down.frag
+++ b/shaders/prepare/buffer_down.frag
@@ -1,0 +1,51 @@
+#version 330 core
+
+/* === Varyings === */
+
+noperspective in vec2 vTexCoord;
+
+/* === Uniforms === */
+
+uniform sampler2D uAlbedoTex;
+uniform sampler2D uNormalTex;
+uniform sampler2D uOrmTex;
+uniform sampler2D uDepthTex;
+uniform sampler2D uDiffuseTex;
+
+/* === Fragments === */
+
+layout(location = 0) out vec4 FragAlbedo;
+layout(location = 1) out vec4 FragNormal;
+layout(location = 2) out vec4 FragOrm;
+layout(location = 3) out vec4 FragDepth;
+layout(location = 4) out vec4 FragDiffuse;
+
+/* === Main Program === */
+
+void main()
+{
+    ivec2 pixCoord = 2 * ivec2(gl_FragCoord.xy);
+
+    ivec2 p0 = pixCoord + ivec2(0, 0);
+    ivec2 p1 = pixCoord + ivec2(1, 0);
+    ivec2 p2 = pixCoord + ivec2(0, 1);
+    ivec2 p3 = pixCoord + ivec2(1, 1);
+
+    float d0 = texelFetch(uDepthTex, p0, 0).r;
+    float d1 = texelFetch(uDepthTex, p1, 0).r;
+    float d2 = texelFetch(uDepthTex, p2, 0).r;
+    float d3 = texelFetch(uDepthTex, p3, 0).r;
+
+    ivec2 selectedPixel = p0;
+    float closestDepth = d0;
+
+    if (d1 < closestDepth) { selectedPixel = p1; closestDepth = d1; }
+    if (d2 < closestDepth) { selectedPixel = p2; closestDepth = d2; }
+    if (d3 < closestDepth) { selectedPixel = p3; closestDepth = d3; }
+
+    FragNormal  = texelFetch(uNormalTex, selectedPixel, 0);
+    FragDepth   = vec4(closestDepth, 0.0, 0.0, 1.0);
+    FragAlbedo  = texelFetch(uAlbedoTex, selectedPixel, 0);
+    FragOrm     = texelFetch(uOrmTex, selectedPixel, 0);
+    FragDiffuse = texelFetch(uDiffuseTex, selectedPixel, 0);
+}

--- a/shaders/prepare/buffer_down.frag
+++ b/shaders/prepare/buffer_down.frag
@@ -1,3 +1,11 @@
+/* buffer_down.frag - G-Buffers downsampling fragment shader
+ *
+ * Copyright (c) 2025 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
 #version 330 core
 
 /* === Varyings === */

--- a/shaders/prepare/ssao.frag
+++ b/shaders/prepare/ssao.frag
@@ -57,8 +57,8 @@ vec2 TapLocation(int i, float spinAngle, out float rNorm)
 
 void main()
 {
-    vec3 position = V_GetViewPosition(uDepthTex, vTexCoord);
-    vec3 normal = V_GetViewNormal(uNormalTex, vTexCoord);
+    vec3 position = V_GetViewPosition(uDepthTex, ivec2(gl_FragCoord.xy));
+    vec3 normal = V_GetViewNormal(uNormalTex, ivec2(gl_FragCoord.xy));
 
     // Compute the radius in screen space
     float ssRadius = uRadius * uView.proj[1][1] / -position.z;

--- a/shaders/prepare/ssil.frag
+++ b/shaders/prepare/ssil.frag
@@ -85,8 +85,8 @@ vec2 FastAcos(vec2 x)
 
 void main()
 {
-    vec3 position = V_GetViewPosition(uDepthTex, vTexCoord);
-    vec3 normal = V_GetViewNormal(uNormalTex, vTexCoord);
+    vec3 position = V_GetViewPosition(uDepthTex, ivec2(gl_FragCoord.xy));
+    vec3 normal = V_GetViewNormal(uNormalTex, ivec2(gl_FragCoord.xy));
     vec3 camera = normalize(-position);
 
     float jitter = M_HashIGN(gl_FragCoord.xy);
@@ -161,7 +161,7 @@ void main()
     }
 
     indirect /= uSliceCount;
-    vec4 history = texture(uHistoryTex, vTexCoord);
+    vec4 history = texelFetch(uHistoryTex, ivec2(gl_FragCoord.xy), 0);
     indirect.rgb = mix(indirect.rgb, history.rgb, uConvergence);
 
     FragColor = vec4(indirect.rgb, pow(indirect.a, uAoPower));

--- a/shaders/prepare/ssr.frag
+++ b/shaders/prepare/ssr.frag
@@ -127,7 +127,7 @@ void main()
     FragColor = vec4(0.0);
 
     float linearDepth = texelFetch(uDepthTex, ivec2(gl_FragCoord.xy), 0).r;
-    if (linearDepth < 1e-4) return; // Clear value (nothing rendered)
+    if (linearDepth >= uView.far) return;
 
     vec3 worldNormal = V_GetWorldNormal(uNormalTex, ivec2(gl_FragCoord.xy));
     vec3 worldPos = V_GetWorldPosition(vTexCoord, linearDepth);

--- a/shaders/prepare/ssr.frag
+++ b/shaders/prepare/ssr.frag
@@ -126,11 +126,11 @@ void main()
 {
     FragColor = vec4(0.0);
 
-    float depth = texture(uDepthTex, vTexCoord).r;
-    if (depth > 1.0 - 1e-5) return;
+    float linearDepth = texelFetch(uDepthTex, ivec2(gl_FragCoord.xy), 0).r;
+    if (linearDepth < 1e-4) return; // Clear value (nothing rendered)
 
-    vec3 worldNormal = V_GetWorldNormal(uNormalTex, vTexCoord);
-    vec3 worldPos = V_GetWorldPosition(vTexCoord, depth);
+    vec3 worldNormal = V_GetWorldNormal(uNormalTex, ivec2(gl_FragCoord.xy));
+    vec3 worldPos = V_GetWorldPosition(vTexCoord, linearDepth);
 
     vec3 viewDir = normalize(worldPos - uView.position);
     vec3 reflectionDir = reflect(viewDir, worldNormal);

--- a/shaders/scene/geometry.frag
+++ b/shaders/scene/geometry.frag
@@ -10,6 +10,7 @@
 
 /* === Includes === */
 
+#include "../include/blocks/view.glsl"
 #include "../include/math.glsl"
 
 /* === Varyings === */
@@ -38,6 +39,7 @@ layout(location = 0) out vec3 FragAlbedo;
 layout(location = 1) out vec3 FragEmission;
 layout(location = 2) out vec4 FragNormal;
 layout(location = 3) out vec3 FragORM;
+layout(location = 4) out float FragDepth;
 
 /* === Main function === */
 
@@ -63,4 +65,6 @@ void main()
     FragORM.r = uOcclusion * orm.x;
     FragORM.g = uRoughness * orm.y;
     FragORM.b = uMetalness * orm.z;
+
+    FragDepth = V_LinearizeDepth(gl_FragCoord.z);
 }

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -22,6 +22,7 @@
 #include <shaders/color.frag.h>
 #include <shaders/screen.vert.h>
 #include <shaders/cubemap.vert.h>
+#include <shaders/buffer_down.frag.h>
 #include <shaders/atrous_wavelet.frag.h>
 #include <shaders/bicubic_up.frag.h>
 #include <shaders/lanczos_up.frag.h>
@@ -185,6 +186,17 @@ GLuint load_shader(const char* vsCode, const char* fsCode)
 // ========================================
 // SHADER LOADING FUNCTIONS
 // ========================================
+
+void r3d_shader_load_prepare_buffer_down(void)
+{
+    LOAD_SHADER(prepare.bufferDown, SCREEN_VERT, BUFFER_DOWN_FRAG);
+    USE_SHADER(prepare.bufferDown);
+    SET_SAMPLER(prepare.bufferDown, uAlbedoTex, R3D_SHADER_SAMPLER_BUFFER_ALBEDO);
+    SET_SAMPLER(prepare.bufferDown, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORM_TAN);
+    SET_SAMPLER(prepare.bufferDown, uOrmTex, R3D_SHADER_SAMPLER_BUFFER_ORM);
+    SET_SAMPLER(prepare.bufferDown, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+    SET_SAMPLER(prepare.bufferDown, uDiffuseTex, R3D_SHADER_SAMPLER_BUFFER_DIFFUSE);
+}
 
 void r3d_shader_load_prepare_atrous_wavelet(void)
 {
@@ -638,7 +650,7 @@ void r3d_shader_load_deferred_ambient(void)
     SET_UNIFORM_BUFFER(deferred.ambient, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(deferred.ambient, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
-    GET_LOCATION(deferred.ambient, uMipCountSSR);
+    GET_LOCATION(deferred.ambient, uSsrNumLevels);
     GET_LOCATION(deferred.ambient, uSsilEnergy);
 
     USE_SHADER(deferred.ambient);
@@ -663,14 +675,11 @@ void r3d_shader_load_deferred_lighting(void)
     SET_UNIFORM_BUFFER(deferred.lighting, LightBlock, R3D_SHADER_BLOCK_LIGHT_SLOT);
     SET_UNIFORM_BUFFER(deferred.lighting, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
-    GET_LOCATION(deferred.lighting, uSSAOLightAffect);
-
     USE_SHADER(deferred.lighting);
 
     SET_SAMPLER(deferred.lighting, uAlbedoTex, R3D_SHADER_SAMPLER_BUFFER_ALBEDO);
     SET_SAMPLER(deferred.lighting, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORM_TAN);
     SET_SAMPLER(deferred.lighting, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
-    SET_SAMPLER(deferred.lighting, uSsaoTex, R3D_SHADER_SAMPLER_BUFFER_SSAO);
     SET_SAMPLER(deferred.lighting, uOrmTex, R3D_SHADER_SAMPLER_BUFFER_ORM);
 
     SET_SAMPLER(deferred.lighting, uShadowDirTex, R3D_SHADER_SAMPLER_SHADOW_DIR);
@@ -799,6 +808,7 @@ void r3d_shader_quit()
 {
     glDeleteBuffers(R3D_SHADER_BLOCK_COUNT, R3D_MOD_SHADER.uniformBuffers);
 
+    UNLOAD_SHADER(prepare.bufferDown);
     UNLOAD_SHADER(prepare.atrousWavelet);
     UNLOAD_SHADER(prepare.bicubicUp);
     UNLOAD_SHADER(prepare.lanczosUp);

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -316,6 +316,15 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
+    r3d_shader_uniform_sampler_t uAlbedoTex;
+    r3d_shader_uniform_sampler_t uNormalTex;
+    r3d_shader_uniform_sampler_t uOrmTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
+    r3d_shader_uniform_sampler_t uDiffuseTex;
+} r3d_shader_prepare_buffer_down_t;
+
+typedef struct {
+    unsigned int id;
     r3d_shader_uniform_sampler_t uSourceTex;
     r3d_shader_uniform_sampler_t uNormalTex;
     r3d_shader_uniform_sampler_t uDepthTex;
@@ -618,7 +627,7 @@ typedef struct {
     r3d_shader_uniform_sampler_t uIrradianceTex;
     r3d_shader_uniform_sampler_t uPrefilterTex;
     r3d_shader_uniform_sampler_t uBrdfLutTex;
-    r3d_shader_uniform_float_t uMipCountSSR;
+    r3d_shader_uniform_float_t uSsrNumLevels;
     r3d_shader_uniform_float_t uSsilEnergy;
 } r3d_shader_deferred_ambient_t;
 
@@ -627,12 +636,10 @@ typedef struct {
     r3d_shader_uniform_sampler_t uAlbedoTex;
     r3d_shader_uniform_sampler_t uNormalTex;
     r3d_shader_uniform_sampler_t uDepthTex;
-    r3d_shader_uniform_sampler_t uSsaoTex;
     r3d_shader_uniform_sampler_t uOrmTex;
     r3d_shader_uniform_sampler_t uShadowDirTex;
     r3d_shader_uniform_sampler_t uShadowSpotTex;
     r3d_shader_uniform_sampler_t uShadowOmniTex;
-    r3d_shader_uniform_float_t uSSAOLightAffect;
 } r3d_shader_deferred_lighting_t;
 
 typedef struct {
@@ -708,6 +715,7 @@ extern struct r3d_shader {
 
     // Prepare shaders
     struct {
+        r3d_shader_prepare_buffer_down_t bufferDown;
         r3d_shader_prepare_atrous_wavelet_t atrousWavelet;
         r3d_shader_prepare_bicubic_up_t bicubicUp;
         r3d_shader_prepare_lanczos_up_t lanczosUp;
@@ -761,6 +769,7 @@ extern struct r3d_shader {
 
 typedef void (*r3d_shader_loader_func)(void);
 
+void r3d_shader_load_prepare_buffer_down(void);
 void r3d_shader_load_prepare_atrous_wavelet(void);
 void r3d_shader_load_prepare_bicubic_up(void);
 void r3d_shader_load_prepare_lanczos_up(void);
@@ -797,6 +806,7 @@ static const struct r3d_shader_loader {
 
     // Prepare shaders
     struct {
+        r3d_shader_loader_func bufferDown;
         r3d_shader_loader_func atrousWavelet;
         r3d_shader_loader_func bicubicUp;
         r3d_shader_loader_func lanczosUp;
@@ -845,6 +855,7 @@ static const struct r3d_shader_loader {
 } R3D_MOD_SHADER_LOADER = {
 
     .prepare = {
+        .bufferDown = r3d_shader_load_prepare_buffer_down,
         .atrousWavelet = r3d_shader_load_prepare_atrous_wavelet,
         .bicubicUp = r3d_shader_load_prepare_bicubic_up,
         .lanczosUp = r3d_shader_load_prepare_lanczos_up,

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -30,24 +30,24 @@ typedef struct {
 } target_format_t;
 
 typedef enum {
-    R3D_TARGET_R8,   R3D_TARGET_RG8,   R3D_TARGET_RGB8,   R3D_TARGET_RGBA8,
-    R3D_TARGET_R16F, R3D_TARGET_RG16F, R3D_TARGET_RGB16F, R3D_TARGET_RGBA16F,
-    R3D_TARGET_R32F, R3D_TARGET_RG32F, R3D_TARGET_RGB32F, R3D_TARGET_RGBA32F,
+    FORMAT_R8,   FORMAT_RG8,   FORMAT_RGB8,   FORMAT_RGBA8,
+    FORMAT_R16F, FORMAT_RG16F, FORMAT_RGB16F, FORMAT_RGBA16F,
+    FORMAT_R32F, FORMAT_RG32F, FORMAT_RGB32F, FORMAT_RGBA32F,
 } target_format_enum_t;
 
 static const target_format_t TARGET_FORMAT[] = {
-    [R3D_TARGET_R8]      = { GL_R8,        GL_RED,  GL_UNSIGNED_BYTE },
-    [R3D_TARGET_RG8]     = { GL_RG8,       GL_RG,   GL_UNSIGNED_BYTE },
-    [R3D_TARGET_RGB8]    = { GL_RGB8,      GL_RGB,  GL_UNSIGNED_BYTE },
-    [R3D_TARGET_RGBA8]   = { GL_RGBA8,     GL_RGBA, GL_UNSIGNED_BYTE },
-    [R3D_TARGET_R16F]    = { GL_R16F,      GL_RED,  GL_HALF_FLOAT },
-    [R3D_TARGET_RG16F]   = { GL_RG16F,     GL_RG,   GL_HALF_FLOAT },
-    [R3D_TARGET_RGB16F]  = { GL_RGB16F,    GL_RGB,  GL_HALF_FLOAT },
-    [R3D_TARGET_RGBA16F] = { GL_RGBA16F,   GL_RGBA, GL_HALF_FLOAT },
-    [R3D_TARGET_R32F]    = { GL_R32F,      GL_RED,  GL_FLOAT },
-    [R3D_TARGET_RG32F]   = { GL_RG32F,     GL_RG,   GL_FLOAT },
-    [R3D_TARGET_RGB32F]  = { GL_RGB32F,    GL_RGB,  GL_FLOAT },
-    [R3D_TARGET_RGBA32F] = { GL_RGBA32F,   GL_RGBA, GL_FLOAT },
+    [FORMAT_R8]      = { GL_R8,        GL_RED,  GL_UNSIGNED_BYTE },
+    [FORMAT_RG8]     = { GL_RG8,       GL_RG,   GL_UNSIGNED_BYTE },
+    [FORMAT_RGB8]    = { GL_RGB8,      GL_RGB,  GL_UNSIGNED_BYTE },
+    [FORMAT_RGBA8]   = { GL_RGBA8,     GL_RGBA, GL_UNSIGNED_BYTE },
+    [FORMAT_R16F]    = { GL_R16F,      GL_RED,  GL_HALF_FLOAT },
+    [FORMAT_RG16F]   = { GL_RG16F,     GL_RG,   GL_HALF_FLOAT },
+    [FORMAT_RGB16F]  = { GL_RGB16F,    GL_RGB,  GL_HALF_FLOAT },
+    [FORMAT_RGBA16F] = { GL_RGBA16F,   GL_RGBA, GL_HALF_FLOAT },
+    [FORMAT_R32F]    = { GL_R32F,      GL_RED,  GL_FLOAT },
+    [FORMAT_RG32F]   = { GL_RG32F,     GL_RG,   GL_FLOAT },
+    [FORMAT_RGB32F]  = { GL_RGB32F,    GL_RGB,  GL_FLOAT },
+    [FORMAT_RGBA32F] = { GL_RGBA32F,   GL_RGBA, GL_FLOAT },
 };
 
 // ========================================
@@ -64,21 +64,21 @@ typedef struct {
 } target_config_t;
 
 static const target_config_t TARGET_CONFIG[] = {
-    [R3D_TARGET_ALBEDO]     = { R3D_TARGET_RGB8,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
-    [R3D_TARGET_NORM_TAN]   = { R3D_TARGET_RGBA16F, 1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
-    [R3D_TARGET_ORM]        = { R3D_TARGET_RGB8,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
-    [R3D_TARGET_DEPTH]      = { R3D_TARGET_R16F,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {65504.0f, 65504.0f, 65504.0f, 65504.0f} },
-    [R3D_TARGET_DIFFUSE]    = { R3D_TARGET_RGB16F,  1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
-    [R3D_TARGET_SPECULAR]   = { R3D_TARGET_RGB16F,  1.0f, GL_NEAREST,              GL_NEAREST, 1, {0} },
-    [R3D_TARGET_SSAO_0]     = { R3D_TARGET_R8,      0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
-    [R3D_TARGET_SSAO_1]     = { R3D_TARGET_R8,      0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
-    [R3D_TARGET_SSIL_0]     = { R3D_TARGET_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
-    [R3D_TARGET_SSIL_1]     = { R3D_TARGET_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
-    [R3D_TARGET_SSIL_2]     = { R3D_TARGET_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
-    [R3D_TARGET_SSR]        = { R3D_TARGET_RGBA16F, 0.5f, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR,  0, {0} },
-    [R3D_TARGET_BLOOM]      = { R3D_TARGET_RGB16F,  0.5f, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR,  0, {0} },
-    [R3D_TARGET_SCENE_0]    = { R3D_TARGET_RGB16F,  1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
-    [R3D_TARGET_SCENE_1]    = { R3D_TARGET_RGB16F,  1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_ALBEDO]   = { FORMAT_RGB8,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
+    [R3D_TARGET_NORM_TAN] = { FORMAT_RGBA16F, 1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
+    [R3D_TARGET_ORM]      = { FORMAT_RGB8,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
+    [R3D_TARGET_DEPTH]    = { FORMAT_R16F,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {65504.0f, 65504.0f, 65504.0f, 65504.0f} },
+    [R3D_TARGET_DIFFUSE]  = { FORMAT_RGB16F,  1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
+    [R3D_TARGET_SPECULAR] = { FORMAT_RGB16F,  1.0f, GL_NEAREST,              GL_NEAREST, 1, {0} },
+    [R3D_TARGET_SSAO_0]   = { FORMAT_R8,      0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SSAO_1]   = { FORMAT_R8,      0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SSIL_0]   = { FORMAT_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SSIL_1]   = { FORMAT_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SSIL_2]   = { FORMAT_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SSR]      = { FORMAT_RGBA16F, 0.5f, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR,  0, {0} },
+    [R3D_TARGET_BLOOM]    = { FORMAT_RGB16F,  0.5f, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR,  0, {0} },
+    [R3D_TARGET_SCENE_0]  = { FORMAT_RGB16F,  1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SCENE_1]  = { FORMAT_RGB16F,  1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
 };
 
 static void alloc_target_texture(r3d_target_t target)

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -97,12 +97,13 @@ static void alloc_target_texture(r3d_target_t target)
         glTexImage2D(GL_TEXTURE_2D, i, format->internal, wLevel, hLevel, 0, format->format, format->type, NULL);
     }
 
+    // NOTE: By default, sampling is blocked at the first level
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL,  0);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, config->minFilter);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, config->magFilter);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL,  0);
 
     glBindTexture(GL_TEXTURE_2D, 0);
 

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -123,8 +123,9 @@ static void alloc_depth_renderbuffer(int resW, int resH)
  */
 static int get_or_create_fbo(const r3d_target_t* targets, int count, bool depth)
 {
-    assert(count < R3D_TARGET_MAX_ATTACHMENTS);
+    assert(targets || (!targets && count == 0));
     assert(count > 0 || (count == 0 && depth));
+    assert(count < R3D_TARGET_MAX_ATTACHMENTS);
 
     /* --- Search if the combination is already cached --- */
 
@@ -358,7 +359,7 @@ void r3d_target_set_write_level(int attachment, int level)
     assert(R3D_MOD_TARGET.currentFbo >= 0);
 
     r3d_target_fbo_t* fbo = &R3D_MOD_TARGET.fbo[R3D_MOD_TARGET.currentFbo];
-    assert(attachment < fbo->targetCount);
+    assert(fbo->targetCount > 0 && attachment < fbo->targetCount);
 
     r3d_target_t target = fbo->targets[attachment];
     assert(level < r3d_target_get_num_levels(target));

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -304,8 +304,9 @@ r3d_target_t r3d_target_swap_scene(r3d_target_t scene)
     return R3D_TARGET_SCENE_0;
 }
 
-void r3d_target_clear(const r3d_target_t* targets, int count, bool depth)
+void r3d_target_clear(const r3d_target_t* targets, int count, int level, bool depth)
 {
+    assert((!depth || level == 0) && "If depth buffer bind, always bind at level zero");
     assert(count > 0 || depth);
 
     int fboIndex = get_or_create_fbo(targets, count, depth);
@@ -315,10 +316,10 @@ void r3d_target_clear(const r3d_target_t* targets, int count, bool depth)
     }
 
     for (int i = 0; i < count; i++) {
-        r3d_target_set_write_level(i, 0);
+        r3d_target_set_write_level(i, level);
     }
 
-    if (count > 0) r3d_target_set_viewport(targets[0], 0);
+    if (count > 0) r3d_target_set_viewport(targets[0], level);
     else glViewport(0, 0, R3D_MOD_TARGET.resW, R3D_MOD_TARGET.resH);
 
     for (int i = 0; i < count; i++) {
@@ -330,8 +331,9 @@ void r3d_target_clear(const r3d_target_t* targets, int count, bool depth)
     }
 }
 
-void r3d_target_bind(const r3d_target_t* targets, int count, bool depth)
+void r3d_target_bind(const r3d_target_t* targets, int count, int level, bool depth)
 {
+    assert((!depth || level == 0) && "If depth buffer bind, always bind at level zero");
     assert(count > 0 || depth);
 
     int fboIndex = get_or_create_fbo(targets, count, depth);
@@ -341,10 +343,10 @@ void r3d_target_bind(const r3d_target_t* targets, int count, bool depth)
     }
 
     for (int i = 0; i < count; i++) {
-        r3d_target_set_write_level(i, 0);
+        r3d_target_set_write_level(i, level);
     }
 
-    if (count > 0) r3d_target_set_viewport(targets[0], 0);
+    if (count > 0) r3d_target_set_viewport(targets[0], level);
     else glViewport(0, 0, R3D_MOD_TARGET.resW, R3D_MOD_TARGET.resH);
 }
 

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -17,79 +17,130 @@
 // MODULE STATE
 // ========================================
 
-struct r3d_target R3D_MOD_TARGET;
+struct r3d_mod_target R3D_MOD_TARGET;
+
+// ========================================
+// INTERNAL OPENGL FORMAT TABLE
+// ========================================
+
+typedef struct {
+    GLenum internal;
+    GLenum format;
+    GLenum type;
+} target_format_t;
+
+typedef enum {
+    R3D_TARGET_R8,   R3D_TARGET_RG8,   R3D_TARGET_RGB8,   R3D_TARGET_RGBA8,
+    R3D_TARGET_R16F, R3D_TARGET_RG16F, R3D_TARGET_RGB16F, R3D_TARGET_RGBA16F,
+    R3D_TARGET_R32F, R3D_TARGET_RG32F, R3D_TARGET_RGB32F, R3D_TARGET_RGBA32F,
+} target_format_enum_t;
+
+static const target_format_t TARGET_FORMAT[] = {
+    [R3D_TARGET_R8]      = { GL_R8,        GL_RED,  GL_UNSIGNED_BYTE },
+    [R3D_TARGET_RG8]     = { GL_RG8,       GL_RG,   GL_UNSIGNED_BYTE },
+    [R3D_TARGET_RGB8]    = { GL_RGB8,      GL_RGB,  GL_UNSIGNED_BYTE },
+    [R3D_TARGET_RGBA8]   = { GL_RGBA8,     GL_RGBA, GL_UNSIGNED_BYTE },
+    [R3D_TARGET_R16F]    = { GL_R16F,      GL_RED,  GL_HALF_FLOAT },
+    [R3D_TARGET_RG16F]   = { GL_RG16F,     GL_RG,   GL_HALF_FLOAT },
+    [R3D_TARGET_RGB16F]  = { GL_RGB16F,    GL_RGB,  GL_HALF_FLOAT },
+    [R3D_TARGET_RGBA16F] = { GL_RGBA16F,   GL_RGBA, GL_HALF_FLOAT },
+    [R3D_TARGET_R32F]    = { GL_R32F,      GL_RED,  GL_FLOAT },
+    [R3D_TARGET_RG32F]   = { GL_RG32F,     GL_RG,   GL_FLOAT },
+    [R3D_TARGET_RGB32F]  = { GL_RGB32F,    GL_RGB,  GL_FLOAT },
+    [R3D_TARGET_RGBA32F] = { GL_RGBA32F,   GL_RGBA, GL_FLOAT },
+};
 
 // ========================================
 // INTERNAL TARGET FUNCTIONS
 // ========================================
 
 typedef struct {
-    GLenum internalFormat, format, type;
+    target_format_enum_t format;
     float resolutionFactor;
     GLenum minFilter;
     GLenum magFilter;
-    bool mipmaps;
+    int numLevels;
+    float clear[4];
 } target_config_t;
 
 static const target_config_t TARGET_CONFIG[] = {
-    [R3D_TARGET_ALBEDO]     = { GL_RGB8,              GL_RGB,             GL_UNSIGNED_BYTE,  1.0f, GL_NEAREST,               GL_NEAREST, false },
-    [R3D_TARGET_NORM_TAN]   = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },
-    [R3D_TARGET_ORM]        = { GL_RGB8,              GL_RGB,             GL_UNSIGNED_BYTE,  1.0f, GL_NEAREST,               GL_NEAREST, false },
-    [R3D_TARGET_DIFFUSE]    = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },
-    [R3D_TARGET_SPECULAR]   = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     1.0f, GL_NEAREST,               GL_NEAREST, false },
-    [R3D_TARGET_SSAO_0]     = { GL_R8,                GL_RED,             GL_UNSIGNED_BYTE,  0.5f, GL_LINEAR,                GL_LINEAR,  false },
-    [R3D_TARGET_SSAO_1]     = { GL_R8,                GL_RED,             GL_UNSIGNED_BYTE,  0.5f, GL_LINEAR,                GL_LINEAR,  false },
-    [R3D_TARGET_SSIL_0]     = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     0.5f, GL_LINEAR,                GL_LINEAR,  false },
-    [R3D_TARGET_SSIL_1]     = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     0.5f, GL_LINEAR,                GL_LINEAR,  false },
-    [R3D_TARGET_SSIL_2]     = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     0.5f, GL_LINEAR,                GL_LINEAR,  false },
-    [R3D_TARGET_SSR]        = { GL_RGBA16F,           GL_RGBA,            GL_HALF_FLOAT,     0.5f, GL_LINEAR_MIPMAP_LINEAR,  GL_LINEAR,  true  },
-    [R3D_TARGET_BLOOM]      = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     0.5f, GL_LINEAR_MIPMAP_LINEAR,  GL_LINEAR,  true  },
-    [R3D_TARGET_SCENE_0]    = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     1.0f, GL_LINEAR,                GL_LINEAR,  false },
-    [R3D_TARGET_SCENE_1]    = { GL_RGB16F,            GL_RGB,             GL_HALF_FLOAT,     1.0f, GL_LINEAR,                GL_LINEAR,  false },
-    [R3D_TARGET_DEPTH]      = { GL_DEPTH_COMPONENT24, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT,   1.0f, GL_NEAREST,               GL_NEAREST, false },
+    [R3D_TARGET_ALBEDO]     = { R3D_TARGET_RGB8,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
+    [R3D_TARGET_NORM_TAN]   = { R3D_TARGET_RGBA16F, 1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
+    [R3D_TARGET_ORM]        = { R3D_TARGET_RGB8,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
+    [R3D_TARGET_DEPTH]      = { R3D_TARGET_R16F,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {65504.0f, 65504.0f, 65504.0f, 65504.0f} },
+    [R3D_TARGET_DIFFUSE]    = { R3D_TARGET_RGB16F,  1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
+    [R3D_TARGET_SPECULAR]   = { R3D_TARGET_RGB16F,  1.0f, GL_NEAREST,              GL_NEAREST, 1, {0} },
+    [R3D_TARGET_SSAO_0]     = { R3D_TARGET_R8,      0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SSAO_1]     = { R3D_TARGET_R8,      0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SSIL_0]     = { R3D_TARGET_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SSIL_1]     = { R3D_TARGET_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SSIL_2]     = { R3D_TARGET_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SSR]        = { R3D_TARGET_RGBA16F, 0.5f, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR,  0, {0} },
+    [R3D_TARGET_BLOOM]      = { R3D_TARGET_RGB16F,  0.5f, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR,  0, {0} },
+    [R3D_TARGET_SCENE_0]    = { R3D_TARGET_RGB16F,  1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_SCENE_1]    = { R3D_TARGET_RGB16F,  1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
 };
 
-static void target_load(r3d_target_t target)
+static void alloc_target_texture(r3d_target_t target)
 {
-    glBindTexture(GL_TEXTURE_2D, R3D_MOD_TARGET.targets[target]);
-    const target_config_t* config = &TARGET_CONFIG[target];
-    int mipCount = r3d_target_get_mip_count(target);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, R3D_MOD_TARGET.targetTextures[target]);
 
-    for (int i = 0; i < mipCount; ++i) {
+    const target_config_t* config = &TARGET_CONFIG[target];
+    const target_format_t* format = &TARGET_FORMAT[config->format];
+
+    int numLevels = r3d_target_get_num_levels(target);
+
+    for (int i = 0; i < numLevels; ++i) {
         int wLevel = 0, hLevel = 0;
         r3d_target_get_resolution(&wLevel, &hLevel, target, i);
-        glTexImage2D(GL_TEXTURE_2D, i, config->internalFormat, wLevel, hLevel, 0, config->format, config->type, NULL);
+        glTexImage2D(GL_TEXTURE_2D, i, format->internal, wLevel, hLevel, 0, format->format, format->type, NULL);
     }
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, config->minFilter);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, config->magFilter);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL,  0);
+
     glBindTexture(GL_TEXTURE_2D, 0);
 
+    R3D_MOD_TARGET.targetStates[target] = (r3d_target_state_t) {0};
     R3D_MOD_TARGET.targetLoaded[target] = true;
+}
+
+static void alloc_depth_renderbuffer(int resW, int resH)
+{
+    glBindRenderbuffer(GL_RENDERBUFFER, R3D_MOD_TARGET.depthRenderbuffer);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, resW, resH);
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
 }
 
 /*
  * Returns the index of the FBO in the cache.
  * If the combination doesn't exist, creates a new FBO and caches it.
  */
-static int get_or_create_fbo(const r3d_target_t* targets, int count)
+static int get_or_create_fbo(const r3d_target_t* targets, int count, bool depth)
 {
     assert(count < R3D_TARGET_MAX_ATTACHMENTS);
+    assert(count > 0 || (count == 0 && depth));
 
     /* --- Search if the combination is already cached --- */
 
     for (int i = 0; i < R3D_MOD_TARGET.fboCount; i++) {
         const r3d_target_fbo_t* fbo = &R3D_MOD_TARGET.fbo[i];
-        if (fbo->count == count && memcmp(fbo->targets, targets, count * sizeof(*targets)) == 0) {
-            return i;
+        if (fbo->targetCount == count && fbo->hasDepth == depth) {
+            if (count == 0 || memcmp(fbo->targets, targets, count * sizeof(*targets)) == 0) {
+                return i;
+            }
         }
     }
 
     /* --- Create the FBO and cache it --- */
 
     assert(R3D_MOD_TARGET.fboCount < R3D_TARGET_MAX_FRAMEBUFFERS);
+
     int newIndex = R3D_MOD_TARGET.fboCount++;
     r3d_target_fbo_t* fbo = &R3D_MOD_TARGET.fbo[newIndex];
 
@@ -99,27 +150,29 @@ static int get_or_create_fbo(const r3d_target_t* targets, int count)
     GLenum glColor[R3D_TARGET_MAX_ATTACHMENTS];
     int locCount = 0;
 
-    for (int i = 0; i < count; ++i)
-    {
+    for (int i = 0; i < count; ++i) {
         if (!R3D_MOD_TARGET.targetLoaded[targets[i]]) {
-            target_load(targets[i]);
+            alloc_target_texture(targets[i]);
         }
 
-        GLuint texture = R3D_MOD_TARGET.targets[targets[i]];
+        GLuint texture = R3D_MOD_TARGET.targetTextures[targets[i]];
+        fbo->targetStates[i] = (r3d_target_attachment_state_t) {0};
         fbo->targets[i] = targets[i];
 
-        if (targets[i] != R3D_TARGET_DEPTH) {
-            GLenum attachment = GL_COLOR_ATTACHMENT0 + locCount;
-            glFramebufferTexture2D(GL_FRAMEBUFFER, attachment, GL_TEXTURE_2D, texture, 0);
-            glColor[locCount++] = attachment;
-        }
-        else {
-            assert(i == count - 1); // Always provide the depth target last
-            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texture, 0);
-        }
+        GLenum attachment = GL_COLOR_ATTACHMENT0 + locCount;
+        glFramebufferTexture2D(GL_FRAMEBUFFER, attachment, GL_TEXTURE_2D, texture, 0);
+        glColor[locCount++] = attachment;
     }
 
-    fbo->count = count;
+    if (depth) {
+        glFramebufferRenderbuffer(
+            GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+            GL_RENDERBUFFER, R3D_MOD_TARGET.depthRenderbuffer
+        );
+    }
+
+    fbo->targetCount = count;
+    fbo->hasDepth = depth;
 
     if (locCount > 0) {
         glDrawBuffers(locCount, glColor);
@@ -137,14 +190,6 @@ static int get_or_create_fbo(const r3d_target_t* targets, int count)
     return newIndex;
 }
 
-static void set_viewport(r3d_target_t target)
-{
-    float viewportFactor = TARGET_CONFIG[target].resolutionFactor;
-    int vpW = (int)((float)R3D_MOD_TARGET.resW * viewportFactor);
-    int vpH = (int)((float)R3D_MOD_TARGET.resH * viewportFactor);
-    glViewport(0, 0, vpW, vpH);
-}
-
 // ========================================
 // MODULE FUNCTIONS
 // ========================================
@@ -153,13 +198,14 @@ bool r3d_target_init(int resW, int resH)
 {
     memset(&R3D_MOD_TARGET, 0, sizeof(R3D_MOD_TARGET));
 
-    glGenTextures(R3D_TARGET_COUNT, R3D_MOD_TARGET.targets);
+    glGenTextures(R3D_TARGET_COUNT, R3D_MOD_TARGET.targetTextures);
+    glGenRenderbuffers(1, &R3D_MOD_TARGET.depthRenderbuffer);
+    alloc_depth_renderbuffer(resW, resH);
 
     R3D_MOD_TARGET.currentFbo = -1;
 
     R3D_MOD_TARGET.resW = resW;
     R3D_MOD_TARGET.resH = resH;
-
     R3D_MOD_TARGET.txlW = 1.0f / resW;
     R3D_MOD_TARGET.txlH = 1.0f / resH;
 
@@ -168,10 +214,13 @@ bool r3d_target_init(int resW, int resH)
 
 void r3d_target_quit(void)
 {
-    glDeleteTextures(R3D_TARGET_COUNT, R3D_MOD_TARGET.targets);
+    glDeleteTextures(R3D_TARGET_COUNT, R3D_MOD_TARGET.targetTextures);
+    glDeleteRenderbuffers(1, &R3D_MOD_TARGET.depthRenderbuffer);
 
     for (int i = 0; i < R3D_MOD_TARGET.fboCount; i++) {
-        glDeleteFramebuffers(1, &R3D_MOD_TARGET.fbo[i].id);
+        if (R3D_MOD_TARGET.fbo[i].id != 0) {
+            glDeleteFramebuffers(1, &R3D_MOD_TARGET.fbo[i].id);
+        }
     }
 }
 
@@ -185,24 +234,25 @@ void r3d_target_resize(int resW, int resH)
 
     R3D_MOD_TARGET.resW = resW;
     R3D_MOD_TARGET.resH = resH;
-
     R3D_MOD_TARGET.txlW = 1.0f / resW;
     R3D_MOD_TARGET.txlH = 1.0f / resH;
 
     // TODO: Avoid reallocating targets if the new dimensions
     //       are smaller than the allocated dimensions?
 
+    alloc_depth_renderbuffer(resW, resH);
+
     for (int i = 0; i < R3D_TARGET_COUNT; i++) {
         if (R3D_MOD_TARGET.targetLoaded[i]) {
-            target_load(i);
+            alloc_target_texture(i);
         }
     }
 }
 
-int r3d_target_get_mip_count(r3d_target_t target)
+int r3d_target_get_num_levels(r3d_target_t target)
 {
     const target_config_t* config = &TARGET_CONFIG[target];
-    if (!config->mipmaps) return 1;
+    if (config->numLevels > 0) return config->numLevels;
 
     int w = (int)((float)R3D_MOD_TARGET.resW * config->resolutionFactor);
     int h = (int)((float)R3D_MOD_TARGET.resH * config->resolutionFactor);
@@ -252,69 +302,101 @@ r3d_target_t r3d_target_swap_scene(r3d_target_t scene)
     return R3D_TARGET_SCENE_0;
 }
 
-void r3d_target_clear(const r3d_target_t* targets, int count)
+void r3d_target_clear(const r3d_target_t* targets, int count, bool depth)
 {
-    int fboIndex = get_or_create_fbo(targets, count);
+    assert(count > 0 || depth);
+
+    int fboIndex = get_or_create_fbo(targets, count, depth);
     if (fboIndex != R3D_MOD_TARGET.currentFbo) {
         glBindFramebuffer(GL_FRAMEBUFFER, R3D_MOD_TARGET.fbo[fboIndex].id);
         R3D_MOD_TARGET.currentFbo = fboIndex;
-        set_viewport(targets[0]);
     }
 
-    bool hasDepth = false;
-    bool hasColor = false;
     for (int i = 0; i < count; i++) {
-        hasDepth |= (targets[i] == R3D_TARGET_DEPTH);
-        hasColor |= (targets[i] != R3D_TARGET_DEPTH);
+        r3d_target_set_write_level(i, 0);
     }
 
-    assert(hasDepth || hasColor);
-    GLenum bitfield = GL_NONE;
+    if (count > 0) r3d_target_set_viewport(targets[0], 0);
+    else glViewport(0, 0, R3D_MOD_TARGET.resW, R3D_MOD_TARGET.resH);
 
-    if (hasColor) {
-        bitfield |= GL_COLOR_BUFFER_BIT;
-        glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    for (int i = 0; i < count; i++) {
+        glClearBufferfv(GL_COLOR, i, TARGET_CONFIG[targets[i]].clear);
     }
 
-    if (hasDepth) {
-        bitfield |= GL_DEPTH_BUFFER_BIT;
-        glDepthMask(GL_TRUE);
-        glClearDepth(1.0f);
+    if (depth) {
+        glClearBufferfv(GL_DEPTH, 0, (float[1]){1.0f});
     }
-
-    glClear(bitfield);
 }
 
-void r3d_target_bind(const r3d_target_t* targets, int count)
+void r3d_target_bind(const r3d_target_t* targets, int count, bool depth)
 {
-    int fboIndex = get_or_create_fbo(targets, count);
+    assert(count > 0 || depth);
+
+    int fboIndex = get_or_create_fbo(targets, count, depth);
     if (fboIndex != R3D_MOD_TARGET.currentFbo) {
         glBindFramebuffer(GL_FRAMEBUFFER, R3D_MOD_TARGET.fbo[fboIndex].id);
         R3D_MOD_TARGET.currentFbo = fboIndex;
-        set_viewport(targets[0]);
     }
+
+    for (int i = 0; i < count; i++) {
+        r3d_target_set_write_level(i, 0);
+    }
+
+    if (count > 0) r3d_target_set_viewport(targets[0], 0);
+    else glViewport(0, 0, R3D_MOD_TARGET.resW, R3D_MOD_TARGET.resH);
 }
 
-void r3d_target_set_mip_level(int attachment, int level)
+void r3d_target_set_viewport(r3d_target_t target, int level)
+{
+    int vpW = 0, vpH = 0;
+    r3d_target_get_resolution(&vpW, &vpH, target, level);
+    glViewport(0, 0, vpW, vpH);
+}
+
+void r3d_target_set_write_level(int attachment, int level)
 {
     assert(R3D_MOD_TARGET.currentFbo >= 0);
 
-    const r3d_target_fbo_t* fbo = &R3D_MOD_TARGET.fbo[R3D_MOD_TARGET.currentFbo];
+    r3d_target_fbo_t* fbo = &R3D_MOD_TARGET.fbo[R3D_MOD_TARGET.currentFbo];
+    assert(attachment < fbo->targetCount);
+
     r3d_target_t target = fbo->targets[attachment];
+    assert(level < r3d_target_get_num_levels(target));
+    r3d_target_attachment_state_t* state = &fbo->targetStates[attachment];
 
-    assert(TARGET_CONFIG[target].mipmaps);
+    if (state->writeLevel != level) {
+        glFramebufferTexture2D(
+            GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + attachment,
+            GL_TEXTURE_2D, R3D_MOD_TARGET.targetTextures[target], level
+        );
+        state->writeLevel = level;
+    }
+}
 
-    glFramebufferTexture2D(
-        GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + attachment,
-        GL_TEXTURE_2D, R3D_MOD_TARGET.targets[target], level
-    );
+void r3d_target_set_read_levels(r3d_target_t target, int baseLevel, int maxLevel)
+{
+    assert(R3D_MOD_TARGET.targetLoaded[target]);
+    assert(baseLevel < r3d_target_get_num_levels(target));
+    assert(maxLevel < r3d_target_get_num_levels(target));
+
+    r3d_target_state_t* state = &R3D_MOD_TARGET.targetStates[target];
+
+    if (state->baseLevel != baseLevel || state->maxLevel != maxLevel) {
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, R3D_MOD_TARGET.targetTextures[target]);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, baseLevel);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL,  maxLevel);
+        glBindTexture(GL_TEXTURE_2D, 0);
+        state->baseLevel = baseLevel;
+        state->maxLevel = maxLevel;
+    }
 }
 
 void r3d_target_gen_mipmap(r3d_target_t target)
 {
     GLuint id = r3d_target_get(target);
 
+    glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, id);
     glGenerateMipmap(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, 0);
@@ -324,35 +406,39 @@ GLuint r3d_target_get(r3d_target_t target)
 {
     assert(target > R3D_TARGET_INVALID && target < R3D_TARGET_COUNT);
     assert(R3D_MOD_TARGET.targetLoaded[target]);
-    return R3D_MOD_TARGET.targets[target];
+    return R3D_MOD_TARGET.targetTextures[target];
+}
+
+GLuint r3d_target_get_levels(r3d_target_t target, int baseLevel, int maxLevel)
+{
+    assert(target > R3D_TARGET_INVALID && target < R3D_TARGET_COUNT);
+    r3d_target_set_read_levels(target, baseLevel, maxLevel);
+    return R3D_MOD_TARGET.targetTextures[target];
 }
 
 GLuint r3d_target_get_or_null(r3d_target_t target)
 {
     if (target <= R3D_TARGET_INVALID || target >= R3D_TARGET_COUNT) return 0;
     if (!R3D_MOD_TARGET.targetLoaded[target]) return 0;
-    return R3D_MOD_TARGET.targets[target];
+    return R3D_MOD_TARGET.targetTextures[target];
 }
 
-void r3d_target_blit(r3d_target_t* targets, int count, GLuint dstFbo, int dstX, int dstY, int dstW, int dstH, bool linear)
+void r3d_target_blit(r3d_target_t target, bool depth, GLuint dstFbo, int dstX, int dstY, int dstW, int dstH, bool linear)
 {
-    bool hasDepth = (targets[count - 1] == R3D_TARGET_DEPTH);
-    bool depthOnly = (count == 1 && hasDepth);
-
-    int fboIndex = get_or_create_fbo(targets, count);
+    int fboIndex = get_or_create_fbo(&target, 1, depth);
 
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, dstFbo);
     glBindFramebuffer(GL_READ_FRAMEBUFFER, R3D_MOD_TARGET.fbo[fboIndex].id);
 
     if (linear) {
-        if (!depthOnly) {
+        if (target > 0) {
             glBlitFramebuffer(
                 0, 0, R3D_MOD_TARGET.resW, R3D_MOD_TARGET.resH,
                 dstX, dstY, dstX + dstW, dstY + dstH, GL_COLOR_BUFFER_BIT,
                 GL_LINEAR
             );
         }
-        if (hasDepth) {
+        if (depth) {
             glBlitFramebuffer(
                 0, 0, R3D_MOD_TARGET.resW, R3D_MOD_TARGET.resH,
                 dstX, dstY, dstX + dstW, dstY + dstH, GL_DEPTH_BUFFER_BIT,
@@ -362,8 +448,8 @@ void r3d_target_blit(r3d_target_t* targets, int count, GLuint dstFbo, int dstX, 
     }
     else {
         GLbitfield mask = GL_NONE;
-        if (!depthOnly) mask |= GL_COLOR_BUFFER_BIT;
-        if (hasDepth) mask |= GL_DEPTH_BUFFER_BIT;
+        if (target > 0) mask |= GL_COLOR_BUFFER_BIT;
+        if (depth) mask |= GL_DEPTH_BUFFER_BIT;
         glBlitFramebuffer(
             0, 0, R3D_MOD_TARGET.resW, R3D_MOD_TARGET.resH,
             dstX, dstY, dstX + dstW, dstY + dstH, mask,

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -207,7 +207,7 @@ r3d_target_t r3d_target_swap_ssao(r3d_target_t ssao);
 r3d_target_t r3d_target_swap_scene(r3d_target_t scene);
 
 /*
- * Clears color targets to {0,0,0,1} and depth to 1.0.
+ * Clears color targets with the values ​​defined in their configuration; the HW depth is cleared to 1.0
  * Creates and binds the FBO with the requested combination.
  * Attachment locations correspond to the provided order.
  * NOTE: This function reassigns all attachments to level zero and automatically sets the viewport.

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -24,10 +24,11 @@
  */
 typedef enum {
     R3D_TARGET_INVALID = -1,
-    R3D_TARGET_ALBEDO,          //< Full - Mip 1 - RGB[8|8|8]
-    R3D_TARGET_NORM_TAN,        //< Full - Mip 1 - RGBA[16|16|16|16]
-    R3D_TARGET_ORM,             //< Full - Mip 1 - RGB[8|8|8]
-    R3D_TARGET_DIFFUSE,         //< Full - Mip 1 - RGB[16|16|16]
+    R3D_TARGET_ALBEDO,          //< Full - Mip 2 - RGB[8|8|8]
+    R3D_TARGET_NORM_TAN,        //< Full - Mip 2 - RGBA[16|16|16|16]
+    R3D_TARGET_ORM,             //< Full - Mip 2 - RGB[8|8|8]
+    R3D_TARGET_DEPTH,           //< Full - Mip 2 - R[16]
+    R3D_TARGET_DIFFUSE,         //< Full - Mip 2 - RGB[16|16|16]
     R3D_TARGET_SPECULAR,        //< Full - Mip 1 - RGB[16|16|16]
     R3D_TARGET_SSAO_0,          //< Half - Mip 1 - R[8]
     R3D_TARGET_SSAO_1,          //< Half - Mip 1 - R[8]
@@ -38,7 +39,6 @@ typedef enum {
     R3D_TARGET_BLOOM,           //< Half - Mip N - RGB[16|16|16]
     R3D_TARGET_SCENE_0,         //< Full - Mip 1 - RGB[16|16|16]
     R3D_TARGET_SCENE_1,         //< Full - Mip 1 - RGB[16|16|16]
-    R3D_TARGET_DEPTH,           //< Full - Mip 1 - D[24]
     R3D_TARGET_COUNT
 } r3d_target_t;
 
@@ -50,21 +50,20 @@ typedef enum {
     R3D_TARGET_ALBEDO,          \
     R3D_TARGET_NORM_TAN,        \
     R3D_TARGET_ORM,             \
+    R3D_TARGET_DEPTH,           \
     R3D_TARGET_DIFFUSE,         \
     R3D_TARGET_SPECULAR,        \
-    R3D_TARGET_DEPTH            \
 
 #define R3D_TARGET_GBUFFER      \
     R3D_TARGET_ALBEDO,          \
     R3D_TARGET_DIFFUSE,         \
     R3D_TARGET_NORM_TAN,        \
     R3D_TARGET_ORM,             \
-    R3D_TARGET_DEPTH            \
+    R3D_TARGET_DEPTH,           \
 
 #define R3D_TARGET_LIGHTING     \
     R3D_TARGET_DIFFUSE,         \
     R3D_TARGET_SPECULAR,        \
-    R3D_TARGET_DEPTH            \
 
 // ========================================
 // HELPER MACROS
@@ -78,16 +77,18 @@ typedef enum {
 #define R3D_TARGET_TEXEL_HEIGHT R3D_MOD_TARGET.txlH
 #define R3D_TARGET_TEXEL_SIZE   R3D_MOD_TARGET.txlW, R3D_MOD_TARGET.txlH
 
-#define R3D_TARGET_CLEAR(...)                                           \
+#define R3D_TARGET_CLEAR(depth, ...)                                    \
     r3d_target_clear(                                                   \
         (r3d_target_t[]){ __VA_ARGS__ },                                \
-        sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t)  \
+        sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t), \
+        (depth)                                                         \
     )
 
-#define R3D_TARGET_BIND(...)                                            \
+#define R3D_TARGET_BIND(depth, ...)                                     \
     r3d_target_bind(                                                    \
         (r3d_target_t[]){ __VA_ARGS__ },                                \
-        sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t)  \
+        sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t), \
+        (depth)                                                         \
     )
 
 /*
@@ -95,7 +96,7 @@ typedef enum {
  * Modifies the target parameter to point to the other buffer.
  */
 #define R3D_TARGET_BIND_AND_SWAP_SSAO(target) do {                      \
-    R3D_TARGET_BIND(target);                                            \
+    R3D_TARGET_BIND(false, target);                                     \
     target = r3d_target_swap_ssao(target);                              \
 } while(0)
 
@@ -104,38 +105,55 @@ typedef enum {
  * Modifies the target parameter to point to the other buffer.
  */
 #define R3D_TARGET_BIND_AND_SWAP_SCENE(target) do {                     \
-    R3D_TARGET_BIND(target);                                            \
+    R3D_TARGET_BIND(false, target);                                     \
     target = r3d_target_swap_scene(target);                             \
 } while(0)
 
 // ========================================
-// FRAMEBUFFER STRUCTURE
+// TARGET FBO STRUCTURE
 // ========================================
 
 #define R3D_TARGET_MAX_FRAMEBUFFERS 32
 #define R3D_TARGET_MAX_ATTACHMENTS  8
 
 typedef struct {
-    GLuint id;
+    int writeLevel;         //< Indicates the level currently attached to the FBO
+} r3d_target_attachment_state_t;
+
+typedef struct {
+    r3d_target_attachment_state_t targetStates[R3D_TARGET_MAX_ATTACHMENTS];
     r3d_target_t targets[R3D_TARGET_MAX_ATTACHMENTS];
-    int count;
+    int targetCount;
+    bool hasDepth;
+    GLuint id;
 } r3d_target_fbo_t;
+
+// ========================================
+// TARGET BUFFER STRUCTURE
+// ========================================
+
+typedef struct {
+    int baseLevel;
+    int maxLevel;
+} r3d_target_state_t;
 
 // ========================================
 // MODULE STATE
 // ========================================
 
-extern struct r3d_target {
+extern struct r3d_mod_target {
 
-    r3d_target_fbo_t fbo[R3D_TARGET_MAX_FRAMEBUFFERS];  //< FBO combination cache. FBOs are automatically generated as needed during bind.
-    int currentFbo;                                     //< Cache index of currently bound FBO, -1 if none bound. Reset via `r3d_target_reset()`.
+    r3d_target_fbo_t fbo[R3D_TARGET_MAX_FRAMEBUFFERS];  //< FBO combination cache. FBOs are automatically generated as needed during bind
+    int currentFbo;                                     //< Cache index of currently bound FBO, -1 if none bound. Reset via `r3d_target_reset()`
     int fboCount;                                       //< Number of FBOs created
 
-    bool targetLoaded[R3D_TARGET_COUNT];    //< Indicates whether the targets have been allocated.
-    GLuint targets[R3D_TARGET_COUNT];       //< Table of targets (textures)
+    r3d_target_state_t targetStates[R3D_TARGET_COUNT];  //< Array of target states
+    GLuint targetTextures[R3D_TARGET_COUNT];            //< Array of target IDs (textures)
+    bool targetLoaded[R3D_TARGET_COUNT];                //< Indicates whether the targets have been allocated
 
-    uint32_t resW, resH;    //< Full internal resolution
-    float txlW, txlH;       //< Size of a texel for full resolution
+    GLuint depthRenderbuffer;   //< Internal depth buffer
+    uint32_t resW, resH;        //< Full internal resolution
+    float txlW, txlH;           //< Size of a texel for full resolution
 
 } R3D_MOD_TARGET;
 
@@ -166,7 +184,7 @@ void r3d_target_resize(int resW, int resH);
  * Returns the total number of mip levels of the internal buffers
  * based on their full resolution.
  */
-int r3d_target_get_mip_count(r3d_target_t target);
+int r3d_target_get_num_levels(r3d_target_t target);
 
 /*
  * Returns the internal resolution for the specified mip level.
@@ -189,27 +207,39 @@ r3d_target_t r3d_target_swap_ssao(r3d_target_t ssao);
 r3d_target_t r3d_target_swap_scene(r3d_target_t scene);
 
 /*
- * Clears color targets with {0,0,0,1} and depth with 1.0.
+ * Clears color targets to {0,0,0,1} and depth to 1.0.
  * Creates and binds the FBO with the requested combination.
  * Attachment locations correspond to the provided order.
- * Depth target must always be passed last in the list (verified by assert).
+ * NOTE: This function reassigns all attachments to level zero and automatically sets the viewport.
  */
-void r3d_target_clear(const r3d_target_t* targets, int count);
+void r3d_target_clear(const r3d_target_t* targets, int count, bool depth);
 
 /*
  * Creates and binds the FBO with the requested combination.
  * Attachment locations correspond to the provided order.
- * Depth target must always be passed last in the list (verified by assert).
+ * NOTE: This function reassigns all attachments to level zero and automatically sets the viewport.
  */
-void r3d_target_bind(const r3d_target_t* targets, int count);
+void r3d_target_bind(const r3d_target_t* targets, int count, bool depth);
+
+/*
+ * Sets the viewport according to the target and specified level.
+ */
+void r3d_target_set_viewport(r3d_target_t target, int level);
 
 /*
  * Changes the mip level of the specified attachment.
  * Takes effect on the currently bound FBO.
  * The attachment index corresponds to the target's location in 'r3d_target_bind'.
- * Asserts that a valid FBO is currently bound.
+ * Asserts that a valid FBO is currently bound and that the level is valid.
  */
-void r3d_target_set_mip_level(int attachment, int level);
+void r3d_target_set_write_level(int attachment, int level);
+
+/*
+ * Defines the sampling levels of the target.
+ * baseLevel defines the first level and maxLevel the last.
+ * Asserts that the target has already been created/used and that the levels are valid.
+ */
+void r3d_target_set_read_levels(r3d_target_t target, int baseLevel, int maxLevel);
 
 /*
  * Generates mipmaps for the specified target.
@@ -225,17 +255,23 @@ void r3d_target_gen_mipmap(r3d_target_t target);
 GLuint r3d_target_get(r3d_target_t target);
 
 /*
+ * Returns the texture ID corresponding to the requested target with base and max levels configured.
+ * Asserts that the requested target has been created and if the target enum is valid.
+ * If not created yet, it means we never bound this target, so it would be empty.
+ */
+GLuint r3d_target_get_levels(r3d_target_t target, int baseLevel, int maxLevel);
+
+/*
  * Returns the texture ID corresponding to the requested target.
  * Or returns 0 if the target has not been created or if the enum is invalid.
  */
 GLuint r3d_target_get_or_null(r3d_target_t target);
 
 /*
- * Blit les cibles fournies vers le FBO indiqué.
- * Supporte le blit de la cible de profondeur seulement.
- * La cible de profondeur doit toujours être spécifiée en dernier.
+ * Blits the provided targets to the specified FBO.
+ * Supports blitting with only a depth target.
  */
-void r3d_target_blit(r3d_target_t* targets, int count, GLuint dstFbo, int dstX, int dstY, int dstW, int dstH, bool linear);
+void r3d_target_blit(r3d_target_t target, bool depth, GLuint dstFbo, int dstX, int dstY, int dstW, int dstH, bool linear);
 
 /*
  * Reset the internal state cache as the FBO target currently binds.

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -81,14 +81,21 @@ typedef enum {
     r3d_target_clear(                                                   \
         (r3d_target_t[]){ __VA_ARGS__ },                                \
         sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t), \
-        (depth)                                                         \
+        0, (depth)                                                      \
     )
 
 #define R3D_TARGET_BIND(depth, ...)                                     \
     r3d_target_bind(                                                    \
         (r3d_target_t[]){ __VA_ARGS__ },                                \
         sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t), \
-        (depth)                                                         \
+        0, (depth)                                                      \
+    )
+
+#define R3D_TARGET_BIND_LEVEL(level, ...)                               \
+    r3d_target_bind(                                                    \
+        (r3d_target_t[]){ __VA_ARGS__ },                                \
+        sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t), \
+        (level), false                                                  \
     )
 
 /*
@@ -207,19 +214,24 @@ r3d_target_t r3d_target_swap_ssao(r3d_target_t ssao);
 r3d_target_t r3d_target_swap_scene(r3d_target_t scene);
 
 /*
- * Clears color targets with the values ​​defined in their configuration; the HW depth is cleared to 1.0
- * Creates and binds the FBO with the requested combination.
- * Attachment locations correspond to the provided order.
- * NOTE: This function reassigns all attachments to level zero and automatically sets the viewport.
+ * Creates, binds and clear the FBO with the requested attachment combination.
+ * Attachment locations follow the order provided.
+ *
+ * This function attaches the targets at the specified level and sets the corresponding viewport.
+ * Ensure that the provided target combination is compatible with the specified level.
+ * The depth buffer can only be attached when the level is zero.
  */
-void r3d_target_clear(const r3d_target_t* targets, int count, bool depth);
+void r3d_target_clear(const r3d_target_t* targets, int count, int level, bool depth);
 
 /*
- * Creates and binds the FBO with the requested combination.
- * Attachment locations correspond to the provided order.
- * NOTE: This function reassigns all attachments to level zero and automatically sets the viewport.
+ * Creates and binds an FBO with the requested attachment combination.
+ * Attachment locations follow the order provided.
+ *
+ * This function attaches the targets at the specified level and sets the corresponding viewport.
+ * Ensure that the provided target combination is compatible with the specified level.
+ * The depth buffer can only be attached when the level is zero.
  */
-void r3d_target_bind(const r3d_target_t* targets, int count, bool depth);
+void r3d_target_bind(const r3d_target_t* targets, int count, int level, bool depth);
 
 /*
  * Sets the viewport according to the target and specified level.

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -164,7 +164,7 @@ void R3D_End(void)
         pass_deferred_compose(sceneTarget);
     }
     else {
-        R3D_TARGET_CLEAR(true);
+        r3d_target_clear(NULL, 0, true);
     }
 
     /* --- Then background and transparent rendering --- */
@@ -521,9 +521,9 @@ void update_view_state(Camera3D camera, double near, double far)
     R3D.viewState.invProj = MatrixInvert(proj);
     R3D.viewState.viewProj = viewProj;
 
-    R3D.viewState.aspect = aspect;
-    R3D.viewState.near = near;
-    R3D.viewState.far = far;
+    R3D.viewState.aspect = (float)aspect;
+    R3D.viewState.near = (float)near;
+    R3D.viewState.far = (float)far;
 }
 
 void upload_light_array_block_for_mesh(const r3d_draw_call_t* call, bool shadow)
@@ -1189,7 +1189,7 @@ void pass_scene_prepass(void)
 {
     /* --- First render only depth --- */
 
-    R3D_TARGET_BIND(true);
+    r3d_target_bind(NULL, 0, true);
     R3D_SHADER_USE(scene.depth);
 
     glEnable(GL_DEPTH_TEST);

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -164,7 +164,7 @@ void R3D_End(void)
         pass_deferred_compose(sceneTarget);
     }
     else {
-        r3d_target_clear(NULL, 0, true);
+        r3d_target_clear(NULL, 0, 0, true);
     }
 
     /* --- Then background and transparent rendering --- */
@@ -1189,7 +1189,7 @@ void pass_scene_prepass(void)
 {
     /* --- First render only depth --- */
 
-    r3d_target_bind(NULL, 0, true);
+    r3d_target_bind(NULL, 0, 0, true);
     R3D_SHADER_USE(scene.depth);
 
     glEnable(GL_DEPTH_TEST);
@@ -1235,18 +1235,12 @@ void pass_scene_decals(void)
 
 void pass_prepare_buffer_down(void)
 {
+    R3D_TARGET_BIND_LEVEL(1, R3D_TARGET_ALBEDO, R3D_TARGET_NORM_TAN, R3D_TARGET_ORM, R3D_TARGET_DEPTH, R3D_TARGET_DIFFUSE);
     R3D_SHADER_USE(prepare.bufferDown);
+
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
     glDisable(GL_BLEND);
-
-    R3D_TARGET_BIND(false, R3D_TARGET_ALBEDO, R3D_TARGET_NORM_TAN, R3D_TARGET_ORM, R3D_TARGET_DEPTH, R3D_TARGET_DIFFUSE);
-    r3d_target_set_viewport(R3D_TARGET_ALBEDO, 1);
-    r3d_target_set_write_level(0, 1);
-    r3d_target_set_write_level(1, 1);
-    r3d_target_set_write_level(2, 1);
-    r3d_target_set_write_level(3, 1);
-    r3d_target_set_write_level(4, 1);
 
     R3D_SHADER_BIND_SAMPLER(prepare.bufferDown, uAlbedoTex, r3d_target_get_levels(R3D_TARGET_ALBEDO, 0, 0));
     R3D_SHADER_BIND_SAMPLER(prepare.bufferDown, uNormalTex, r3d_target_get_levels(R3D_TARGET_NORM_TAN, 0, 0));

--- a/src/r3d_utils.c
+++ b/src/r3d_utils.c
@@ -23,7 +23,7 @@ Texture2D R3D_GetWhiteTexture(void)
     texture.width = 1;
     texture.height = 1;
     texture.mipmaps = 1;
-    texture.format = PIXELFORMAT_UNCOMPRESSED_GRAYSCALE;
+    texture.format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
     return texture;
 }
 
@@ -34,7 +34,7 @@ Texture2D R3D_GetBlackTexture(void)
     texture.width = 1;
     texture.height = 1;
     texture.mipmaps = 1;
-    texture.format = PIXELFORMAT_UNCOMPRESSED_GRAYSCALE;
+    texture.format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
     return texture;
 }
 
@@ -45,7 +45,7 @@ Texture2D R3D_GetNormalTexture(void)
     texture.width = 1;
     texture.height = 1;
     texture.mipmaps = 1;
-    texture.format = PIXELFORMAT_UNCOMPRESSED_R32G32B32;
+    texture.format = PIXELFORMAT_UNCOMPRESSED_R8G8B8;
     return texture;
 }
 
@@ -56,7 +56,7 @@ Texture2D R3D_GetBufferNormal(void)
     texture.width = R3D_TARGET_WIDTH;
     texture.height = R3D_TARGET_HEIGHT;
     texture.mipmaps = 1;
-    texture.format = PIXELFORMAT_UNCOMPRESSED_R32;
+    texture.format = PIXELFORMAT_UNCOMPRESSED_R16G16B16A16;
     return texture;
 }
 
@@ -67,7 +67,7 @@ Texture2D R3D_GetBufferDepth(void)
     texture.width = R3D_TARGET_WIDTH;
     texture.height = R3D_TARGET_HEIGHT;
     texture.mipmaps = 1;
-    texture.format = PIXELFORMAT_UNCOMPRESSED_R32;
+    texture.format = PIXELFORMAT_UNCOMPRESSED_R16;
     return texture;
 }
 


### PR DESCRIPTION
First, regarding the API, for simplicity I had to remove the `ssao.lightAffect` parameter.
I plan to reintroduce such control, but only for material occlusion.

---

This PR aims to address several issues at once.

First, it introduces a linear depth buffer, which will later allow optimizations for certain screen-space effects using depth mipmap.

Having a pre-filled linear depth buffer improves precision for deferred lighting/shadows, we no longer even need to enforce a precise clipping range to avoid distance artifacts.

Also, it now allows downsampling of all buffers needed for screen passes, fixing artifacts sometimes caused by incorrect/imperfect sampling with SSAO and SSIL. This also improves denoising quality while making it less costly, and it enables safe `texelFetch`, since anything written in half res can also be read in half res.

It also reduces the number of operations required to obtain the view-space position during screen passes.

However, this makes customization more complicated if, for example, you want SSAO to run in full or quarter res. That said, in the current state, there's no strong reason to do so.

Finally, the `r3d_target.c` module has been largely redesigned. The hardware depth buffer is now used as a renderbuffer, eliminating any risk when sampling depth, it will always go through the linear depth buffer.

I also revamped the target configuration system to allow specifying the desired clear value, as well as other adjustments such as defining the sampleable levels of a target and caches to store the state of attached and sampleable levels.