### PR TITLE
Review `R3D_Init()`

### DIFF
--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -147,8 +147,10 @@ extern "C" {
  * 
  * @param resWidth Width of the internal resolution.
  * @param resHeight Height of the internal resolution.
+ *
+ * @return True if the initialization is successful.
  */
-R3DAPI void R3D_Init(int resWidth, int resHeight);
+R3DAPI bool R3D_Init(int resWidth, int resHeight);
 
 /**
  * @brief Closes the rendering engine and deallocates all resources.

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -35,7 +35,7 @@ struct r3d_core_state R3D;
 // PUBLIC API
 // ========================================
 
-void R3D_Init(int resWidth, int resHeight)
+bool R3D_Init(int resWidth, int resHeight)
 {
     memset(&R3D, 0, sizeof(R3D));
 
@@ -59,16 +59,42 @@ void R3D_Init(int resWidth, int resHeight)
     R3D.colorSpace = R3D_COLORSPACE_SRGB;
     R3D.layers = R3D_LAYER_ALL;
 
-    r3d_texture_init();
-    r3d_target_init(resWidth, resHeight);
-    r3d_shader_init();
-    r3d_opengl_init();
-    r3d_light_init();
-    r3d_draw_init();
-    r3d_env_init();
+    if (!r3d_texture_init()) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to init texture module");
+        return false;
+    }
 
-    // Defines suitable clipping plane distances for r3d
-    rlSetClipPlanes(0.05f, 4000.0f);
+    if (!r3d_target_init(resWidth, resHeight)) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to init target module");
+        return false;
+    }
+
+    if (!r3d_shader_init()) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to init shader module");
+        return false;
+    }
+
+    if (!r3d_opengl_init()) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to init OpenGL module");
+        return false;
+    }
+
+    if (!r3d_light_init()) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to init light module");
+        return false;
+    }
+
+    if (!r3d_draw_init()) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to init draw module");
+        return false;
+    }
+
+    if (!r3d_env_init()) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to init env module");
+        return false;
+    }
+
+    return true;
 }
 
 void R3D_Close(void)


### PR DESCRIPTION
I'm submitting this as a PR to note that `R3D_Init()` now returns a bool...

It's a bit silly, internal module initialization functions usually return a status indicating success, and `R3D_Init()` was never updated for some reasons...

Now it's done.