### PR TITLE
Review draw call sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ int main(void)
     InitWindow(800, 600, "R3D Example");
     SetTargetFPS(60);
 
-    R3D_Init(800, 600, 0);
+    R3D_Init(800, 600);
 
     // Create scene objects
     R3D_Mesh mesh = R3D_GenMeshSphere(1.0f, 16, 32);

--- a/examples/animation.c
+++ b/examples/animation.c
@@ -12,7 +12,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D with FXAA
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
     R3D_SetAntiAliasing(R3D_ANTI_ALIASING_FXAA);
 
     // Setup environment sky

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -1,3 +1,5 @@
+#include "r3d/r3d_material.h"
+#include "raylib.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 
@@ -8,7 +10,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Create meshes
     R3D_Mesh plane = R3D_GenMeshPlane(1000, 1000, 1, 1);

--- a/examples/billboards.c
+++ b/examples/billboards.c
@@ -12,7 +12,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
     R3D_SetTextureFilter(TEXTURE_FILTER_POINT);
 
     // Set background/ambient color

--- a/examples/bloom.c
+++ b/examples/bloom.c
@@ -13,7 +13,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Setup bloom and tonemapping
     R3D_ENVIRONMENT_SET(tonemap.mode, R3D_TONEMAP_ACES);

--- a/examples/decal.c
+++ b/examples/decal.c
@@ -24,7 +24,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Create decal
     R3D_Decal decal = R3D_DECAL_BASE;

--- a/examples/dof.c
+++ b/examples/dof.c
@@ -14,7 +14,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D with FXAA
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
     R3D_SetAntiAliasing(R3D_ANTI_ALIASING_FXAA);
 
     // Configure depth of field and background

--- a/examples/instanced.c
+++ b/examples/instanced.c
@@ -10,7 +10,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Set ambient light
     R3D_ENVIRONMENT_SET(ambient.color, DARKGRAY);

--- a/examples/lights.c
+++ b/examples/lights.c
@@ -16,7 +16,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Set ambient light
     R3D_ENVIRONMENT_SET(background.color, BLACK);

--- a/examples/particles.c
+++ b/examples/particles.c
@@ -16,7 +16,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Set environment
     R3D_ENVIRONMENT_SET(background.color, (Color){4, 4, 4});

--- a/examples/pbr.c
+++ b/examples/pbr.c
@@ -12,7 +12,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
     R3D_SetAntiAliasing(R3D_ANTI_ALIASING_FXAA);
 
     // Setup environment sky

--- a/examples/probe.c
+++ b/examples/probe.c
@@ -13,7 +13,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Setup environment sky
     R3D_Cubemap cubemap = R3D_LoadCubemap(RESOURCES_PATH "panorama/indoor.hdr", R3D_CUBEMAP_LAYOUT_AUTO_DETECT);

--- a/examples/resize.c
+++ b/examples/resize.c
@@ -12,7 +12,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Create sphere mesh and materials
     R3D_Mesh sphere = R3D_GenMeshSphere(0.5f, 64, 64);

--- a/examples/skybox.c
+++ b/examples/skybox.c
@@ -12,7 +12,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Create sphere mesh
     R3D_Mesh sphere = R3D_GenMeshSphere(0.5f, 32, 64);

--- a/examples/sponza.c
+++ b/examples/sponza.c
@@ -12,7 +12,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Post-processing setup
     R3D_ENVIRONMENT_SET(bloom.mode, R3D_BLOOM_MIX);

--- a/examples/sprite.c
+++ b/examples/sprite.c
@@ -14,7 +14,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
     R3D_SetTextureFilter(TEXTURE_FILTER_POINT);
 
     // Set background/ambient color

--- a/examples/sun.c
+++ b/examples/sun.c
@@ -12,7 +12,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
     R3D_SetAntiAliasing(R3D_ANTI_ALIASING_FXAA);
 
     // Create meshes and material

--- a/examples/transparency.c
+++ b/examples/transparency.c
@@ -8,7 +8,7 @@ int main(void)
     SetTargetFPS(60);
 
     // Initialize R3D
