### PR TITLE
Decal mask

### DIFF
--- a/include/r3d/r3d_decal.h
+++ b/include/r3d/r3d_decal.h
@@ -51,7 +51,8 @@
         .uvScale = {1.0f, 1.0f},                        \
         .alphaCutoff = 0.01f,                           \
         .normalThreshold = 0,                           \
-        .fadeWidth = 0                                  \
+        .fadeWidth = 0,                                 \
+        .applyColor = true                              \
     }
 
 // ========================================
@@ -71,14 +72,12 @@ typedef struct R3D_Decal {
     R3D_EmissionMap emission;   ///< Emission map
     R3D_NormalMap normal;       ///< Normal map
     R3D_OrmMap orm;             ///< Occlusion-Roughness-Metalness map
-
     Vector2 uvOffset;           ///< UV offset (default: {0.0f, 0.0f})
     Vector2 uvScale;            ///< UV scale (default: {1.0f, 1.0f})
-
     float alphaCutoff;          ///< Alpha cutoff threshold (default: 0.01f)
-
-    float normalThreshold;      ///< Maximum angle against the surface normal to draw decal. 0.0f disables threshold. (default 0.0f)
-    float fadeWidth;            ///< The width of fading along the normal threshold (default 0.0f)
+    float normalThreshold;      ///< Maximum angle against the surface normal to draw decal. 0.0f disables threshold. (default: 0.0f)
+    float fadeWidth;            ///< The width of fading along the normal threshold (default: 0.0f)
+    bool applyColor;            ///< Indicates that the albedo color will not be rendered, only the alpha component of the albedo will be used as a mask. (default: true)
 } R3D_Decal;
 
 // ========================================

--- a/shaders/scene/decal.frag
+++ b/shaders/scene/decal.frag
@@ -62,7 +62,7 @@ void main()
     /* Discard fragments outside projector bounds */
     if (any(greaterThan(abs(positionObjectSpace.xyz), vec3(0.5)))) discard;
 
-    /* Compute decal UVs */
+    /* Compute decal UVs in [0, 1] range */
     vec2 decalTexCoord = uTexCoordOffset + (positionObjectSpace.xz + 0.5) * uTexCoordScale;
 
     /* Sample albedo and apply alpha cutoff */
@@ -82,7 +82,7 @@ void main()
     /* Compute fade factor */
     float fadeAlpha = clamp(difference / uFadeWidth, 0.0, 1.0) * albedo.a;
 
-    /* Build TBN matrix */
+    /* Build TBN matrix (and correct handedness if necessary) */
     vec3 surfaceTangent = M_DecodeOctahedral(normTanData.ba);
     vec3 surfaceBitangent = normalize(cross(surfaceNormal, surfaceTangent));
     surfaceBitangent *= sign(dot(cross(surfaceTangent, surfaceBitangent), surfaceNormal));

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -631,7 +631,7 @@ void r3d_shader_load_scene_decal(void)
     GET_LOCATION(scene.decal, uMetalness);
     GET_LOCATION(scene.decal, uNormalThreshold);
     GET_LOCATION(scene.decal, uFadeWidth);
-    GET_LOCATION(scene.decal, uAlbedoEnabled);
+    GET_LOCATION(scene.decal, uApplyColor);
 
     USE_SHADER(scene.decal);
 

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -600,7 +600,7 @@ typedef struct {
     r3d_shader_uniform_float_t uMetalness;
     r3d_shader_uniform_float_t uNormalThreshold;
     r3d_shader_uniform_float_t uFadeWidth;
-    r3d_shader_uniform_int_t uAlbedoEnabled;
+    r3d_shader_uniform_int_t uApplyColor;
 } r3d_shader_scene_decal_t;
 
 typedef struct {

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -952,14 +952,11 @@ void raster_decal(const r3d_draw_call_t* call)
 
     R3D_SHADER_SET_FLOAT(scene.decal, uNormalThreshold, decal->normalThreshold);
     R3D_SHADER_SET_FLOAT(scene.decal, uFadeWidth, decal->fadeWidth);
-    R3D_SHADER_SET_INT(scene.decal, uAlbedoEnabled, (decal->albedo.texture.id != 0));
+    R3D_SHADER_SET_INT(scene.decal, uApplyColor, decal->applyColor);
 
     /* --- Bind active texture maps --- */
 
-    if (decal->albedo.texture.id != 0) /* uAlbedoEnabled must be false otherwise */ {
-        R3D_SHADER_BIND_SAMPLER(scene.decal, uAlbedoMap, decal->albedo.texture.id);
-    }
-
+    R3D_SHADER_BIND_SAMPLER(scene.decal, uAlbedoMap, R3D_TEXTURE_SELECT(decal->albedo.texture.id, WHITE));
     R3D_SHADER_BIND_SAMPLER(scene.decal, uNormalMap, R3D_TEXTURE_SELECT(decal->normal.texture.id, NORMAL));
     R3D_SHADER_BIND_SAMPLER(scene.decal, uEmissionMap, R3D_TEXTURE_SELECT(decal->emission.texture.id, WHITE));
     R3D_SHADER_BIND_SAMPLER(scene.decal, uOrmMap, R3D_TEXTURE_SELECT(decal->orm.texture.id, WHITE));


### PR DESCRIPTION
Adds a boolean `applyColor` to `R3D_Decal` so that only the albedo alpha is used as a mask.

See the comment here for more details: https://github.com/Bigfoot71/r3d/pull/159#issuecomment-3773291359

The decal shader was also slightly reorganized by the way.

I tried to group texture sampling as much as possible, revisited the handling of handedness, and lightened the comments a bit since the code is fairly clear.

@grunthon I'll give you veto power if there's any issue!

Here is an example with `applyColor` set to false:

[Enregistrement d'écran_20260120_162119.webm](https://github.com/user-attachments/assets/d645cd22-7c7b-4951-8c7f-51339dc822be)
