### PR TITLE
Added `R3D_DepthMode`

### DIFF
--- a/include/r3d/r3d_material.h
+++ b/include/r3d/r3d_material.h
@@ -49,13 +49,14 @@
             .roughness = 1.0f,                          \
             .metalness = 0.0f,                          \
         },                                              \
-        .transparencyMode = R3D_TRANSPARENCY_DISABLED,  \
-        .billboardMode = R3D_BILLBOARD_DISABLED,        \
-        .blendMode = R3D_BLEND_MIX,                     \
-        .cullMode = R3D_CULL_BACK,                      \
         .uvOffset = {0.0f, 0.0f},                       \
         .uvScale = {1.0f, 1.0f},                        \
         .alphaCutoff = 0.01f,                           \
+        .transparencyMode = R3D_TRANSPARENCY_DISABLED,  \
+        .billboardMode = R3D_BILLBOARD_DISABLED,        \
+        .blendMode = R3D_BLEND_MIX,                     \
+        .depthMode = R3D_DEPTH_LESS,                    \
+        .cullMode = R3D_CULL_BACK,                      \
         .shader = 0,                                    \
     }
 
@@ -101,6 +102,23 @@ typedef enum R3D_BlendMode {
     R3D_BLEND_MULTIPLY,             ///< Multiply blending: source color is multiplied with the destination, darkening the image.
     R3D_BLEND_PREMULTIPLIED_ALPHA   ///< Premultiplied alpha blending: source color is blended with the destination assuming the source color is already multiplied by its alpha.
 } R3D_BlendMode;
+
+/**
+ * @brief Depth comparison modes.
+ *
+ * Defines how fragments are tested against the depth buffer during rendering.
+ * @note The depth mode affects both forward and deferred rendering passes.
+ */
+typedef enum R3D_DepthMode {
+    R3D_DEPTH_LESS = 0,    // Passes if depth < depth buffer (default)
+    R3D_DEPTH_LEQUAL,      // Passes if depth <= depth buffer
+    R3D_DEPTH_EQUAL,       // Passes if depth == depth buffer
+    R3D_DEPTH_GREATER,     // Passes if depth > depth buffer
+    R3D_DEPTH_GEQUAL,      // Passes if depth >= depth buffer
+    R3D_DEPTH_NOTEQUAL,    // Passes if depth != depth buffer
+    R3D_DEPTH_ALWAYS,      // Always passes
+    R3D_DEPTH_NEVER        // Never passes
+} R3D_DepthMode;
 
 /**
  * @brief Face culling modes.
@@ -167,22 +185,22 @@ typedef struct R3D_OrmMap {
  */
 typedef struct R3D_Material {
 
-    R3D_AlbedoMap albedo;       ///< Albedo map
-    R3D_EmissionMap emission;   ///< Emission map
-    R3D_NormalMap normal;       ///< Normal map
-    R3D_OrmMap orm;             ///< Occlusion-Roughness-Metalness map
+    R3D_AlbedoMap albedo;                   ///< Albedo map
+    R3D_EmissionMap emission;               ///< Emission map
+    R3D_NormalMap normal;                   ///< Normal map
+    R3D_OrmMap orm;                         ///< Occlusion-Roughness-Metalness map
+
+    Vector2 uvOffset;                       ///< UV offset (default: {0.0f, 0.0f})
+    Vector2 uvScale;                        ///< UV scale (default: {1.0f, 1.0f})
+    float alphaCutoff;                      ///< Alpha cutoff threshold (default: 0.01f)
 
     R3D_TransparencyMode transparencyMode;  ///< Transparency mode (default: DISABLED)
     R3D_BillboardMode billboardMode;        ///< Billboard mode (default: DISABLED)
     R3D_BlendMode blendMode;                ///< Blend mode (default: MIX)
+    R3D_DepthMode depthMode;                ///< Depth mode (default: LESS)
     R3D_CullMode cullMode;                  ///< Face culling mode (default: BACK)
 
-    Vector2 uvOffset;    ///< UV offset (default: {0.0f, 0.0f})
-    Vector2 uvScale;     ///< UV scale (default: {1.0f, 1.0f})
-
-    float alphaCutoff;   ///< Alpha cutoff threshold (default: 0.01f)
-
-    R3D_SurfaceShader* shader; ///< Custom shader applied to the material (default: NULL)
+    R3D_SurfaceShader* shader;              ///< Custom shader applied to the material (default: NULL)
 
 } R3D_Material;
 

