### PR TITLE
Add unlit material mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,7 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/scene/scene.vert"
     "${R3D_ROOT_PATH}/shaders/scene/geometry.frag"
     "${R3D_ROOT_PATH}/shaders/scene/forward.frag"
+    "${R3D_ROOT_PATH}/shaders/scene/unlit.frag"
     "${R3D_ROOT_PATH}/shaders/scene/depth.frag"
     "${R3D_ROOT_PATH}/shaders/scene/depth_cube.frag"
     "${R3D_ROOT_PATH}/shaders/scene/decal.frag"

--- a/docs/shaders/surface_shader.md
+++ b/docs/shaders/surface_shader.md
@@ -374,9 +374,10 @@ Use `#pragma usage` to specify which variants should be pre-compiled:
 
 | Hint | Description |
 |------|-------------|
-| `opaque` | Opaque rendering (default if no pragma specified) |
-| `prepass` | Transparent pre-pass rendering |
-| `transparent` | Transparent rendering (alpha blending) |
+| `opaque` | Opaque rendering for **lit objects** (default if no pragma specified) |
+| `prepass` | Transparent pre-pass rendering for **lit objects** |
+| `transparent` | Transparent rendering (color/alpha blending) for **lit objects** |
+| `unlit` | Unlit rendering (handles both opaque and transparent **unlit objects**) |
 | `shadow` | Shadow map rendering |
 | `decal` | Decal rendering |
 | `probe` | Reflection probe rendering |
@@ -389,6 +390,7 @@ Use `#pragma usage` to specify which variants should be pre-compiled:
 
 void fragment() {
     ALBEDO = vec3(1.0, 0.0, 0.0);
+    ALPHA = 0.5; // Alpha cutoff
 }
 ```
 
@@ -398,7 +400,17 @@ void fragment() {
 
 void fragment() {
     ALBEDO = vec3(0.0, 0.5, 1.0);
-    ALPHA = 0.5;
+    ALPHA = 0.5; // Alpha blending
+}
+```
+
+**Unlit object:**
+```glsl
+#pragma usage unlit
+
+void fragment() {
+    ALBEDO = vec3(1.0, 1.0, 0.0);
+    ALPHA = 0.5; // Alpha cutoff or blending
 }
 ```
 
