### PR TITLE
Correctly handle null albedo texture for decals

### DIFF
--- a/examples/decal.c
+++ b/examples/decal.c
@@ -28,7 +28,7 @@ int main(void)
 
     // Create decal
     R3D_Decal decal = R3D_DECAL_BASE;
-    decal.albedo = R3D_LoadAlbedoMap(RESOURCES_PATH "images/decal.png", WHITE);
+    //decal.albedo = R3D_LoadAlbedoMap(RESOURCES_PATH "images/decal.png", WHITE);
     decal.normal = R3D_LoadNormalMap(RESOURCES_PATH "images/decal_normal.png", 1.0f);
     decal.normalThreshold = 89.0f;
 

--- a/shaders/scene/decal.frag
+++ b/shaders/scene/decal.frag
@@ -42,6 +42,7 @@ uniform vec2 uTexCoordScale;
 
 uniform float uNormalThreshold;
 uniform float uFadeWidth;
+uniform bool uAlbedoEnabled;
 
 /* === Fragments === */
 
@@ -103,7 +104,7 @@ void main()
     FragNormal = vec4(M_EncodeOctahedral(N), 0.0, 1.0);
 
 	/* Apply material */
-    FragAlbedo = albedo;
+    if (uAlbedoEnabled) FragAlbedo = albedo;
     FragEmission = vec4(vEmission * texture(uEmissionMap, decalTexCoord).rgb, fadeAlpha);
 
     vec3 orm = texture(uOrmMap, decalTexCoord).rgb;

--- a/shaders/scene/decal.frag
+++ b/shaders/scene/decal.frag
@@ -105,6 +105,9 @@ void main()
     if (uAlbedoEnabled) {
         FragAlbedo = vec4(albedo.rgb, albedo.a * fadeAlpha);
     }
+    else {
+        FragAlbedo = vec4(0);
+    }
     
     FragEmission = vec4(vEmission * texture(uEmissionMap, decalTexCoord).rgb, fadeAlpha);
 

--- a/shaders/scene/decal.frag
+++ b/shaders/scene/decal.frag
@@ -83,11 +83,9 @@ void main()
     /* Discard if the angle exceeds the threshold */
     if (difference < 0.0) discard;
 
-    /* Fade on edge of threshold */
-    // note: could do another (or the main) uAlphaCutoff check here for discard
+    /* Compute fade on edge of threshold */
     float fadeAlpha = clamp(difference / uFadeWidth, 0.0, 1.0);
-    albedo.a *= fadeAlpha;
-
+ 
     /* Retrieve surface tangent */
     vec3 surfaceTangent = M_DecodeOctahedral(texelFetch(uNormTanTex, ivec2(gl_FragCoord.xy), 0).ba);
 
@@ -104,7 +102,10 @@ void main()
     FragNormal = vec4(M_EncodeOctahedral(N), 0.0, 1.0);
 
 	/* Apply material */
-    if (uAlbedoEnabled) FragAlbedo = albedo;
+    if (uAlbedoEnabled) {
+        FragAlbedo = vec4(albedo.rgb, albedo.a * fadeAlpha);
+    }
+    
     FragEmission = vec4(vEmission * texture(uEmissionMap, decalTexCoord).rgb, fadeAlpha);
 
     vec3 orm = texture(uOrmMap, decalTexCoord).rgb;

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -631,6 +631,7 @@ void r3d_shader_load_scene_decal(void)
     GET_LOCATION(scene.decal, uMetalness);
     GET_LOCATION(scene.decal, uNormalThreshold);
     GET_LOCATION(scene.decal, uFadeWidth);
+    GET_LOCATION(scene.decal, uAlbedoEnabled);
 
     USE_SHADER(scene.decal);
 

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -600,6 +600,7 @@ typedef struct {
     r3d_shader_uniform_float_t uMetalness;
     r3d_shader_uniform_float_t uNormalThreshold;
     r3d_shader_uniform_float_t uFadeWidth;
+    r3d_shader_uniform_int_t uAlbedoEnabled;
 } r3d_shader_scene_decal_t;
 
 typedef struct {

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -952,6 +952,7 @@ void raster_decal(const r3d_draw_call_t* call)
 
     R3D_SHADER_SET_FLOAT(scene.decal, uNormalThreshold, decal->normalThreshold);
     R3D_SHADER_SET_FLOAT(scene.decal, uFadeWidth, decal->fadeWidth);
+    R3D_SHADER_SET_INT(scene.decal, uAlbedoEnabled, (decal->albedo.texture.id == 0) ? 0 : 1);
 
     /* --- Bind active texture maps --- */
 


### PR DESCRIPTION
The main purpose of this is to correctly render normal-only decals when no albedo texture is set. There are other ways this could be handled but this keeps it simple and just disables the output when the texture is null.