### PR TITLE
Asset importer review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,6 @@ endif()
 
 add_library(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/src/importer/r3d_importer_animation.c"
-    "${R3D_ROOT_PATH}/src/importer/r3d_importer.c"
     "${R3D_ROOT_PATH}/src/importer/r3d_importer_material.c"
     "${R3D_ROOT_PATH}/src/importer/r3d_importer_mesh.c"
     "${R3D_ROOT_PATH}/src/importer/r3d_importer_skeleton.c"
@@ -274,6 +273,7 @@ add_library(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/src/r3d_decal.c"
     "${R3D_ROOT_PATH}/src/r3d_ambient_map.c"
     "${R3D_ROOT_PATH}/src/r3d_environment.c"
+    "${R3D_ROOT_PATH}/src/r3d_importer.c"
     "${R3D_ROOT_PATH}/src/r3d_instance.c"
     "${R3D_ROOT_PATH}/src/r3d_lighting.c"
     "${R3D_ROOT_PATH}/src/r3d_material.c"

--- a/examples/transparency.c
+++ b/examples/transparency.c
@@ -11,27 +11,27 @@ int main(void)
     R3D_Init(GetScreenWidth(), GetScreenHeight());
 
     // Create cube model
-    R3D_Mesh mesh = R3D_GenMeshCube(1, 1, 1);
-    R3D_Model cube = R3D_LoadModelFromMesh(mesh);
-    cube.materials[0].transparencyMode = R3D_TRANSPARENCY_ALPHA;
-    cube.materials[0].albedo.color = (Color){150, 150, 255, 100};
-    cube.materials[0].orm.occlusion = 1.0f;
-    cube.materials[0].orm.roughness = 0.2f;
-    cube.materials[0].orm.metalness = 0.2f;
+    R3D_Mesh cube = R3D_GenMeshCube(1, 1, 1);
+    R3D_Material matCube = R3D_MATERIAL_BASE;
+    matCube.transparencyMode = R3D_TRANSPARENCY_ALPHA;
+    matCube.albedo.color = (Color){150, 150, 255, 100};
+    matCube.orm.occlusion = 1.0f;
+    matCube.orm.roughness = 0.2f;
+    matCube.orm.metalness = 0.2f;
 
     // Create plane model
-    mesh = R3D_GenMeshPlane(1000, 1000, 1, 1);
-    R3D_Model plane = R3D_LoadModelFromMesh(mesh);
-    plane.materials[0].orm.occlusion = 1.0f;
-    plane.materials[0].orm.roughness = 1.0f;
-    plane.materials[0].orm.metalness = 0.0f;
+    R3D_Mesh plane = R3D_GenMeshPlane(1000, 1000, 1, 1);
+    R3D_Material matPlane = R3D_MATERIAL_BASE;
+    matPlane.orm.occlusion = 1.0f;
+    matPlane.orm.roughness = 1.0f;
+    matPlane.orm.metalness = 0.0f;
 
     // Create sphere model
-    mesh = R3D_GenMeshSphere(0.5f, 64, 64);
-    R3D_Model sphere = R3D_LoadModelFromMesh(mesh);
-    sphere.materials[0].orm.occlusion = 1.0f;
-    sphere.materials[0].orm.roughness = 0.25f;
-    sphere.materials[0].orm.metalness = 0.75f;
+    R3D_Mesh sphere = R3D_GenMeshSphere(0.5f, 64, 64);
+    R3D_Material matSphere = R3D_MATERIAL_BASE;
+    matSphere.orm.occlusion = 1.0f;
+    matSphere.orm.roughness = 0.25f;
+    matSphere.orm.metalness = 0.75f;
 
     // Setup camera
     Camera3D camera = {
@@ -57,18 +57,18 @@ int main(void)
             ClearBackground(RAYWHITE);
 
             R3D_Begin(camera);
-                R3D_DrawModel(plane, (Vector3){0, -0.5f, 0}, 1.0f);
-                R3D_DrawModel(sphere, Vector3Zero(), 1.0f);
-                R3D_DrawModel(cube, Vector3Zero(), 1.0f);
+                R3D_DrawMesh(plane, matPlane, (Vector3){0, -0.5f, 0}, 1.0f);
+                R3D_DrawMesh(sphere, matSphere, Vector3Zero(), 1.0f);
+                R3D_DrawMesh(cube, matCube, Vector3Zero(), 1.0f);
             R3D_End();
 
         EndDrawing();
     }
 
     // Cleanup
-    R3D_UnloadModel(sphere, false);
-    R3D_UnloadModel(plane, false);
-    R3D_UnloadModel(cube, false);
+    R3D_UnloadMesh(sphere);
+    R3D_UnloadMesh(plane);
+    R3D_UnloadMesh(cube);
     R3D_Close();
 
     CloseWindow();

--- a/include/r3d/r3d_animation.h
+++ b/include/r3d/r3d_animation.h
@@ -10,6 +10,7 @@
 #define R3D_ANIMATION_H
 
 #include "./r3d_platform.h"
+#include "./r3d_importer.h"
 #include <raylib.h>
 #include <stdint.h>
 
@@ -101,6 +102,14 @@ R3DAPI R3D_AnimationLib R3D_LoadAnimationLib(const char* filePath);
  * @note Free the returned array using R3D_UnloadAnimationLib().
  */
 R3DAPI R3D_AnimationLib R3D_LoadAnimationLibFromMemory(const void* data, unsigned int size, const char* hint);
+
+/**
+ * @brief Loads animations from an existing importer.
+ * @param importer Importer instance containing animation data.
+ * @return Pointer to an array of R3D_Animation, or NULL on failure.
+ * @note Free the returned array using R3D_UnloadAnimationLib().
+ */
+R3DAPI R3D_AnimationLib R3D_LoadAnimationLibFromImporter(const R3D_Importer* importer);
 
 /**
  * @brief Releases all resources associated with an animation library.

--- a/include/r3d/r3d_importer.h
+++ b/include/r3d/r3d_importer.h
@@ -1,0 +1,107 @@
+/* r3d_importer.h -- R3D Importer Module.
+ *
+ * Copyright (c) 2025 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#ifndef R3D_IMPORTER_H
+#define R3D_IMPORTER_H
+
+#include "./r3d_platform.h"
+#include <stdint.h>
+
+/**
+ * @defgroup Importer
+ * @{
+ */
+
+// ========================================
+// ENUMS TYPES
+// ========================================
+
+/**
+ * @typedef R3D_ImportFlags
+ * @brief Flags controlling importer behavior.
+ *
+ * These flags define how the importer processes the source asset.
+ */
+typedef uint32_t R3D_ImportFlags;
+
+/**
+ * @brief Keep a CPU-side copy of mesh data.
+ *
+ * When enabled, raw mesh data is preserved in RAM after model import.
+ */
+#define R3D_IMPORT_MESH_DATA    (1 << 0)
+
+/**
+ * @brief Enable high-quality import processing.
+ *
+ * When enabled, the importer uses a higher-quality post-processing
+ * (e.g. smooth normals, mesh optimization, data validation).
+ * This mode is intended for editor usage and offline processing.
+ *
+ * When disabled, a faster import preset is used, suitable for runtime.
+ */
+#define R3D_IMPORT_QUALITY      (1 << 1)
+
+// ========================================
+// STRUCTS TYPES
+// ========================================
+
+/**
+ * @brief Opaque importer handle.
+ *
+ * Represents a loaded asset file that can be used to extract multiple
+ * resources (models, skeletons, animations) without re-importing the file.
+ */
+typedef struct R3D_Importer R3D_Importer;
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+/**
+ * @brief Load an importer from a file.
+ *
+ * Creates an importer instance from the specified file path.
+ * The file is parsed once and can be reused to extract multiple
+ * resources such as models and animations.
+ *
+ * @param filePath Path to the asset file.
+ * @param flags Importer behavior flags.
+ *
+ * @return Pointer to a new importer instance, or NULL on failure.
+ */
+R3DAPI R3D_Importer* R3D_LoadImporter(const char* filePath, R3D_ImportFlags flags);
+
+/**
+ * @brief Load an importer from a memory buffer.
+ *
+ * Creates an importer instance from in-memory asset data.
+ * This is useful for embedded assets or streamed content.
+ *
+ * @param data Pointer to the asset data.
+ * @param size Size of the data buffer in bytes.
+ * @param hint Optional file format hint (may be NULL).
+ * @param flags Importer behavior flags.
+ *
+ * @return Pointer to a new importer instance, or NULL on failure.
+ */
+R3DAPI R3D_Importer* R3D_LoadImporterFromMemory(const void* data, unsigned int size, const char* hint, R3D_ImportFlags flags);
+
+/**
+ * @brief Destroy an importer instance.
+ *
+ * Frees all resources associated with the importer.
+ * Any models or animations extracted from it remain valid.
+ *
+ * @param importer Importer instance to destroy.
+ */
+R3DAPI void R3D_UnloadImporter(R3D_Importer* importer);
+
+/** @} */ // end of Importer
+
+#endif // R3D_IMPORTER_H

--- a/include/r3d/r3d_model.h
+++ b/include/r3d/r3d_model.h
@@ -12,6 +12,7 @@
 #include "./r3d_material.h"
 #include "./r3d_skeleton.h"
 #include "./r3d_platform.h"
+#include "./r3d_importer.h"
 #include "./r3d_mesh.h"
 
 /**
@@ -31,6 +32,7 @@
 typedef struct R3D_Model {
 
     R3D_Mesh* meshes;                   ///< Array of meshes composing the model.
+    R3D_MeshData* meshData;             ///< Array of meshes data in RAM (optional, can be NULL).
     R3D_Material* materials;            ///< Array of materials used by the model.
     int* meshMaterials;                 ///< Array of material indices, one per mesh.
 
@@ -63,6 +65,19 @@ extern "C" {
 R3DAPI R3D_Model R3D_LoadModel(const char* filePath);
 
 /**
+ * @brief Load a 3D model from a file with import flags.
+ *
+ * Extended version of R3D_LoadModel() allowing control over the import
+ * process through additional flags.
+ *
+ * @param filePath Path to the 3D model file to load.
+ * @param flags Importer behavior flags.
+ *
+ * @return Loaded model structure containing meshes and materials.
+ */
+R3DAPI R3D_Model R3D_LoadModelEx(const char* filePath, R3D_ImportFlags flags);
+
+/**
  * @brief Load a 3D model from memory buffer.
  *
  * Loads a 3D model from a memory buffer containing the file data.
@@ -80,19 +95,34 @@ R3DAPI R3D_Model R3D_LoadModel(const char* filePath);
 R3DAPI R3D_Model R3D_LoadModelFromMemory(const void* data, unsigned int size, const char* hint);
 
 /**
- * @brief Create a model from a single mesh.
+ * @brief Load a 3D model from a memory buffer with import flags.
  *
- * Creates a model structure containing a single mesh with a default material.
- * This is useful for procedurally generated meshes or simple geometry.
+ * Extended version of R3D_LoadModelFromMemory() allowing control over
+ * the import process through additional flags.
  *
- * @warning The model's bounding box calculation assumes that the mesh's
- * bounding boxes has already been computed.
+ * @param data Pointer to the memory buffer containing the model data.
+ * @param size Size of the data buffer in bytes.
+ * @param hint Hint on the model format (can be NULL).
+ * @param flags Importer behavior flags.
  *
- * @param mesh The mesh to be wrapped in a model structure.
+ * @return Loaded model structure containing meshes and materials.
  *
- * @return Model structure containing the specified mesh.
+ * @note External dependencies (e.g., textures or linked resources) are not supported.
+ *       The model data must be fully self-contained.
  */
-R3DAPI R3D_Model R3D_LoadModelFromMesh(R3D_Mesh mesh);
+R3DAPI R3D_Model R3D_LoadModelFromMemoryEx(const void* data, unsigned int size, const char* hint, R3D_ImportFlags flags);
+
+/**
+ * @brief Load a 3D model from an existing importer.
+ *
+ * Creates a model from a previously loaded importer instance.
+ * This avoids re-importing the source file.
+ *
+ * @param importer Importer instance to extract the model from.
+ *
+ * @return Loaded model structure containing meshes and materials.
+ */
+R3DAPI R3D_Model R3D_LoadModelFromImporter(const R3D_Importer* importer);
 
 /**
  * @brief Unload a model and optionally its materials.

--- a/include/r3d/r3d_skeleton.h
+++ b/include/r3d/r3d_skeleton.h
@@ -10,6 +10,7 @@
 #define R3D_SKELETON_H
 
 #include "./r3d_platform.h"
+#include "./r3d_importer.h"
 #include <raylib.h>
 #include <stdint.h>
 
@@ -83,7 +84,17 @@ R3DAPI R3D_Skeleton R3D_LoadSkeleton(const char* filePath);
  * @param hint Optional format hint (can be NULL).
  * @return Return the loaded R3D_Skeleton.
  */
-R3DAPI R3D_Skeleton R3D_LoadSkeletonFromData(const void* data, unsigned int size, const char* hint);
+R3DAPI R3D_Skeleton R3D_LoadSkeletonFromMemory(const void* data, unsigned int size, const char* hint);
+
+/**
+ * @brief Loads a skeleton hierarchy from an existing importer.
+ *
+ * Extracts the skeleton data from a previously loaded importer instance.
+ *
+ * @param importer Importer instance to extract the skeleton from.
+ * @return Return the loaded R3D_Skeleton.
+ */
+R3DAPI R3D_Skeleton R3D_LoadSkeletonFromImporter(const R3D_Importer* importer);
 
 /**
  * @brief Frees the memory allocated for a skeleton.

--- a/src/importer/r3d_importer_animation.c
+++ b/src/importer/r3d_importer_animation.c
@@ -6,7 +6,7 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-#include "./r3d_importer.h"
+#include "./r3d_importer_internal.h"
 
 #include <assimp/anim.h>
 #include <r3d_config.h>
@@ -73,7 +73,7 @@ static bool load_quaternion_track(R3D_AnimationTrack* track, unsigned int count,
     return true;
 }
 
-static bool load_channel(R3D_AnimationChannel* channel, const r3d_importer_t* importer, const struct aiNodeAnim* aiChannel)
+static bool load_channel(R3D_AnimationChannel* channel, const R3D_Importer* importer, const struct aiNodeAnim* aiChannel)
 {
     if (!aiChannel) {
         R3D_TRACELOG(LOG_ERROR, "Invalid animation channel");
@@ -119,7 +119,7 @@ fail:
 // ANIMATION LOADING (INTERNAL)
 // ========================================
 
-static bool load_animation(R3D_Animation* animation, const r3d_importer_t* importer, const struct aiAnimation* aiAnim)
+static bool load_animation(R3D_Animation* animation, const R3D_Importer* importer, const struct aiAnimation* aiAnim)
 {
     // Basic validation
     if (!aiAnim || aiAnim->mNumChannels == 0) {
@@ -195,7 +195,7 @@ static bool load_animation(R3D_Animation* animation, const r3d_importer_t* impor
 // PUBLIC FUNCTIONS
 // ========================================
 
-bool r3d_importer_load_animations(const r3d_importer_t* importer, R3D_AnimationLib* animLib)
+bool r3d_importer_load_animations(const R3D_Importer* importer, R3D_AnimationLib* animLib)
 {
     if (!importer || !r3d_importer_is_valid(importer)) {
         R3D_TRACELOG(LOG_ERROR, "Invalid importer for animation loading");

--- a/src/importer/r3d_importer_internal.h
+++ b/src/importer/r3d_importer_internal.h
@@ -56,7 +56,8 @@ typedef struct {
 
 struct R3D_Importer {
     const struct aiScene* scene;
-    r3d_bone_map_entry_t* boneMap;
+    r3d_bone_map_entry_t* boneMapArray;
+    r3d_bone_map_entry_t* boneMapHead;
     int boneCount;
     R3D_ImportFlags flags;
 };
@@ -189,7 +190,7 @@ static inline int r3d_importer_get_bone_index(const R3D_Importer* importer, cons
     if (!importer || !name) return -1;
 
     r3d_bone_map_entry_t* entry = NULL;
-    HASH_FIND_STR(importer->boneMap, name, entry);
+    HASH_FIND_STR(importer->boneMapHead, name, entry);
 
     return entry ? entry->index : -1;
 }

--- a/src/importer/r3d_importer_material.c
+++ b/src/importer/r3d_importer_material.c
@@ -6,7 +6,7 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-#include "./r3d_importer.h"
+#include "./r3d_importer_internal.h"
 
 #include <assimp/GltfMaterial.h>
 #include <assimp/material.h>
@@ -18,7 +18,7 @@
 // MATERIAL LOADING (INTERNAL)
 // ========================================
 
-static void load_material(R3D_Material* material, const r3d_importer_t* importer, r3d_importer_texture_cache_t* textureCache, int index)
+static void load_material(R3D_Material* material, const R3D_Importer* importer, r3d_importer_texture_cache_t* textureCache, int index)
 {
     const struct aiMaterial* aiMat = r3d_importer_get_material(importer, index);
 
@@ -138,7 +138,7 @@ static void load_material(R3D_Material* material, const r3d_importer_t* importer
 // PUBLIC FUNCTIONS
 // ========================================
 
-bool r3d_importer_load_materials(const r3d_importer_t* importer, R3D_Model* model, r3d_importer_texture_cache_t* textureCache)
+bool r3d_importer_load_materials(const R3D_Importer* importer, R3D_Model* model, r3d_importer_texture_cache_t* textureCache)
 {
     if (!model || !importer || !textureCache || !r3d_importer_is_valid(importer)) {
         R3D_TRACELOG(LOG_ERROR, "Invalid parameters for material loading");

--- a/src/importer/r3d_importer_mesh.c
+++ b/src/importer/r3d_importer_mesh.c
@@ -17,7 +17,6 @@
 #include <float.h>
 
 #include "../common/r3d_math.h"
-#include "r3d/r3d_model.h"
 
 // ========================================
 // CONSTANTS

--- a/src/importer/r3d_importer_skeleton.c
+++ b/src/importer/r3d_importer_skeleton.c
@@ -6,7 +6,7 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-#include "./r3d_importer.h"
+#include "./r3d_importer_internal.h"
 
 #include <assimp/mesh.h>
 #include <r3d_config.h>
@@ -21,7 +21,7 @@
 // ========================================
 
 typedef struct {
-    const r3d_importer_t* importer;
+    const R3D_Importer* importer;
     R3D_BoneInfo* bones;
     Matrix* invBind;
     Matrix* localBind;
@@ -98,7 +98,7 @@ static void upload_skeleton_bind_pose(R3D_Skeleton* skeleton)
 // PUBLIC FUNCTIONS
 // ========================================
 
-bool r3d_importer_load_skeleton(const r3d_importer_t* importer, R3D_Skeleton* skeleton)
+bool r3d_importer_load_skeleton(const R3D_Importer* importer, R3D_Skeleton* skeleton)
 {
     if (!importer || !r3d_importer_is_valid(importer)) {
         R3D_TRACELOG(LOG_ERROR, "Invalid importer for skeleton processing");

--- a/src/importer/r3d_importer_texture.c
+++ b/src/importer/r3d_importer_texture.c
@@ -6,7 +6,7 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-#include "./r3d_importer.h"
+#include "./r3d_importer_internal.h"
 #include <r3d_config.h>
 
 #include <assimp/GltfMaterial.h>
@@ -80,7 +80,7 @@ typedef struct {
 } texture_entry_t;
 
 typedef struct {
-    const r3d_importer_t* importer;
+    const R3D_Importer* importer;
     texture_job_t* jobs;
     texture_slot_t* slots;
     int slotCount;
@@ -242,7 +242,7 @@ static bool texture_job_init(texture_job_t* job, const struct aiMaterial* materi
 // IMAGE LOADING
 // ========================================
 
-static bool load_image_base(Image* outImage, bool* outOwned, const r3d_importer_t* importer, const char* path)
+static bool load_image_base(Image* outImage, bool* outOwned, const R3D_Importer* importer, const char* path)
 {
     if (path[0] == '*') {
         int textureIndex = atoi(&path[1]);
@@ -273,7 +273,7 @@ static bool load_image_base(Image* outImage, bool* outOwned, const r3d_importer_
     return outImage->data != NULL;
 }
 
-static bool load_image_simple(texture_slot_t* slot, const r3d_importer_t* importer, const texture_job_t* job)
+static bool load_image_simple(texture_slot_t* slot, const R3D_Importer* importer, const texture_job_t* job)
 {
     slot->wrapMode = get_wrap_mode(job->wrap[0]);
     bool success = load_image_base(&slot->image, &slot->ownsImageData, importer, job->paths[0]);
@@ -283,7 +283,7 @@ static bool load_image_simple(texture_slot_t* slot, const r3d_importer_t* import
     return success;
 }
 
-static bool load_image_orm(texture_slot_t* slot, const r3d_importer_t* importer, const texture_job_t* job)
+static bool load_image_orm(texture_slot_t* slot, const R3D_Importer* importer, const texture_job_t* job)
 {
 #   define ROUGHNESS_IDX 1
 
@@ -363,7 +363,7 @@ static int worker_thread(void* arg)
 // ========================================
 
 r3d_importer_texture_cache_t* r3d_importer_load_texture_cache(
-    const r3d_importer_t* importer, 
+    const R3D_Importer* importer, 
     R3D_ColorSpace colorSpace, 
     TextureFilter filter)
 {

--- a/src/r3d_animation.c
+++ b/src/r3d_animation.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <glad.h>
 
-#include "./importer/r3d_importer.h"
+#include "./importer/r3d_importer_internal.h"
 
 // ========================================
 // PUBLIC API
@@ -19,31 +19,30 @@
 
 R3D_AnimationLib R3D_LoadAnimationLib(const char* filePath)
 {
-    R3D_AnimationLib animLib = {0};
+    R3D_Importer* importer = R3D_LoadImporter(filePath, 0);
+    if (importer == NULL) return (R3D_AnimationLib) {0};
 
-    r3d_importer_t importer = {0};
-    if (!r3d_importer_create_from_file(&importer, filePath)) {
-        return animLib;
-    }
-
-    r3d_importer_load_animations(&importer, &animLib);
-    r3d_importer_destroy(&importer);
+    R3D_AnimationLib animLib = R3D_LoadAnimationLibFromImporter(importer);
+    R3D_UnloadImporter(importer);
 
     return animLib;
 }
 
 R3D_AnimationLib R3D_LoadAnimationLibFromMemory(const void* data, unsigned int size, const char* hint)
 {
+    R3D_Importer* importer = R3D_LoadImporterFromMemory(data, size, hint, 0);
+    if (importer == NULL) return (R3D_AnimationLib) {0};
+
+    R3D_AnimationLib animLib = R3D_LoadAnimationLibFromImporter(importer);
+    R3D_UnloadImporter(importer);
+
+    return animLib;
+}
+
+R3D_AnimationLib R3D_LoadAnimationLibFromImporter(const R3D_Importer* importer)
+{
     R3D_AnimationLib animLib = {0};
-
-    r3d_importer_t importer = {0};
-    if (!r3d_importer_create_from_memory(&importer, data, size, hint)) {
-        return animLib;
-    }
-
-    r3d_importer_load_animations(&importer, &animLib);
-    r3d_importer_destroy(&importer);
-
+    r3d_importer_load_animations(importer, &animLib);
     return animLib;
 }
 

--- a/src/r3d_skeleton.c
+++ b/src/r3d_skeleton.c
@@ -11,7 +11,7 @@
 #include <stddef.h>
 #include <glad.h>
 
-#include "./importer/r3d_importer.h"
+#include "./importer/r3d_importer_internal.h"
 
 // ========================================
 // PUBLIC API
@@ -21,28 +21,24 @@ R3D_Skeleton R3D_LoadSkeleton(const char* filePath)
 {
     R3D_Skeleton skeleton = {0};
 
-    r3d_importer_t importer = {0};
-    if (!r3d_importer_create_from_file(&importer, filePath)) {
-        return skeleton;
-    }
+    R3D_Importer* importer = R3D_LoadImporter(filePath, 0);
+    if (importer == NULL) return skeleton;
 
-    r3d_importer_load_skeleton(&importer, &skeleton);
-    r3d_importer_destroy(&importer);
+    r3d_importer_load_skeleton(importer, &skeleton);
+    R3D_UnloadImporter(importer);
 
     return skeleton;
 }
 
-R3D_Skeleton R3D_LoadSkeletonFromData(const void* data, unsigned int size, const char* hint)
+R3D_Skeleton R3D_LoadSkeletonFromMemory(const void* data, unsigned int size, const char* hint)
 {
     R3D_Skeleton skeleton = {0};
 
-    r3d_importer_t importer = {0};
-    if (!r3d_importer_create_from_memory(&importer, data, size, hint)) {
-        return skeleton;
-    }
+    R3D_Importer* importer = R3D_LoadImporterFromMemory(data, size, hint, 0);
+    if (importer == NULL) return skeleton;
 
-    r3d_importer_load_skeleton(&importer, &skeleton);
-    r3d_importer_destroy(&importer);
+    r3d_importer_load_skeleton(importer, &skeleton);
+    R3D_UnloadImporter(importer);
 
     return skeleton;
 }


### PR DESCRIPTION
This PR exposes the assimp based asset importer through a new opaque type `R3D_Importer`

This makes it possible, without breaking the existing API, to import a source file once and then load its components (models, skeletons, animations) without re-importing the same file multiple times.

Models can still be loaded using `R3D_LoadModel(filePath)`, but a new extended version `R3D_LoadModelEx(filePath, flags)` has been added to allow passing import options. These flags are also supported by the new public importer.

Currently, two import flags are supported:
- `R3D_IMPORT_MESH_DATA` keeps a CPU side copy of mesh data in the new `meshData` member of `R3D_Model`. This pointer is NULL by default when the flag is not enabled.
- `R3D_IMPORT_QUALITY` enables additional assimp post processing steps, intended for higher quality imports. This mode is primarily recommended for editor or offline usage.

Minor breaking changes:
- `R3D_LoadModelFromMesh()` has been removed. This function existed to resemble raylib's rmodels, but its usefulness for R3D was zero.
- `R3D_LoadSkeletonFromData()` has been renamed to `R3D_LoadSkeletonFromMemory()`. I don't know what was going through my head when naming it...

---

The bone map in the importer has also been revised to avoid allocations for each entry... I think it could even be reused for skeletons, but I'll look at that later.

Also, the different primitive types "points", "lines", "triangles" are now supported for imported models. This was a silly oversight...