### PR TITLE
Add stencil tests

### DIFF
--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -366,22 +366,23 @@ static inline void sort_fill_material_data(r3d_draw_sort_t* sortData, const r3d_
         sortData->material.transparency = sortData->material.transparency;
         sortData->material.blend = call->mesh.material.blendMode;
         sortData->material.cull = call->mesh.material.cullMode;
+        sortData->material.stencilFunc = call->mesh.material.stencil.mode;
+        sortData->material.stencilRef = call->mesh.material.stencil.ref;
+        sortData->material.stencilMask = call->mesh.material.stencil.mask;
+        sortData->material.stencilOpFail = call->mesh.material.stencil.opFail;
+        sortData->material.stencilOpZFail = call->mesh.material.stencil.opZFail;
+        sortData->material.stencilOpPass = call->mesh.material.stencil.opPass;
         sortData->material.depthFunc = call->mesh.material.depthMode;
         sortData->material.billboard = call->mesh.material.billboardMode;
         break;
-    
+
     case R3D_DRAW_CALL_DECAL:
+        memset(&sortData->material, 0, sizeof(sortData->material));
         sortData->material.shader = (uintptr_t)call->decal.instance.shader;
-        sortData->material.shading = 0;
         sortData->material.albedo = call->decal.instance.albedo.texture.id;
         sortData->material.normal = call->decal.instance.normal.texture.id;
         sortData->material.orm = call->decal.instance.orm.texture.id;
         sortData->material.emission = call->decal.instance.emission.texture.id;
-        sortData->material.transparency = R3D_TRANSPARENCY_ALPHA;
-        sortData->material.blend = R3D_BLEND_MIX;
-        sortData->material.cull = R3D_CULL_NONE;
-        sortData->material.depthFunc = R3D_COMPARE_ALWAYS;
-        sortData->material.billboard = R3D_BILLBOARD_DISABLED;
         break;
     }
 }

--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -380,7 +380,7 @@ static inline void sort_fill_material_data(r3d_draw_sort_t* sortData, const r3d_
         sortData->material.transparency = R3D_TRANSPARENCY_ALPHA;
         sortData->material.blend = R3D_BLEND_MIX;
         sortData->material.cull = R3D_CULL_NONE;
-        sortData->material.depthFunc = R3D_DEPTH_ALWAYS;
+        sortData->material.depthFunc = R3D_COMPARE_ALWAYS;
         sortData->material.billboard = R3D_BILLBOARD_DISABLED;
         break;
     }
@@ -753,6 +753,54 @@ void r3d_draw_sort_list(r3d_draw_list_enum_t list, Vector3 viewPosition, r3d_dra
     );
 }
 