-    R3D_Init(GetScreenWidth(), GetScreenHeight(), 0);
+    R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Create cube model
     R3D_Mesh mesh = R3D_GenMeshCube(1, 1, 1);

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -23,17 +23,6 @@
 // ========================================
 
 /**
- * @brief Flags to configure the rendering engine behavior.
- *
- * These flags control various aspects of the rendering pipeline.
- */
-typedef uint32_t R3D_Flags;
-
-#define R3D_FLAG_NONE                   0           ///< No special rendering flags
-#define R3D_FLAG_TRANSPARENT_SORTING    (1 << 0)    ///< Back-to-front sorting of transparent objects for correct blending of non-discarded fragments.
-#define R3D_FLAG_OPAQUE_SORTING         (1 << 1)    ///< Front-to-back sorting of opaque objects to optimize depth testing at the cost of additional sorting.
-
-/**
  * @brief Bitfield type used to specify rendering layers for 3D objects.
  *
  * This type is used by `R3D_Mesh` and `R3D_Sprite` objects to indicate
@@ -155,15 +144,12 @@ extern "C" {
 /**
  * @brief Initializes the rendering engine.
  * 
- * This function sets up the internal rendering system with the provided resolution 
- * and state flags, which define the internal behavior. These flags can be modified
- * later via R3D_SetState.
+ * This function sets up the internal rendering system with the provided resolution.
  * 
  * @param resWidth Width of the internal resolution.
  * @param resHeight Height of the internal resolution.
- * @param flags Flags indicating internal behavior (modifiable via R3D_SetState).
  */
-R3DAPI void R3D_Init(int resWidth, int resHeight, R3D_Flags flags);
+R3DAPI void R3D_Init(int resWidth, int resHeight);
 
 /**
  * @brief Closes the rendering engine and deallocates all resources.
@@ -172,34 +158,6 @@ R3DAPI void R3D_Init(int resWidth, int resHeight, R3D_Flags flags);
  * including the resources associated with the created lights.
  */
 R3DAPI void R3D_Close(void);
-
-/**
- * @brief Checks if a specific internal state flag is set.
- * 
- * @param flags The state flags to check.
- * @return True if the flags are set, false otherwise.
- */
-R3DAPI bool R3D_HasState(R3D_Flags flags);
-
-/**
- * @brief Sets internal state flags for the rendering engine.
- * 
- * This function modifies the behavior of the rendering engine by setting one or more 
- * state flags. Flags can be later cleared with R3D_ClearState.
- * 
- * @param flags The flags to set.
- */
-R3DAPI void R3D_SetState(R3D_Flags flags);
-
-/**
- * @brief Clears specific internal state flags.
- * 
- * This function clears one or more previously set state flags, modifying the 
- * behavior of the rendering engine accordingly.
- * 
- * @param flags The flags to clear.
- */
-R3DAPI void R3D_ClearState(R3D_Flags flags);
 
 /**
  * @brief Gets the current internal resolution.

--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -746,6 +746,7 @@ void r3d_draw_sort_list(r3d_draw_list_enum_t list, Vector3 viewPosition, r3d_dra
     case R3D_DRAW_SORT_MATERIAL_ONLY:
         compare_func = compare_materials_only;
         sort_fill_cache_by_material(list);
+        break;
     }
 
     qsort(

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -104,8 +104,8 @@ typedef enum {
  * Used to control draw order for depth testing efficiency or visual correctness.
  */
 typedef enum {
-    R3D_DRAW_SORT_FRONT_TO_BACK,    //< Typically used for opaque geometry
-    R3D_DRAW_SORT_BACK_TO_FRONT,    //< Typically used for transparent geometry
+    R3D_DRAW_SORT_BACK_TO_FRONT,    //< Used for transparent geometry
+    R3D_DRAW_SORT_BY_MATERIALS      //< Used to reduce GL state changes
 } r3d_draw_sort_enum_t;
 
 /*
@@ -220,6 +220,23 @@ typedef struct {
     int numCalls;   //< Number of active entries
 } r3d_draw_list_t;
 
+/*
+ * Data stored by draw call in the sort cache.
+ */
+typedef union {
+    float distance;
+    struct {
+        uint32_t albedo;
+        uint32_t normal;
+        uint32_t orm;
+        uint32_t emission;
+        uint32_t blend;
+        uint32_t cull;
+        uint32_t transparency;
+        uint32_t billboard;
+    } material;
+} r3d_draw_sort_t;
+
 // ========================================
 // MODULE STATE
 // ========================================