@@ -408,6 +420,7 @@ void fragment() {
 
 void fragment() {
     ALBEDO = vec3(1.0, 1.0, 0.0);
+    ALPHA = 0.5; // Alpha fading
 }
 ```
 
@@ -415,6 +428,7 @@ void fragment() {
 
 - Usage hints are **optional**; missing variants will still compile on-demand
 - Multiple hints can be specified: `#pragma usage opaque transparent shadow`
+- Rendering mode separation: `opaque`, `prepass`, and `transparent` apply to **lit objects** only, while `unlit` applies to **unlit objects** regardless of opacity
 - If no pragma is specified, only `opaque` is pre-compiled
 - Variants not in the pragma can still be used; they just compile lazily
 

--- a/include/r3d/r3d_material.h
+++ b/include/r3d/r3d_material.h
@@ -65,19 +65,6 @@
 // ========================================
 
 /**
- * @brief Billboard modes.
- *
- * This enumeration defines how a 3D object aligns itself relative to the camera.
- * It provides options to disable billboarding or to enable specific modes of alignment.
- */
-typedef enum R3D_BillboardMode {
-    R3D_BILLBOARD_DISABLED,         ///< Billboarding is disabled; the object retains its original orientation.
-    R3D_BILLBOARD_FRONT,            ///< Full billboarding; the object fully faces the camera, rotating on all axes.
-    R3D_BILLBOARD_Y_AXIS            /**< Y-axis constrained billboarding; the object rotates only around the Y-axis,
-                                         keeping its "up" orientation fixed. This is suitable for upright objects like characters or signs. */
-} R3D_BillboardMode;
-
-/**
  * @brief Transparency modes.
  *
  * This enumeration defines how a material handles transparency during rendering.
@@ -89,6 +76,19 @@ typedef enum R3D_TransparencyMode {
     R3D_TRANSPARENCY_PREPASS,       ///< Supports transparency with shadows. Writes shadows for alpha > 0.1 and depth for alpha > 0.99.
     R3D_TRANSPARENCY_ALPHA,         ///< Standard transparency without shadows or depth writes.
 } R3D_TransparencyMode;
+
+/**
+ * @brief Billboard modes.
+ *
+ * This enumeration defines how a 3D object aligns itself relative to the camera.
+ * It provides options to disable billboarding or to enable specific modes of alignment.
+ */
+typedef enum R3D_BillboardMode {
+    R3D_BILLBOARD_DISABLED,         ///< Billboarding is disabled; the object retains its original orientation.
+    R3D_BILLBOARD_FRONT,            ///< Full billboarding; the object fully faces the camera, rotating on all axes.
+    R3D_BILLBOARD_Y_AXIS            /**< Y-axis constrained billboarding; the object rotates only around the Y-axis,
+                                         keeping its "up" orientation fixed. This is suitable for upright objects like characters or signs. */
+} R3D_BillboardMode;
 
 /**
  * @brief Blend modes.
@@ -199,6 +199,8 @@ typedef struct R3D_Material {
     R3D_BlendMode blendMode;                ///< Blend mode (default: MIX)
     R3D_DepthMode depthMode;                ///< Depth mode (default: LESS)
     R3D_CullMode cullMode;                  ///< Face culling mode (default: BACK)
+
+    bool unlit;                             ///< If true, material does not participate in lighting (default: false)
 
     R3D_SurfaceShader* shader;              ///< Custom shader applied to the material (default: NULL)
 

--- a/shaders/include/user/scene.frag
+++ b/shaders/include/user/scene.frag
@@ -33,7 +33,7 @@ vec4 SampleAlbedo(vec2 texCoord)
 vec3 SampleEmission(vec2 texCoord)
 {
     vec3 emission = vec3(0.0);
-#if !defined(DEPTH) && !defined(DEPTH_CUBE)
+#if !defined(UNLIT) && !defined(DEPTH) && !defined(DEPTH_CUBE)
     emission = vEmission * texture(uEmissionMap, texCoord).rgb;
 #endif
     return emission;
@@ -42,7 +42,7 @@ vec3 SampleEmission(vec2 texCoord)
 vec3 SampleNormal(vec2 texCoord)
 {
     vec3 normal = vec3(0.0);
-#if !defined(DEPTH) && !defined(DEPTH_CUBE)
+#if !defined(UNLIT) && !defined(DEPTH) && !defined(DEPTH_CUBE)
     normal = texture(uNormalMap, texCoord).rgb;
 #endif
     return normal;
@@ -51,7 +51,7 @@ vec3 SampleNormal(vec2 texCoord)
 vec3 SampleOrm(vec2 texCoord)
 {
     vec3 ORM = vec3(0.0);
-#if !defined(DEPTH) && !defined(DEPTH_CUBE)
+#if !defined(UNLIT) && !defined(DEPTH) && !defined(DEPTH_CUBE)
     ORM = texture(uOrmMap, texCoord).rgb;
     ORM.x *= uOcclusion;
     ORM.y *= uRoughness;
@@ -66,7 +66,7 @@ void FetchMaterial(vec2 texCoord)
     ALBEDO = color.rgb;
     ALPHA = color.a;
 
-#if !defined(DEPTH) && !defined(DEPTH_CUBE)
+#if !defined(UNLIT) && !defined(DEPTH) && !defined(DEPTH_CUBE)
     EMISSION   = vEmission * texture(uEmissionMap, texCoord).rgb;
     NORMAL_MAP = texture(uNormalMap, texCoord).rgb;
     vec3 ORM   = texture(uOrmMap, texCoord).rgb;
@@ -97,7 +97,7 @@ void SceneFragment(vec2 texCoord, mat3 tbn, float alphaCutoff)
     ALBEDO = color.rgb;
     ALPHA = color.a;
 
-#if !defined(DEPTH) && !defined(DEPTH_CUBE)
+#if !defined(UNLIT) && !defined(DEPTH) && !defined(DEPTH_CUBE)
     EMISSION   = vEmission * texture(uEmissionMap, texCoord).rgb;
     NORMAL_MAP = texture(uNormalMap, texCoord).rgb;
     vec3 ORM   = texture(uOrmMap, texCoord).rgb;
@@ -105,7 +105,7 @@ void SceneFragment(vec2 texCoord, mat3 tbn, float alphaCutoff)
     ROUGHNESS  = uRoughness * ORM.y;
     METALNESS  = uMetalness * ORM.z;
 
-#endif // !R3D_NO_AUTO_FETCH && !DEPTH && !DEPTH_CUBE
+#endif // !R3D_NO_AUTO_FETCH && !UNLIT && !DEPTH && !DEPTH_CUBE
 #endif // !R3D_NO_AUTO_FETCH
 
     /* --- Execute user code --- */

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -197,7 +197,7 @@ void main()
     #endif // DECAL
     }
 