--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -383,7 +383,7 @@ static inline void sort_fill_material_data(r3d_draw_sort_t* sortData, const r3d_
         sortData->material.emission = call->mesh.material.emission.texture.id;
         sortData->material.blend = call->mesh.material.blendMode;
         sortData->material.cull = call->mesh.material.cullMode;
-        sortData->material.transparency = call->mesh.material.transparencyMode;
+        sortData->material.depthFunc = call->mesh.material.depthMode;
         sortData->material.billboard = call->mesh.material.billboardMode;
         break;
     
@@ -395,7 +395,7 @@ static inline void sort_fill_material_data(r3d_draw_sort_t* sortData, const r3d_
         sortData->material.emission = call->decal.instance.emission.texture.id;
         sortData->material.blend = R3D_BLEND_MIX;
         sortData->material.cull = R3D_CULL_NONE;
-        sortData->material.transparency = R3D_TRANSPARENCY_ALPHA;
+        sortData->material.depthFunc = R3D_DEPTH_ALWAYS;
         sortData->material.billboard = R3D_BILLBOARD_DISABLED;
         break;
     }
@@ -759,23 +759,6 @@ void r3d_draw_sort_list(r3d_draw_list_enum_t list, Vector3 viewPosition, r3d_dra
     );
 }
 
-void r3d_draw_apply_cull_mode(R3D_CullMode mode)
-{
-    switch (mode) {
-    case R3D_CULL_NONE:
-        glDisable(GL_CULL_FACE);
-        break;
-    case R3D_CULL_BACK:
-        glEnable(GL_CULL_FACE);
-        glCullFace(GL_BACK);
-        break;
-    case R3D_CULL_FRONT:
-        glEnable(GL_CULL_FACE);
-        glCullFace(GL_FRONT);
-        break;
-    }
-}
-
 void r3d_draw_apply_blend_mode(R3D_BlendMode blend, R3D_TransparencyMode transparency)
 {
     switch (blend) {
@@ -795,6 +778,40 @@ void r3d_draw_apply_blend_mode(R3D_BlendMode blend, R3D_TransparencyMode transpa
         break;
     case R3D_BLEND_PREMULTIPLIED_ALPHA:
         glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+        break;
+    default:
+        break;
+    }
+}
+
+void r3d_draw_apply_depth_mode(R3D_DepthMode mode)
+{
+    switch (mode) {
+    case R3D_DEPTH_LESS: glDepthFunc(GL_LESS); break;
+    case R3D_DEPTH_LEQUAL: glDepthFunc(GL_LEQUAL); break;
+    case R3D_DEPTH_EQUAL: glDepthFunc(GL_EQUAL); break;
+    case R3D_DEPTH_GREATER: glDepthFunc(GL_GREATER); break;
+    case R3D_DEPTH_GEQUAL: glDepthFunc(GL_GEQUAL); break;
+    case R3D_DEPTH_NOTEQUAL: glDepthFunc(GL_NOTEQUAL); break;
+    case R3D_DEPTH_ALWAYS: glDepthFunc(GL_ALWAYS); break;
+    case R3D_DEPTH_NEVER: glDepthFunc(GL_NEVER); break;
+    default: break;
+    }
+}
+
+void r3d_draw_apply_cull_mode(R3D_CullMode mode)
+{
+    switch (mode) {
+    case R3D_CULL_NONE:
+        glDisable(GL_CULL_FACE);
+        break;
+    case R3D_CULL_BACK:
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_BACK);
+        break;
+    case R3D_CULL_FRONT:
+        glEnable(GL_CULL_FACE);
+        glCullFace(GL_FRONT);
         break;
     default:
         break;

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -234,7 +234,7 @@ typedef struct {
         uint32_t emission;
         uint8_t blend;
         uint8_t cull;
-        uint8_t transparency;
+        uint8_t depthFunc;
         uint8_t billboard;
     } material;
 } r3d_draw_sort_t;
@@ -342,16 +342,21 @@ bool r3d_draw_call_is_visible(const r3d_draw_call_t* call, const r3d_frustum_t* 
 void r3d_draw_sort_list(r3d_draw_list_enum_t list, Vector3 viewPosition, r3d_draw_sort_enum_t mode);
 
 /*
- * Apply the OpenGL face culling state for a draw call.
- */
-void r3d_draw_apply_cull_mode(R3D_CullMode mode);
-
-/*
  * Applies the OpenGL blend function for the current draw call.
  * Assumes GL_BLEND is already enabled and only sets the blend equations.
  * The MIX blend mode always uses standard alpha blending.
  */
 void r3d_draw_apply_blend_mode(R3D_BlendMode blend, R3D_TransparencyMode transparency);
+
+/*
+ * Applies the depth function corresponding to the material's depth mode.
+ */
+void r3d_draw_apply_depth_mode(R3D_DepthMode mode);
+
+/*
+ * Apply the OpenGL face culling state for a draw call.
+ */
+void r3d_draw_apply_cull_mode(R3D_CullMode mode);
 
 /*
  * Configure face culling for shadow rendering depending on shadow casting mode.


### PR DESCRIPTION
This PR adds the `R3D_DepthMode` enum used in `R3D_Material` to define depth comparison functions.
This parameter applies to opaque, transparent, and prepass rendering.
It does not apply to shadow map or probe rendering.