+void r3d_draw_apply_stencil_state(R3D_StencilState state)
+{
+    GLenum glFunc;
+    switch (state.mode) {
+        case R3D_COMPARE_LESS:     glFunc = GL_LESS; break;
+        case R3D_COMPARE_LEQUAL:   glFunc = GL_LEQUAL; break;
+        case R3D_COMPARE_EQUAL:    glFunc = GL_EQUAL; break;
+        case R3D_COMPARE_GREATER:  glFunc = GL_GREATER; break;
+        case R3D_COMPARE_GEQUAL:   glFunc = GL_GEQUAL; break;
+        case R3D_COMPARE_NOTEQUAL: glFunc = GL_NOTEQUAL; break;
+        case R3D_COMPARE_ALWAYS:   glFunc = GL_ALWAYS; break;
+        case R3D_COMPARE_NEVER:    glFunc = GL_NEVER; break;
+        default:                   glFunc = GL_ALWAYS; break;
+    }
+
+    GLenum glOpFail, glOpZFail, glOpPass;
+
+    switch (state.opFail) {
+        case R3D_STENCIL_KEEP:    glOpFail = GL_KEEP; break;
+        case R3D_STENCIL_ZERO:    glOpFail = GL_ZERO; break;
+        case R3D_STENCIL_REPLACE: glOpFail = GL_REPLACE; break;
+        case R3D_STENCIL_INCR:    glOpFail = GL_INCR; break;
+        case R3D_STENCIL_DECR:    glOpFail = GL_DECR; break;
+        default:                  glOpFail = GL_KEEP; break;
+    }
+
+    switch (state.opZFail) {
+        case R3D_STENCIL_KEEP:    glOpZFail = GL_KEEP; break;
+        case R3D_STENCIL_ZERO:    glOpZFail = GL_ZERO; break;
+        case R3D_STENCIL_REPLACE: glOpZFail = GL_REPLACE; break;
+        case R3D_STENCIL_INCR:    glOpZFail = GL_INCR; break;
+        case R3D_STENCIL_DECR:    glOpZFail = GL_DECR; break;
+        default:                  glOpZFail = GL_KEEP; break;
+    }
+
+    switch (state.opPass) {
+        case R3D_STENCIL_KEEP:    glOpPass = GL_KEEP; break;
+        case R3D_STENCIL_ZERO:    glOpPass = GL_ZERO; break;
+        case R3D_STENCIL_REPLACE: glOpPass = GL_REPLACE; break;
+        case R3D_STENCIL_INCR:    glOpPass = GL_INCR; break;
+        case R3D_STENCIL_DECR:    glOpPass = GL_DECR; break;
+        default:                  glOpPass = GL_KEEP; break;
+    }
+
+    glStencilFunc(glFunc, state.ref, state.mask);
+    glStencilOp(glOpFail, glOpZFail, glOpPass);
+}
+
 void r3d_draw_apply_blend_mode(R3D_BlendMode blend, R3D_TransparencyMode transparency)
 {
     switch (blend) {
@@ -783,17 +831,17 @@ void r3d_draw_apply_blend_mode(R3D_BlendMode blend, R3D_TransparencyMode transpa
     }
 }
 
-void r3d_draw_apply_depth_mode(R3D_DepthMode mode)
+void r3d_draw_apply_depth_mode(R3D_CompareMode mode)
 {
     switch (mode) {
-    case R3D_DEPTH_LESS: glDepthFunc(GL_LESS); break;
-    case R3D_DEPTH_LEQUAL: glDepthFunc(GL_LEQUAL); break;
-    case R3D_DEPTH_EQUAL: glDepthFunc(GL_EQUAL); break;
-    case R3D_DEPTH_GREATER: glDepthFunc(GL_GREATER); break;
-    case R3D_DEPTH_GEQUAL: glDepthFunc(GL_GEQUAL); break;
-    case R3D_DEPTH_NOTEQUAL: glDepthFunc(GL_NOTEQUAL); break;
-    case R3D_DEPTH_ALWAYS: glDepthFunc(GL_ALWAYS); break;
-    case R3D_DEPTH_NEVER: glDepthFunc(GL_NEVER); break;
+    case R3D_COMPARE_LESS: glDepthFunc(GL_LESS); break;
+    case R3D_COMPARE_LEQUAL: glDepthFunc(GL_LEQUAL); break;
+    case R3D_COMPARE_EQUAL: glDepthFunc(GL_EQUAL); break;
+    case R3D_COMPARE_GREATER: glDepthFunc(GL_GREATER); break;
+    case R3D_COMPARE_GEQUAL: glDepthFunc(GL_GEQUAL); break;
+    case R3D_COMPARE_NOTEQUAL: glDepthFunc(GL_NOTEQUAL); break;
+    case R3D_COMPARE_ALWAYS: glDepthFunc(GL_ALWAYS); break;
+    case R3D_COMPARE_NEVER: glDepthFunc(GL_NEVER); break;
     default: break;
     }
 }

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -254,6 +254,12 @@ typedef struct {
         uint8_t transparency;
         uint8_t blend;
         uint8_t cull;
+        uint8_t stencilFunc;
+        uint8_t stencilRef;
+        uint8_t stencilMask;
+        uint8_t stencilOpFail;
+        uint8_t stencilOpZFail;
+        uint8_t stencilOpPass;
         uint8_t depthFunc;
         uint8_t billboard;
     } material;

--- a/src/modules/r3d_draw.h
+++ b/src/modules/r3d_draw.h
@@ -366,6 +366,12 @@ bool r3d_draw_call_is_visible(const r3d_draw_call_t* call, const r3d_frustum_t* 
 void r3d_draw_sort_list(r3d_draw_list_enum_t list, Vector3 viewPosition, r3d_draw_sort_enum_t mode);
 
 /*
+ * Applies the given stencil state.
+ * Assumes that GL_STENCIL_TEST is already enabled.
+ */
+void r3d_draw_apply_stencil_state(R3D_StencilState state);
+
+/*
  * Applies the OpenGL blend function for the current draw call.
  * Assumes GL_BLEND is already enabled and only sets the blend equations.
  * The MIX blend mode always uses standard alpha blending.
@@ -375,7 +381,7 @@ void r3d_draw_apply_blend_mode(R3D_BlendMode blend, R3D_TransparencyMode transpa
 /*
  * Applies the depth function corresponding to the material's depth mode.
  */
-void r3d_draw_apply_depth_mode(R3D_DepthMode mode);
+void r3d_draw_apply_depth_mode(R3D_CompareMode mode);
 
 /*
  * Apply the OpenGL face culling state for a draw call.

--- a/src/modules/r3d_env.c
+++ b/src/modules/r3d_env.c
@@ -92,10 +92,10 @@ static bool layer_pool_expand(r3d_env_layer_pool_t* pool, int addCount)
 // TEXTURE FUNCTIONS
 // ========================================
 
-static bool allocate_renderbuffer_depth(GLuint renderbuffer, int size)
+static bool alloc_depth_stencil_renderbuffer(GLuint renderbuffer, int size)
 {
     glBindRenderbuffer(GL_RENDERBUFFER, renderbuffer);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, size, size);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, size, size);
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
     return true;
 }
@@ -596,13 +596,13 @@ void r3d_env_capture_bind_fbo(int face, int mipLevel)
     glBindFramebuffer(GL_FRAMEBUFFER, R3D_MOD_ENV.captureFramebuffer);
 
     if (!R3D_MOD_ENV.captureCubeAllocated) {
-        allocate_renderbuffer_depth(R3D_MOD_ENV.captureDepth, R3D_PROBE_CAPTURE_SIZE);
+        alloc_depth_stencil_renderbuffer(R3D_MOD_ENV.captureDepth, R3D_PROBE_CAPTURE_SIZE);
         cubemap_spec_t spec = cubemap_spec(R3D_PROBE_CAPTURE_SIZE, 0, true);
         allocate_cubemap(R3D_MOD_ENV.captureCube, spec);
         R3D_MOD_ENV.captureCubeAllocated = true;
 
         glFramebufferRenderbuffer(
-            GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+            GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
             GL_RENDERBUFFER, R3D_MOD_ENV.captureDepth
         );
     }

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -118,10 +118,10 @@ static void alloc_target_texture(r3d_target_t target)
     R3D_MOD_TARGET.targetLoaded[target] = true;
 }
 
-static void alloc_depth_renderbuffer(int resW, int resH)
+static void alloc_depth_stencil_renderbuffer(int resW, int resH)
 {
     glBindRenderbuffer(GL_RENDERBUFFER, R3D_MOD_TARGET.depthRenderbuffer);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, resW, resH);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, resW, resH);
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
 }
 
@@ -175,7 +175,7 @@ static int get_or_create_fbo(const r3d_target_t* targets, int count, bool depth)
 
     if (depth) {
         glFramebufferRenderbuffer(
-            GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT,
+            GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
             GL_RENDERBUFFER, R3D_MOD_TARGET.depthRenderbuffer
         );
     }
@@ -209,7 +209,7 @@ bool r3d_target_init(int resW, int resH)
 
     glGenTextures(R3D_TARGET_COUNT, R3D_MOD_TARGET.targetTextures);
     glGenRenderbuffers(1, &R3D_MOD_TARGET.depthRenderbuffer);
-    alloc_depth_renderbuffer(resW, resH);
+    alloc_depth_stencil_renderbuffer(resW, resH);
 
     R3D_MOD_TARGET.currentFbo = -1;
 
@@ -249,7 +249,7 @@ void r3d_target_resize(int resW, int resH)
     // TODO: Avoid reallocating targets if the new dimensions
     //       are smaller than the allocated dimensions?
 
-    alloc_depth_renderbuffer(resW, resH);
+    alloc_depth_stencil_renderbuffer(resW, resH);
 
     for (int i = 0; i < R3D_TARGET_COUNT; i++) {
         if (R3D_MOD_TARGET.targetLoaded[i]) {
@@ -334,7 +334,7 @@ void r3d_target_clear(const r3d_target_t* targets, int count, int level, bool de
     }
 
     if (depth) {
-        glClearBufferfv(GL_DEPTH, 0, (float[1]){1.0f});
+        glClearBufferfi(GL_DEPTH_STENCIL, 0, 1.0f, 0);
     }
 }
 


### PR DESCRIPTION
Addition of stencil test support for materials.

The enum `R3D_DepthMode` has been renamed to `R3D_CompareMode` and can be used for both depth and stencil modes.
The enum `R3D_StencilOp` and the struct `R3D_StencilState` have been added.
The member `R3D_StencilState stencil` has been added to `R3D_Material`.
The default state is equivalent to an inactive state.

Also supports reflection probes.

---

_We're really starting to need to add a state cache for activatable states, this will be implemented right after this PR._