@@ -240,9 +257,9 @@ extern struct r3d_draw {
     r3d_draw_group_t* groups;                       //< Array of draw groups (shared data across draw calls)
 
     r3d_draw_list_t list[R3D_DRAW_LIST_COUNT];      //< Lists of draw call indices organized by rendering category
+    r3d_draw_sort_t* sortCache;                     //< Draw call sorting data cache array
     r3d_draw_call_t* calls;                         //< Array of draw calls
     int* groupIndices;                              //< Array of group indices for each draw call (automatically managed)
-    float* cacheDists;                              //< Array of distances between draw calls and the camera for sorting
 
     int numClusters;                                //< Number of active draw clusters
     int numGroups;                                  //< Number of active draw groups

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -104,8 +104,9 @@ typedef enum {
  * Used to control draw order for depth testing efficiency or visual correctness.
  */
 typedef enum {
-    R3D_DRAW_SORT_BACK_TO_FRONT,    //< Used for transparent geometry
-    R3D_DRAW_SORT_BY_MATERIALS      //< Used to reduce GL state changes
+    R3D_DRAW_SORT_FRONT_TO_BACK,    //< Sort first by materials, then front to back, used for simple opaque geometry
+    R3D_DRAW_SORT_BACK_TO_FRONT,    //< Sort back to front only, used for simple transparent geometry
+    R3D_DRAW_SORT_MATERIAL_ONLY     //< Sort only by materials, used for instanced and decals
 } r3d_draw_sort_enum_t;
 
 /*
@@ -117,7 +118,7 @@ typedef enum {
     R3D_DRAW_LIST_DEFERRED,          //< Fully opaque
     R3D_DRAW_LIST_PREPASS,           //< Forward but with depth prepass
     R3D_DRAW_LIST_FORWARD,           //< Forward only, without prepass
-    R3D_DRAW_LIST_DECAL,           
+    R3D_DRAW_LIST_DECAL,
 
     R3D_DRAW_LIST_NON_INST_COUNT,
 
@@ -223,7 +224,7 @@ typedef struct {
 /*
  * Data stored by draw call in the sort cache.
  */
-typedef union {
+typedef struct {
     float distance;
     struct {
         uint32_t albedo;

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -34,7 +34,7 @@ struct r3d_core_state R3D;
 // PUBLIC API
 // ========================================
 
-void R3D_Init(int resWidth, int resHeight, R3D_Flags flags)
+void R3D_Init(int resWidth, int resHeight)
 {
     memset(&R3D, 0, sizeof(R3D));
 
@@ -57,7 +57,6 @@ void R3D_Init(int resWidth, int resHeight, R3D_Flags flags)
     R3D.textureFilter = TEXTURE_FILTER_TRILINEAR;
     R3D.colorSpace = R3D_COLORSPACE_SRGB;
     R3D.layers = R3D_LAYER_ALL;
-    R3D.state = flags;
 
     r3d_texture_init();
     r3d_target_init(resWidth, resHeight);
@@ -80,21 +79,6 @@ void R3D_Close(void)
     r3d_light_quit();
     r3d_draw_quit();
     r3d_env_quit();
-}
-
-bool R3D_HasState(R3D_Flags flags)
-{
-    return R3D_CORE_FLAGS_HAS(state, flags);
-}
-
-void R3D_SetState(R3D_Flags flags)
-{
-    R3D_CORE_FLAGS_ASSIGN(state, flags);
-}
-
-void R3D_ClearState(R3D_Flags flags)
-{
-    R3D_CORE_FLAGS_CLEAR(state, flags);
 }
 
 void R3D_GetResolution(int* width, int* height)

--- a/src/r3d_core_state.h
+++ b/src/r3d_core_state.h
@@ -75,7 +75,6 @@ extern struct r3d_core_state {
     R3D_ColorSpace colorSpace;          //< Color space that must be considered for supplied colors or surface colors
     Matrix matCubeViews[6];             //< Pre-computed view matrices for cubemap faces
     R3D_Layer layers;                   //< Active rendering layers
-    R3D_Flags state;                    //< Renderer state flags
 } R3D;
 
 #endif // R3D_CORE_STATE_H

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -127,11 +127,15 @@ void R3D_End(void)
 
     r3d_draw_compute_visible_groups(&R3D.viewState.frustum);
 
-    r3d_draw_sort_list(R3D_DRAW_LIST_DEFERRED, R3D.viewState.viewPosition, R3D_DRAW_SORT_BY_MATERIALS);
-    r3d_draw_sort_list(R3D_DRAW_LIST_DECAL, R3D.viewState.viewPosition, R3D_DRAW_SORT_BY_MATERIALS);
-
+    r3d_draw_sort_list(R3D_DRAW_LIST_DEFERRED, R3D.viewState.viewPosition, R3D_DRAW_SORT_FRONT_TO_BACK);
+    r3d_draw_sort_list(R3D_DRAW_LIST_DECAL, R3D.viewState.viewPosition, R3D_DRAW_SORT_MATERIAL_ONLY);
     r3d_draw_sort_list(R3D_DRAW_LIST_PREPASS, R3D.viewState.viewPosition, R3D_DRAW_SORT_BACK_TO_FRONT);
     r3d_draw_sort_list(R3D_DRAW_LIST_FORWARD, R3D.viewState.viewPosition, R3D_DRAW_SORT_BACK_TO_FRONT);
+
+    r3d_draw_sort_list(R3D_DRAW_LIST_DEFERRED_INST, R3D.viewState.viewPosition, R3D_DRAW_SORT_MATERIAL_ONLY);
+    r3d_draw_sort_list(R3D_DRAW_LIST_PREPASS_INST, R3D.viewState.viewPosition, R3D_DRAW_SORT_MATERIAL_ONLY);
+    r3d_draw_sort_list(R3D_DRAW_LIST_FORWARD_INST, R3D.viewState.viewPosition, R3D_DRAW_SORT_MATERIAL_ONLY);
+    r3d_draw_sort_list(R3D_DRAW_LIST_DECAL_INST, R3D.viewState.viewPosition, R3D_DRAW_SORT_MATERIAL_ONLY);
 
     /* --- Deferred path for opaques and decals --- */
 

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -127,14 +127,11 @@ void R3D_End(void)
 
     r3d_draw_compute_visible_groups(&R3D.viewState.frustum);
 
-    if (R3D_CORE_FLAGS_HAS(state, R3D_FLAG_OPAQUE_SORTING)) {
-        r3d_draw_sort_list(R3D_DRAW_LIST_DEFERRED, R3D.viewState.viewPosition, R3D_DRAW_SORT_FRONT_TO_BACK);
-    }
+    r3d_draw_sort_list(R3D_DRAW_LIST_DEFERRED, R3D.viewState.viewPosition, R3D_DRAW_SORT_BY_MATERIALS);
+    r3d_draw_sort_list(R3D_DRAW_LIST_DECAL, R3D.viewState.viewPosition, R3D_DRAW_SORT_BY_MATERIALS);
 
-    if (R3D_CORE_FLAGS_HAS(state, R3D_FLAG_TRANSPARENT_SORTING)) {
-        r3d_draw_sort_list(R3D_DRAW_LIST_PREPASS, R3D.viewState.viewPosition, R3D_DRAW_SORT_BACK_TO_FRONT);
-        r3d_draw_sort_list(R3D_DRAW_LIST_FORWARD, R3D.viewState.viewPosition, R3D_DRAW_SORT_BACK_TO_FRONT);
-    }
+    r3d_draw_sort_list(R3D_DRAW_LIST_PREPASS, R3D.viewState.viewPosition, R3D_DRAW_SORT_BACK_TO_FRONT);
+    r3d_draw_sort_list(R3D_DRAW_LIST_FORWARD, R3D.viewState.viewPosition, R3D_DRAW_SORT_BACK_TO_FRONT);
 
     /* --- Deferred path for opaques and decals --- */
 


### PR DESCRIPTION
The sorting flags have been removed, and as a result the initialization flags were completely removed as well.

In practice, there are very few cases where transparency sorting is not desirable at all.

For opaque rendering, at least a material based sort will be required with the introduction of custom shaders, so this change anticipates that need.

All opaque, instanced, and decal rendering is now sorted by material similarity to reduce state changes.

Additionally, opaque draws using the same material are sorted front to back.
Compared to the cost of the sort itself, this comes at almost no extra cost.

In cases where depth sorting does not make sense, the sort focuses solely on materials.

There is no performance difference for simple cases, and overall a fixed and deterministic sorting cost is preferable to unpredictable driver overhead.