-#if defined(DEPTH) || defined(DEPTH_CUBE) || defined(PROBE)
+#if defined(UNLIT) || defined(DEPTH) || defined(DEPTH_CUBE) || defined(PROBE)
     if (uBillboard == BILLBOARD_FRONT) {
         BillboardFront(finalPosition, finalNormal, finalTangent, billboardCenter, uMatInvView);
     }
@@ -229,7 +229,7 @@ void main()
     }
 #endif // FORWARD
 
-#if defined(DEPTH) || defined(DEPTH_CUBE) || defined(PROBE)
+#if defined(UNLIT) || defined(DEPTH) || defined(DEPTH_CUBE) || defined(PROBE)
     gl_Position = uMatViewProj * vec4(vPosition, 1.0);
 #else
     gl_Position = uView.viewProj * vec4(vPosition, 1.0);

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -53,10 +53,10 @@ uniform bool uInstancing;
 uniform bool uSkinning;
 uniform int uBillboard;
 
-#if defined(DEPTH) || defined(DEPTH_CUBE) || defined(PROBE)
+#if defined(UNLIT) || defined(DEPTH) || defined(DEPTH_CUBE) || defined(PROBE)
 uniform mat4 uMatInvView;   // inv view only for billboard modes
 uniform mat4 uMatViewProj;
-#endif // DEPTH || DEPTH_CUBE
+#endif // UNLIT || DEPTH || DEPTH_CUBE || PROBE
 
 /* === Varyings === */
 

--- a/shaders/scene/unlit.frag
+++ b/shaders/scene/unlit.frag
@@ -1,0 +1,35 @@
+/* unlit.frag -- Fragment shader used for unlit objects
+ *
+ * Copyright (c) 2025 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+/* === Varyings === */
+
+smooth in vec2 vTexCoord;
+smooth in vec4 vColor;
+
+/* === Uniforms === */
+
+uniform sampler2D uAlbedoMap;
+uniform float uAlphaCutoff;
+
+/* === Fragments === */
+
+layout(location = 0) out vec4 FragColor;
+
+/* === User override === */
+
+#include "../include/user/scene.frag"
+
+/* === Main function === */
+
+void main()
+{
+    SceneFragment(vTexCoord, mat3(1.0), uAlphaCutoff);
+    FragColor = vec4(ALBEDO, ALPHA);
+}

--- a/src/importer/r3d_importer_material.c
+++ b/src/importer/r3d_importer_material.c
@@ -132,6 +132,12 @@ static void load_material(R3D_Material* material, const R3D_Importer* importer, 
             material->cullMode = R3D_CULL_NONE;
         }
     }
+
+    // Handle shading mode
+    int shadingMode;
+    if (aiGetMaterialInteger(aiMat, AI_MATKEY_SHADING_MODEL, &shadingMode) == AI_SUCCESS) {
+        material->unlit = (shadingMode == aiShadingMode_Unlit);
+    }
 }
 
 // ========================================

--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -37,13 +37,16 @@ struct r3d_draw R3D_MOD_DRAW;
 
 #define IS_CALL_PREPASS(call) (                                             \
     ((call)->type == R3D_DRAW_CALL_MESH) &&                                 \
