### PR TITLE
Animation player and skeleton review

### DIFF
--- a/include/r3d/r3d_animation_player.h
+++ b/include/r3d/r3d_animation_player.h
@@ -84,8 +84,9 @@ typedef struct R3D_AnimationPlayer {
     R3D_Skeleton skeleton;      ///< Skeleton to animate.
 
     Matrix* localPose;          ///< Array of bone transforms representing the blended local pose.
-    Matrix* globalPose;         ///< Array of bone transforms multiplied by bone offsets for GPU skinning.
-    uint32_t texGlobalPose;     ///< GPU texture ID storing the global pose as a 1D RGBA32F texture.
+    Matrix* modelPose;          ///< Array of bone transforms in model space, obtained by hierarchical accumulation.
+    Matrix* skinBuffer;         ///< Array of final skinning matrices (boneOffsets * modelPose), sent to the GPU.
+    uint32_t skinTexture;       ///< GPU texture ID storing the skinning matrices as a 1D RGBA16F texture.
 
     R3D_AnimationEventCallback eventCallback;   ///< Callback function to receive animation events.
     void* eventUserData;                        ///< Optional user data pointer passed to the callback.

--- a/include/r3d/r3d_animation_player.h
+++ b/include/r3d/r3d_animation_player.h
@@ -85,7 +85,7 @@ typedef struct R3D_AnimationPlayer {
 
     Matrix* localPose;          ///< Array of bone transforms representing the blended local pose.
     Matrix* modelPose;          ///< Array of bone transforms in model space, obtained by hierarchical accumulation.
-    Matrix* skinBuffer;         ///< Array of final skinning matrices (boneOffsets * modelPose), sent to the GPU.
+    Matrix* skinBuffer;         ///< Array of final skinning matrices (invBind * modelPose), sent to the GPU.
     uint32_t skinTexture;       ///< GPU texture ID storing the skinning matrices as a 1D RGBA16F texture.
 
     R3D_AnimationEventCallback eventCallback;   ///< Callback function to receive animation events.
@@ -255,17 +255,41 @@ R3DAPI void R3D_SetAnimationLoop(R3D_AnimationPlayer* player, int animIndex, boo
 R3DAPI void R3D_AdvanceAnimationPlayerTime(R3D_AnimationPlayer* player, float dt);
 
 /**
- * @brief Calculates the current blended skeleton pose.
+ * @brief Calculates the current blended local pose of the skeleton.
  *
- * Interpolates keyframes and blends all active animations according to their weights.
+ * Interpolates keyframes and blends all active animations according to their weights,
+ * but only computes the local transforms of each bone relative to its parent.
  * Does NOT advance animation time.
  *
- * @param player Animation player.
+ * @param player Animation player whose local pose will be updated.
+ */
+R3DAPI void R3D_CalculateAnimationPlayerLocalPose(R3D_AnimationPlayer* player);
+
+/**
+ * @brief Calculates the current blended model (global) pose of the skeleton.
+ *
+ * Interpolates keyframes and blends all active animations according to their weights,
+ * but only computes the global transforms of each bone in model space.
+ * This assumes the local pose is already up-to-date.
+ * Does NOT advance animation time.
+ *
+ * @param player Animation player whose model pose will be updated.
+ */
+R3DAPI void R3D_CalculateAnimationPlayerModelPose(R3D_AnimationPlayer* player);
+
+/**
+ * @brief Calculates the current blended skeleton pose (local and model).
+ *
+ * Interpolates keyframes and blends all active animations according to their weights,
+ * then computes both local and model transforms for the entire skeleton.
+ * Does NOT advance animation time.
+ *
+ * @param player Animation player whose local and model poses will be updated.
  */
 R3DAPI void R3D_CalculateAnimationPlayerPose(R3D_AnimationPlayer* player);
 
 /**
- * @brief Uploads the current global pose array to the internal GPU texture.
+ * @brief Calculates the skinning matrices and uploads them to the GPU.
  *
  * @param player Animation player.
  */

--- a/include/r3d/r3d_skeleton.h
+++ b/include/r3d/r3d_skeleton.h
@@ -102,6 +102,24 @@ R3DAPI void R3D_UnloadSkeleton(R3D_Skeleton skeleton);
  */
 R3DAPI bool R3D_IsSkeletonValid(R3D_Skeleton skeleton);
 
+/**
+ * @brief Returns the index of the bone with the given name.
+ * 
+ * @param skeleton Skeleton to search in.
+ * @param boneName Name of the bone to find.
+ * @return Index of the bone, or a negative value if not found.
+ */
+R3DAPI int R3D_GetSkeletonBoneIndex(R3D_Skeleton skeleton, const char* boneName);
+
+/**
+ * @brief Returns a pointer to the bone with the given name.
+ * 
+ * @param skeleton Skeleton to search in.
+ * @param boneName Name of the bone to find.
+ * @return Pointer to the bone, or NULL if not found.
+ */
+R3DAPI R3D_BoneInfo* R3D_GetSkeletonBone(R3D_Skeleton skeleton, const char* boneName);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/include/r3d/r3d_skeleton.h
+++ b/include/r3d/r3d_skeleton.h
@@ -44,9 +44,10 @@ typedef struct R3D_Skeleton {
     R3D_BoneInfo* bones;    ///< Array of bone descriptors defining the hierarchy and names.
     int boneCount;          ///< Total number of bones in the skeleton.
 
-    Matrix* boneOffsets;    ///< Inverse bind matrices, one per bone. Transform vertices from mesh space to bone space (used in skinning).
-    Matrix* bindLocal;      ///< Bind pose transforms in local bone space (relative to parent).
-    Matrix* bindPose;       ///< Bind pose transforms in model space. Used as the default pose when not animated.
+    Matrix* localBind;      ///< Bind pose matrices relative to parent
+    Matrix* modelBind;      ///< Bind pose matrices in model/global space
+    Matrix* invBind;        ///< Inverse bind matrices (model space) for skinning
+    Matrix rootBind;        ///< Root correction if local bind is not identity
 
     uint32_t skinTexture;   ///< Texture ID that contains the bind pose for GPU skinning. This is a 1D Texture RGBA16F 4*boneCount.
 

--- a/include/r3d/r3d_skeleton.h
+++ b/include/r3d/r3d_skeleton.h
@@ -46,9 +46,9 @@ typedef struct R3D_Skeleton {
 
     Matrix* boneOffsets;    ///< Inverse bind matrices, one per bone. Transform vertices from mesh space to bone space (used in skinning).
     Matrix* bindLocal;      ///< Bind pose transforms in local bone space (relative to parent).
-    Matrix* bindPose;       ///< Bind pose transforms in model space (global). Used as the default pose when not animated.
+    Matrix* bindPose;       ///< Bind pose transforms in model space. Used as the default pose when not animated.
 
-    uint32_t texBindPose;   ///< Texture ID that contains the bind pose for GPU skinning. This is a 1D Texture RGBA32F 4*boneCount.
+    uint32_t skinTexture;   ///< Texture ID that contains the bind pose for GPU skinning. This is a 1D Texture RGBA16F 4*boneCount.
 
 } R3D_Skeleton;
 

--- a/src/importer/r3d_importer_skeleton.c
+++ b/src/importer/r3d_importer_skeleton.c
@@ -23,9 +23,10 @@
 typedef struct {
     const r3d_importer_t* importer;
     R3D_BoneInfo* bones;
-    Matrix* boneOffsets;
-    Matrix* bindLocal;
-    Matrix* bindPose;
+    Matrix* invBind;
+    Matrix* localBind;
+    Matrix* modelBind;
+    Matrix* rootBind;
     int boneCount;
 } skeleton_build_context_t;
 
@@ -36,22 +37,29 @@ typedef struct {
 static void build_skeleton_recursive(
     skeleton_build_context_t* ctx,
     const struct aiNode* node,
-    int parentIndex,
-    Matrix parentTransform)
+    Matrix parentTransform,
+    int parentIndex)
 {
     if (!node) return;
 
     Matrix localTransform = r3d_importer_cast(node->mTransformation);
-    Matrix globalTransform = r3d_matrix_multiply(&localTransform, &parentTransform);
+    Matrix modelTransform = r3d_matrix_multiply(&localTransform, &parentTransform);
 
     // Check if this node is a bone
     int currentIndex = r3d_importer_get_bone_index(ctx->importer, node->mName.data);
 
     if (currentIndex >= 0) {
-        // Store bone data
-        ctx->bindPose[currentIndex] = globalTransform;
-        ctx->bindLocal[currentIndex] = localTransform;
+        // Store bone matrices
+        ctx->localBind[currentIndex] = localTransform;
+        ctx->modelBind[currentIndex] = modelTransform;
 
+        // Store bind root matrix
+        if (parentIndex == -1) {
+            Matrix invLocalTransform = MatrixInvert(localTransform);
+            *ctx->rootBind = r3d_matrix_multiply(&invLocalTransform, &modelTransform);
+        }
+
+        // Store bone infos
         strncpy(ctx->bones[currentIndex].name, node->mName.data, sizeof(ctx->bones[currentIndex].name) - 1);
         ctx->bones[currentIndex].name[sizeof(ctx->bones[currentIndex].name) - 1] = '\0';
         ctx->bones[currentIndex].parent = parentIndex;
@@ -62,7 +70,7 @@ static void build_skeleton_recursive(
 
     // Recursively process children
     for (unsigned int i = 0; i < node->mNumChildren; i++) {
-        build_skeleton_recursive(ctx, node->mChildren[i], parentIndex, globalTransform);
+        build_skeleton_recursive(ctx, node->mChildren[i], modelTransform, parentIndex);
     }
 }
 
@@ -73,7 +81,7 @@ static void build_skeleton_recursive(
 static void upload_skeleton_bind_pose(R3D_Skeleton* skeleton)
 {
     Matrix* finalBindPose = RL_MALLOC(skeleton->boneCount * sizeof(Matrix));
-    r3d_matrix_multiply_batch(finalBindPose, skeleton->boneOffsets, skeleton->bindPose, skeleton->boneCount);
+    r3d_matrix_multiply_batch(finalBindPose, skeleton->invBind, skeleton->modelBind, skeleton->boneCount);
 
     glGenTextures(1, &skeleton->skinTexture);
     glBindTexture(GL_TEXTURE_1D, skeleton->skinTexture);
@@ -104,17 +112,17 @@ bool r3d_importer_load_skeleton(const r3d_importer_t* importer, R3D_Skeleton* sk
 
     // Allocate bone arrays
     skeleton->bones = RL_MALLOC(boneCount * sizeof(R3D_BoneInfo));
-    skeleton->boneOffsets = RL_MALLOC(boneCount * sizeof(Matrix));
-    skeleton->bindLocal = RL_MALLOC(boneCount * sizeof(Matrix));
-    skeleton->bindPose = RL_MALLOC(boneCount * sizeof(Matrix));
+    skeleton->invBind = RL_MALLOC(boneCount * sizeof(Matrix));
+    skeleton->localBind = RL_MALLOC(boneCount * sizeof(Matrix));
+    skeleton->modelBind = RL_MALLOC(boneCount * sizeof(Matrix));
     skeleton->boneCount = boneCount;
 
-    if (!skeleton->bones || !skeleton->boneOffsets || !skeleton->bindLocal || !skeleton->bindPose) {
+    if (!skeleton->bones || !skeleton->invBind || !skeleton->localBind || !skeleton->modelBind) {
         R3D_TRACELOG(LOG_ERROR, "Failed to allocate memory for skeleton bones");
         RL_FREE(skeleton->bones);
-        RL_FREE(skeleton->boneOffsets);
-        RL_FREE(skeleton->bindLocal);
-        RL_FREE(skeleton->bindPose);
+        RL_FREE(skeleton->invBind);
+        RL_FREE(skeleton->localBind);
+        RL_FREE(skeleton->modelBind);
         RL_FREE(skeleton);
         return false;
     }
@@ -134,7 +142,7 @@ bool r3d_importer_load_skeleton(const r3d_importer_t* importer, R3D_Skeleton* sk
             int boneIdx = r3d_importer_get_bone_index(importer, bone->mName.data);
 
             if (boneIdx >= 0) {
-                skeleton->boneOffsets[boneIdx] = r3d_importer_cast(bone->mOffsetMatrix);
+                skeleton->invBind[boneIdx] = r3d_importer_cast(bone->mOffsetMatrix);
             }
         }
     }
@@ -143,13 +151,14 @@ bool r3d_importer_load_skeleton(const r3d_importer_t* importer, R3D_Skeleton* sk
     skeleton_build_context_t ctx = {
         .importer = importer,
         .bones = skeleton->bones,
-        .boneOffsets = skeleton->boneOffsets,
-        .bindLocal = skeleton->bindLocal,
-        .bindPose = skeleton->bindPose,
+        .invBind = skeleton->invBind,
+        .localBind = skeleton->localBind,
+        .modelBind = skeleton->modelBind,
+        .rootBind = &skeleton->rootBind,
         .boneCount = boneCount
     };
 
-    build_skeleton_recursive(&ctx, r3d_importer_get_root(importer), -1, R3D_MATRIX_IDENTITY);
+    build_skeleton_recursive(&ctx, r3d_importer_get_root(importer), R3D_MATRIX_IDENTITY, -1);
     upload_skeleton_bind_pose(skeleton);
 
     R3D_TRACELOG(LOG_INFO, "Loaded skeleton with %d bones", boneCount);

--- a/src/importer/r3d_importer_skeleton.c
+++ b/src/importer/r3d_importer_skeleton.c
@@ -75,8 +75,8 @@ static void upload_skeleton_bind_pose(R3D_Skeleton* skeleton)
     Matrix* finalBindPose = RL_MALLOC(skeleton->boneCount * sizeof(Matrix));
     r3d_matrix_multiply_batch(finalBindPose, skeleton->boneOffsets, skeleton->bindPose, skeleton->boneCount);
 
-    glGenTextures(1, &skeleton->texBindPose);
-    glBindTexture(GL_TEXTURE_1D, skeleton->texBindPose);
+    glGenTextures(1, &skeleton->skinTexture);
+    glBindTexture(GL_TEXTURE_1D, skeleton->skinTexture);
     glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA16F, 4 * skeleton->boneCount, 0, GL_RGBA, GL_FLOAT, finalBindPose);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/src/r3d_animation_player.c
+++ b/src/r3d_animation_player.c
@@ -16,8 +16,9 @@
 // INTERNAL FUNCTIONS DECLARATIONS
 // ========================================
 
-static void compute_pose(R3D_AnimationPlayer* player, float totalWeight);
 static void emit_event(R3D_AnimationPlayer* player, R3D_AnimationEvent event, int animIndex);
+static void compute_local_matrices(R3D_AnimationPlayer* player, float totalWeight);
+static void compute_model_matrices(R3D_AnimationPlayer* player);
 
 // ========================================
 // PUBLIC API
@@ -187,6 +188,39 @@ void R3D_AdvanceAnimationPlayerTime(R3D_AnimationPlayer* player, float dt)
     }
 }
 
+void R3D_CalculateAnimationPlayerLocalPose(R3D_AnimationPlayer* player)
+{
+    const R3D_AnimationState* states = player->states;
+    int boneCount = player->skeleton.boneCount;
+    int animCount = player->animLib.count;
+
+    float totalWeight = 0.0f;
+    for (int iAnim = 0; iAnim < animCount; iAnim++) {
+        totalWeight += states[iAnim].weight;
+    }
+
+    if (totalWeight > 0.0f) compute_local_matrices(player, totalWeight);
+    else memcpy(player->localPose, player->skeleton.localBind, boneCount * sizeof(Matrix));
+}
+
+void R3D_CalculateAnimationPlayerModelPose(R3D_AnimationPlayer* player)
+{
+    const R3D_AnimationState* states = player->states;
+    int boneCount = player->skeleton.boneCount;
+    int animCount = player->animLib.count;
+
+    bool hasWeight = false;
+    for (int iAnim = 0; iAnim < animCount; iAnim++) {
+        if (states[iAnim].weight > 0.0f) {
+            hasWeight = true;
+            break;
+        }
+    }
+
+    if (hasWeight) compute_model_matrices(player);
+    else memcpy(player->modelPose, player->skeleton.modelBind, boneCount * sizeof(Matrix));
+}
+
 void R3D_CalculateAnimationPlayerPose(R3D_AnimationPlayer* player)
 {
     const int boneCount = player->skeleton.boneCount;
@@ -200,17 +234,18 @@ void R3D_CalculateAnimationPlayerPose(R3D_AnimationPlayer* player)
     }
 
     if (totalWeight > 0.0f) {
-        compute_pose(player, totalWeight);
+        compute_local_matrices(player, totalWeight);
+        compute_model_matrices(player);
     }
     else {
-        memcpy(player->localPose, player->skeleton.bindLocal, boneCount * sizeof(Matrix));
-        memcpy(player->modelPose, player->skeleton.bindPose, boneCount * sizeof(Matrix));
+        memcpy(player->localPose, player->skeleton.localBind, boneCount * sizeof(Matrix));
+        memcpy(player->modelPose, player->skeleton.modelBind, boneCount * sizeof(Matrix));
     }
 }
 
 void R3D_UploadAnimationPlayerPose(R3D_AnimationPlayer* player)
 {
-    r3d_matrix_multiply_batch(player->skinBuffer, player->skeleton.boneOffsets, player->modelPose, player->skeleton.boneCount);
+    r3d_matrix_multiply_batch(player->skinBuffer, player->skeleton.invBind, player->modelPose, player->skeleton.boneCount);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_1D, player->skinTexture);
@@ -229,6 +264,13 @@ void R3D_UpdateAnimationPlayer(R3D_AnimationPlayer* player, float dt)
 // ========================================
 // INTERNAL FUNCTIONS DEFINITIONS
 // ========================================
+
+void emit_event(R3D_AnimationPlayer* player, R3D_AnimationEvent event, int animIndex)
+{
+    if (player->eventCallback != NULL) {
+        player->eventCallback(player, event, animIndex, player->eventUserData);
+    }
+}
 
 static void find_key_frames(
     const float* times, uint32_t count, float time,
@@ -344,11 +386,15 @@ static const R3D_AnimationChannel* find_channel_for_bone(const R3D_Animation* an
     return NULL;
 }
 
-void compute_pose(R3D_AnimationPlayer* player, float totalWeight)
+void compute_local_matrices(R3D_AnimationPlayer* player, float totalWeight)
 {
-    const int boneCount = player->skeleton.boneCount;
-    const int animCount = player->animLib.count;
-    R3D_AnimationState* states = player->states;
+    int boneCount = player->skeleton.boneCount;
+    int animCount = player->animLib.count;
+
+    const Matrix* localBind = player->skeleton.localBind;
+    Matrix* localPose = player->localPose;
+
+    float invTotalWeight = 1.0f / totalWeight;
 
     for (int iBone = 0; iBone < boneCount; iBone++)
     {
@@ -358,7 +404,7 @@ void compute_pose(R3D_AnimationPlayer* player, float totalWeight)
         for (int iAnim = 0; iAnim < animCount; iAnim++)
         {
             const R3D_Animation* anim = &player->animLib.animations[iAnim];
-            const R3D_AnimationState* state = &states[iAnim];
+            const R3D_AnimationState* state = &player->states[iAnim];
             if (state->weight <= 0.0f) continue;
 
             const R3D_AnimationChannel* channel = find_channel_for_bone(anim, iBone);
@@ -366,38 +412,34 @@ void compute_pose(R3D_AnimationPlayer* player, float totalWeight)
             isAnimated = true;
 
             Transform local = interpolate_channel(channel, state->currentTime * anim->ticksPerSecond);
-            float w = state->weight / totalWeight;
+            float w = state->weight * invTotalWeight;
 
             blended.translation = Vector3Add(blended.translation, Vector3Scale(local.translation, w));
             blended.rotation = QuaternionAdd(blended.rotation, QuaternionScale(local.rotation, w));
             blended.scale = Vector3Add(blended.scale, Vector3Scale(local.scale, w));
         }
 
-        if (isAnimated) {
-            blended.rotation = QuaternionNormalize(blended.rotation);
-            player->localPose[iBone] = r3d_matrix_scale_rotq_translate(blended.scale, blended.rotation, blended.translation);
-        }
-        else {
-            player->localPose[iBone] = player->skeleton.bindLocal[iBone];
+        if (!isAnimated) {
+            localPose[iBone] = localBind[iBone];
+            continue;
         }
 
-        int parentIdx = player->skeleton.bones[iBone].parent;
-        if (parentIdx >= 0) {
-            player->modelPose[iBone] = r3d_matrix_multiply(&player->localPose[iBone], &player->modelPose[parentIdx]);
-        }
-        else {
-            Matrix invLocalBind = MatrixInvert(player->skeleton.bindLocal[iBone]);
-            Matrix parentGlobalScene = r3d_matrix_multiply(&invLocalBind, &player->skeleton.bindPose[iBone]);
-            player->modelPose[iBone] = r3d_matrix_multiply(&player->localPose[iBone], &parentGlobalScene);
-        }
-
-        player->skinBuffer[iBone] = r3d_matrix_multiply(&player->skeleton.boneOffsets[iBone], &player->modelPose[iBone]);
+        blended.rotation = QuaternionNormalize(blended.rotation);
+        localPose[iBone] = r3d_matrix_scale_rotq_translate(blended.scale, blended.rotation, blended.translation);
     }
 }
 
-void emit_event(R3D_AnimationPlayer* player, R3D_AnimationEvent event, int animIndex)
+void compute_model_matrices(R3D_AnimationPlayer* player)
 {
-    if (player->eventCallback != NULL) {
-        player->eventCallback(player, event, animIndex, player->eventUserData);
+    const R3D_BoneInfo* bones = player->skeleton.bones;
+    const Matrix* rootBind = &player->skeleton.rootBind;
+    const Matrix* localPose = player->localPose;
+    Matrix* modelPose = player->modelPose;
+
+    int boneCount = player->skeleton.boneCount;
+
+    for (int iBone = 0; iBone < boneCount; iBone++) {
+        int iParent = bones[iBone].parent;
+        modelPose[iBone] = r3d_matrix_multiply(&localPose[iBone], (iParent >= 0) ? &modelPose[iParent] : rootBind);
     }
 }

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -304,7 +304,7 @@ void R3D_DrawModelPro(R3D_Model model, Matrix transform)
     r3d_draw_group_t drawGroup = {0};
     drawGroup.aabb = model.aabb;
     drawGroup.transform = transform;
-    drawGroup.texPose = model.skeleton.texBindPose;
+    drawGroup.texPose = model.skeleton.skinTexture;
 
     r3d_draw_group_push(&drawGroup);
 
@@ -336,7 +336,7 @@ void R3D_DrawModelInstancedEx(R3D_Model model, R3D_InstanceBuffer instances, int
 
     drawGroup.aabb = model.aabb;
     drawGroup.transform = transform;
-    drawGroup.texPose = model.skeleton.texBindPose;
+    drawGroup.texPose = model.skeleton.skinTexture;
 
     drawGroup.transform = transform;
     drawGroup.instances = instances;
@@ -379,8 +379,8 @@ void R3D_DrawAnimatedModelPro(R3D_Model model, R3D_AnimationPlayer player, Matri
 
     drawGroup.aabb = model.aabb;
     drawGroup.transform = transform;
-    drawGroup.texPose = (player.texGlobalPose > 0)
-        ? player.texGlobalPose : model.skeleton.texBindPose;
+    drawGroup.texPose = (player.skinTexture > 0)
+        ? player.skinTexture : model.skeleton.skinTexture;
 
     r3d_draw_group_push(&drawGroup);
 
@@ -412,8 +412,8 @@ void R3D_DrawAnimatedModelInstancedEx(R3D_Model model, R3D_AnimationPlayer playe
 
     drawGroup.aabb = model.aabb;
     drawGroup.transform = transform;
-    drawGroup.texPose = (player.texGlobalPose > 0)
-        ? player.texGlobalPose : model.skeleton.texBindPose;
+    drawGroup.texPose = (player.skinTexture > 0)
+        ? player.skinTexture : model.skeleton.skinTexture;
 
     drawGroup.transform = transform;
     drawGroup.instances = instances;

--- a/src/r3d_skeleton.c
+++ b/src/r3d_skeleton.c
@@ -63,3 +63,23 @@ bool R3D_IsSkeletonValid(R3D_Skeleton skeleton)
 {
     return (skeleton.skinTexture > 0);
 }
+
+int R3D_GetSkeletonBoneIndex(R3D_Skeleton skeleton, const char* boneName)
+{
+    for (int i = 0; i < skeleton.boneCount; i++) {
+        if (strcmp(skeleton.bones[i].name, boneName) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+R3D_BoneInfo* R3D_GetSkeletonBone(R3D_Skeleton skeleton, const char* boneName)
+{
+    for (int i = 0; i < skeleton.boneCount; i++) {
+        if (strcmp(skeleton.bones[i].name, boneName) == 0) {
+            return &skeleton.bones[i];
+        }
+    }
+    return NULL;
+}

--- a/src/r3d_skeleton.c
+++ b/src/r3d_skeleton.c
@@ -54,9 +54,9 @@ void R3D_UnloadSkeleton(R3D_Skeleton skeleton)
     }
 
     RL_FREE(skeleton.bones);
-    RL_FREE(skeleton.boneOffsets);
-    RL_FREE(skeleton.bindLocal);
-    RL_FREE(skeleton.bindPose);
+    RL_FREE(skeleton.invBind);
+    RL_FREE(skeleton.modelBind);
+    RL_FREE(skeleton.localBind);
 }
 
 bool R3D_IsSkeletonValid(R3D_Skeleton skeleton)

--- a/src/r3d_skeleton.c
+++ b/src/r3d_skeleton.c
@@ -49,8 +49,8 @@ R3D_Skeleton R3D_LoadSkeletonFromData(const void* data, unsigned int size, const
 
 void R3D_UnloadSkeleton(R3D_Skeleton skeleton)
 {
-    if (skeleton.texBindPose > 0) {
-        glDeleteTextures(1, &skeleton.texBindPose);
+    if (skeleton.skinTexture > 0) {
+        glDeleteTextures(1, &skeleton.skinTexture);
     }
 
     RL_FREE(skeleton.bones);
@@ -61,5 +61,5 @@ void R3D_UnloadSkeleton(R3D_Skeleton skeleton)
 
 bool R3D_IsSkeletonValid(R3D_Skeleton skeleton)
 {
-    return (skeleton.texBindPose > 0);
+    return (skeleton.skinTexture > 0);
 }


### PR DESCRIPTION
This PR fixes consistency issues in matrix arrays naming and adds more flexibility in pose calculation.

### API changes in `R3D_AnimationPlayer`:

- `localPose` now contains the actual local pose of each bone.
- `modelPose` now contains the pose in model space.
- `globalPose` which previously held skinning matrices, has been renamed to `skinBuffer`.
- `skinBuffer` now contains the skinning matrices that will be uploaded to the GPU texture.
- `skinTexture` is the new name for the GPU skinning texture.

### API changes in `R3D_Skeleton`:

- `boneOffsets` has been renamed to `invBind`.
- `bindPose` has been renamed to `modelBind`.
- `bindLocal` has been renamed to `localBind`.
- `rootBind` has been added to avoid recalculating it at runtime during animations.
- `texBindPose` has been renamed to `skinTexture`.

### New skeleton convenience functions:

Two helper functions have been added to retrieve bones by name:

- `R3D_GetSkeletonBoneIndex(skeleton, name)`
- `R3D_GetSkeletonBone(skeleton, name)`

### New animation player functions:

- `R3D_CalculateAnimationPlayerLocalPose(&player)`
- `R3D_CalculateAnimationPlayerModelPose(&player)`

These functions allow calculating only the local pose first (so it can be modified), then computing the model pose from the local matrices.

Skinning matrices are then computed into `skinBuffer` during the call to `R3D_UploadAnimationPlayerPose()` before uploading to the GPU.

The `R3D_CalculateAnimationPlayerPose()` function is still present to calculate both local and model poses at once, and it is still called by `R3D_UpdateAnimationPlayer()` for simple animation cases.