-    ((call)->mesh.material.transparencyMode == R3D_TRANSPARENCY_PREPASS)    \
+    ((call)->mesh.material.transparencyMode == R3D_TRANSPARENCY_PREPASS) && \
+    (!(call)->mesh.material.unlit)                                          \
 )
 
 #define IS_CALL_FORWARD(call) (                                             \
-    ((call)->type == R3D_DRAW_CALL_MESH) &&                                 \
-    ((call)->mesh.material.transparencyMode == R3D_TRANSPARENCY_ALPHA ||    \
-     (call)->mesh.material.blendMode != R3D_BLEND_MIX)                      \
+    ((call)->type == R3D_DRAW_CALL_MESH) && (                               \
+        ((call)->mesh.material.transparencyMode == R3D_TRANSPARENCY_ALPHA) || \
+        ((call)->mesh.material.blendMode != R3D_BLEND_MIX) ||               \
+        ((call)->mesh.material.unlit)                                       \
+    )                                                                       \
 )
 
 // ========================================
@@ -377,6 +380,7 @@ static inline void sort_fill_material_data(r3d_draw_sort_t* sortData, const r3d_
     switch (call->type) {
     case R3D_DRAW_CALL_MESH:
         sortData->material.shader = (uintptr_t)call->mesh.material.shader;
+        sortData->material.unlit = call->mesh.material.unlit;
         sortData->material.albedo = call->mesh.material.albedo.texture.id;
         sortData->material.normal = call->mesh.material.normal.texture.id;
         sortData->material.orm = call->mesh.material.orm.texture.id;
@@ -389,6 +393,7 @@ static inline void sort_fill_material_data(r3d_draw_sort_t* sortData, const r3d_
     
     case R3D_DRAW_CALL_DECAL:
         sortData->material.shader = (uintptr_t)call->decal.instance.shader;
+        sortData->material.unlit = false;
         sortData->material.albedo = call->decal.instance.albedo.texture.id;
         sortData->material.normal = call->decal.instance.normal.texture.id;
         sortData->material.orm = call->decal.instance.orm.texture.id;

--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -20,6 +20,7 @@
 
 #include "../common/r3d_frustum.h"
 #include "../common/r3d_math.h"
+#include "r3d/r3d_material.h"
 
 // ========================================
 // MODULE STATE
@@ -358,11 +359,12 @@ static inline void sort_fill_material_data(r3d_draw_sort_t* sortData, const r3d_
     switch (call->type) {
     case R3D_DRAW_CALL_MESH:
         sortData->material.shader = (uintptr_t)call->mesh.material.shader;
-        sortData->material.unlit = call->mesh.material.unlit;
+        sortData->material.shading = call->mesh.material.unlit;
         sortData->material.albedo = call->mesh.material.albedo.texture.id;
         sortData->material.normal = call->mesh.material.normal.texture.id;
         sortData->material.orm = call->mesh.material.orm.texture.id;
         sortData->material.emission = call->mesh.material.emission.texture.id;
+        sortData->material.transparency = sortData->material.transparency;
         sortData->material.blend = call->mesh.material.blendMode;
         sortData->material.cull = call->mesh.material.cullMode;
         sortData->material.depthFunc = call->mesh.material.depthMode;
@@ -371,11 +373,12 @@ static inline void sort_fill_material_data(r3d_draw_sort_t* sortData, const r3d_
     
     case R3D_DRAW_CALL_DECAL:
         sortData->material.shader = (uintptr_t)call->decal.instance.shader;
-        sortData->material.unlit = false;
+        sortData->material.shading = 0;
         sortData->material.albedo = call->decal.instance.albedo.texture.id;
         sortData->material.normal = call->decal.instance.normal.texture.id;
         sortData->material.orm = call->decal.instance.orm.texture.id;
         sortData->material.emission = call->decal.instance.emission.texture.id;
+        sortData->material.transparency = R3D_TRANSPARENCY_ALPHA;
         sortData->material.blend = R3D_BLEND_MIX;
         sortData->material.cull = R3D_CULL_NONE;
         sortData->material.depthFunc = R3D_DEPTH_ALWAYS;

--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -648,6 +648,7 @@ void r3d_draw_call_push(const r3d_draw_call_t* call)
     r3d_draw_list_enum_t list = R3D_DRAW_LIST_OPAQUE;
     if (r3d_draw_is_decal(call)) list = R3D_DRAW_LIST_DECAL;
     else if (!r3d_draw_is_opaque(call)) list = R3D_DRAW_LIST_TRANSPARENT;
+    if (r3d_draw_has_instances(group)) list += R3D_DRAW_LIST_NON_INST_COUNT;
 
     // Update internal flags
     if (r3d_draw_is_deferred(call)) R3D_MOD_DRAW.hasDeferred = true;

--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -20,7 +20,6 @@
 
 #include "../common/r3d_frustum.h"
 #include "../common/r3d_math.h"
-#include "r3d/r3d_material.h"
 
 // ========================================
 // MODULE STATE

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -246,11 +246,12 @@ typedef struct {
     float distance;
     struct {
         uintptr_t shader;
-        uint32_t unlit;
+        uint32_t shading;
         uint32_t albedo;
         uint32_t normal;
         uint32_t orm;
         uint32_t emission;
+        uint8_t transparency;
         uint8_t blend;
         uint8_t cull;
         uint8_t depthFunc;

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -465,6 +465,7 @@ static inline bool r3d_draw_is_decal(const r3d_draw_call_t* call)
 
 /*
  * Indicates whether a draw call corresponds to an object that is only rendered in deferred.
+ * Always check if an object is prepassed before checking if it is deferred.
  */
 static inline bool r3d_draw_is_deferred(const r3d_draw_call_t* call)
 {
@@ -505,6 +506,7 @@ static inline bool r3d_draw_is_prepass(const r3d_draw_call_t* call)
 
 /*
  * Indicates whether a draw call corresponds to an object rendered only in forward (unlit opaque / transparent)
+ * Always check if an object is prepassed before checking if it is forwarded.
  */
 static inline bool r3d_draw_is_forward(const r3d_draw_call_t* call)
 {

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -115,9 +115,9 @@ typedef enum {
  */
 typedef enum {
 
-    R3D_DRAW_LIST_DEFERRED,          //< Fully opaque
-    R3D_DRAW_LIST_PREPASS,           //< Forward but with depth prepass
-    R3D_DRAW_LIST_FORWARD,           //< Forward only, without prepass
+    R3D_DRAW_LIST_DEFERRED,         //< Fully opaque lit
+    R3D_DRAW_LIST_PREPASS,          //< Lit forward but with opaque depth prepass
+    R3D_DRAW_LIST_FORWARD,          //< Lit and unlit forward, without prepass
     R3D_DRAW_LIST_DECAL,
 
     R3D_DRAW_LIST_NON_INST_COUNT,
@@ -228,6 +228,7 @@ typedef struct {
     float distance;
     struct {
         uintptr_t shader;
+        uint32_t unlit;
         uint32_t albedo;
         uint32_t normal;
         uint32_t orm;

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -754,6 +754,23 @@ typedef struct {
 typedef struct {
     unsigned int id;
     r3d_shader_uniform_sampler_t uBoneMatricesTex;
+    r3d_shader_uniform_mat4_t uMatModel;
+    r3d_shader_uniform_mat4_t uMatNormal;
+    r3d_shader_uniform_col4_t uAlbedoColor;
+    r3d_shader_uniform_vec2_t uTexCoordOffset;
+    r3d_shader_uniform_vec2_t uTexCoordScale;
+    r3d_shader_uniform_int_t uInstancing;
+    r3d_shader_uniform_int_t uSkinning;
+    r3d_shader_uniform_int_t uBillboard;
+    r3d_shader_uniform_mat4_t uMatInvView;
+    r3d_shader_uniform_mat4_t uMatViewProj;
+    r3d_shader_uniform_sampler_t uAlbedoMap;
+    r3d_shader_uniform_float_t uAlphaCutoff;
+} r3d_shader_scene_unlit_t;
+
+typedef struct {
+    unsigned int id;
+    r3d_shader_uniform_sampler_t uBoneMatricesTex;
     r3d_shader_uniform_mat4_t uMatInvView;
     r3d_shader_uniform_mat4_t uMatModel;
     r3d_shader_uniform_mat4_t uMatViewProj;
@@ -965,6 +982,7 @@ typedef struct {
         struct {
             r3d_shader_scene_geometry_t geometry;
             r3d_shader_scene_forward_t forward;
+            r3d_shader_scene_unlit_t unlit;
             r3d_shader_scene_depth_t depth;
             r3d_shader_scene_depth_cube_t depthCube;
             r3d_shader_scene_probe_t probe;
@@ -1020,6 +1038,7 @@ extern struct r3d_mod_shader {
     struct {
         r3d_shader_scene_geometry_t geometry;
         r3d_shader_scene_forward_t forward;
+        r3d_shader_scene_unlit_t unlit;
         r3d_shader_scene_background_t background;
         r3d_shader_scene_skybox_t skybox;
         r3d_shader_scene_depth_t depth;
@@ -1070,6 +1089,7 @@ bool r3d_shader_load_prepare_cubemap_prefilter(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_cubemap_skybox(r3d_shader_custom_t* custom);
 bool r3d_shader_load_scene_geometry(r3d_shader_custom_t* custom);
 bool r3d_shader_load_scene_forward(r3d_shader_custom_t* custom);
+bool r3d_shader_load_scene_unlit(r3d_shader_custom_t* custom);
 bool r3d_shader_load_scene_background(r3d_shader_custom_t* custom);
 bool r3d_shader_load_scene_skybox(r3d_shader_custom_t* custom);
 bool r3d_shader_load_scene_depth(r3d_shader_custom_t* custom);
@@ -1112,6 +1132,7 @@ static const struct r3d_shader_loader {
     struct {
         r3d_shader_loader_func geometry;
         r3d_shader_loader_func forward;
+        r3d_shader_loader_func unlit;
         r3d_shader_loader_func background;
         r3d_shader_loader_func skybox;
         r3d_shader_loader_func depth;
@@ -1161,6 +1182,7 @@ static const struct r3d_shader_loader {
     .scene = {
         .geometry = r3d_shader_load_scene_geometry,
         .forward = r3d_shader_load_scene_forward,
+        .unlit = r3d_shader_load_scene_unlit,
         .background = r3d_shader_load_scene_background,
         .skybox = r3d_shader_load_scene_skybox,
         .depth = r3d_shader_load_scene_depth,

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -872,6 +872,7 @@ void raster_probe(const r3d_draw_call_t* call, const Matrix* invView, const Matr
     /* --- Applying material parameters that are independent of shaders --- */
 
     r3d_draw_apply_blend_mode(material->blendMode, material->transparencyMode);
+    r3d_draw_apply_depth_mode(material->depthMode);
     r3d_draw_apply_cull_mode(material->cullMode);
 
     /* --- Rendering the object corresponding to the draw call --- */
@@ -1272,7 +1273,6 @@ void pass_scene_probes(void)
             /* --- Render scene --- */
 
             glEnable(GL_DEPTH_TEST);
-            glDepthFunc(GL_LEQUAL);
             glDepthMask(GL_TRUE);
             glEnable(GL_BLEND);
 
@@ -1291,6 +1291,7 @@ void pass_scene_probes(void)
 
             /* --- Render background --- */
 
+            glDepthFunc(GL_LEQUAL);
             glDepthMask(GL_FALSE);
             glDisable(GL_BLEND);
 

--- a/src/r3d_surface_shader.c
+++ b/src/r3d_surface_shader.c
@@ -26,9 +26,10 @@ typedef uint32_t usage_hint_t;
 #define USAGE_HINT_OPAQUE        (1 << 0)   //< Build: geometry
 #define USAGE_HINT_PREPASS       (1 << 1)   //< Build: geometry, forward, depth
 #define USAGE_HINT_TRANSPARENT   (1 << 2)   //< Build: forward
-#define USAGE_HINT_SHADOW        (1 << 3)   //< Build: depth, depthCube
-#define USAGE_HINT_DECAL         (1 << 4)   //< Build: decal
-#define USAGE_HINT_PROBE         (1 << 5)   //< Build: probe
+#define USAGE_HINT_UNLIT         (1 << 3)   //< Build: unlit
+#define USAGE_HINT_SHADOW        (1 << 4)   //< Build: depth, depthCube
+#define USAGE_HINT_DECAL         (1 << 5)   //< Build: decal
+#define USAGE_HINT_PROBE         (1 << 6)   //< Build: probe
 
 // ========================================
 // OPAQUE STRUCTS
@@ -278,6 +279,7 @@ usage_hint_t parse_pragma_usage(const char** ptr)
             {"opaque",      6,  USAGE_HINT_OPAQUE},
             {"prepass",     7,  USAGE_HINT_PREPASS},
             {"transparent", 11, USAGE_HINT_TRANSPARENT},
+            {"unlit",       5,  USAGE_HINT_UNLIT},
             {"shadow",      6,  USAGE_HINT_SHADOW},
             {"decal",       5,  USAGE_HINT_DECAL},
             {"probe",       5,  USAGE_HINT_PROBE}
@@ -325,6 +327,7 @@ bool compile_shader_variants(R3D_SurfaceShader* shader, usage_hint_t usage)
     } variants[] = {
         {"geometry",  USAGE_HINT_OPAQUE | USAGE_HINT_PREPASS,      R3D_MOD_SHADER_LOADER.scene.geometry},
         {"forward",   USAGE_HINT_PREPASS | USAGE_HINT_TRANSPARENT, R3D_MOD_SHADER_LOADER.scene.forward},
+        {"unlit",     USAGE_HINT_UNLIT,                            R3D_MOD_SHADER_LOADER.scene.unlit},
         {"depth",     USAGE_HINT_SHADOW | USAGE_HINT_PREPASS,      R3D_MOD_SHADER_LOADER.scene.depth},
         {"depthCube", USAGE_HINT_SHADOW,                           R3D_MOD_SHADER_LOADER.scene.depthCube},
         {"decal",     USAGE_HINT_DECAL,                            R3D_MOD_SHADER_LOADER.scene.decal},


### PR DESCRIPTION
**Added unlit rendering mode for materials**

This PR introduces unlit material support by adding a `bool unlit` member to `R3D_Material` and a new `unlit.frag` shader that outputs only albedo and alpha.

**Rendering pipeline integration:**
- Unlit objects are rendered during the forward pass
- Opaque unlit objects render just before forward transparency
- Transparent unlit objects render alongside forward transparent objects to ensure correct blend ordering

**Draw list refactoring:**
This required a redesign of draw list management in `modules/r3d_draw.c`. Instead of separate lists per rendering path, "meshes lists" are now based on opacity: "opaque" and "transparent".

**Shadow map rendering:**
Unlit objects cast shadows and write depth only when their transparency mode is `DISABLED` or `PREPASS`. The `ALPHA` transparency mode produces no shadows and writes no depth, consistent with lit object behavior.

Note: For unlit objects, `PREPASS` mode doesn't function as a true prepass. It simply indicates that shadows should be rendered using the same alpha threshold as lit prepass objects. However, unlike lit prepass objects, the opaque portions of unlit objects don't write depth since there is no practical use for doing it at the moment. _(maybe for custom screen shaders, but even then, it's something to think about...)_

**Reflection probe rendering:**
Unlit objects are captured in reflection probes identically to lit objects, no special handling required.

**Decal limitations:**
Decals cannot be applied to unlit objects. Since unlit objects render at the end of the pipeline, decals only apply to opaque lit objects.

**Custom shader support:**
Custom shaders work with unlit materials, but only `ALBEDO` and `ALPHA` outputs are used.

**Shader usage hints:**
A new `unlit` usage hint has been added. The existing hints (`opaque`, `prepass`, `transparent`) are intended for lit objects only, while `unlit` applies to any unlit object regardless of its transparency mode.