### PR TITLE
SSAO Review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,7 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/prepare/blur_up.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssao_in_down.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssao.frag"
+    "${R3D_ROOT_PATH}/shaders/prepare/ssao_blur.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssil_in_down.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssil.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssr_in_down.frag"

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -67,10 +67,10 @@
         },                                              \
         .ssao = {                                       \
             .sampleCount = 16,                          \
-            .intensity = 1.0f,                          \
+            .intensity = 0.5f,                          \
             .power = 1.5f,                              \
-            .radius = 0.35f,                            \
-            .bias = 0.007f,                             \
+            .radius = 0.5f,                             \
+            .bias = 0.02f,                              \
             .enabled = false,                           \
         },                                              \
         .ssil = {                                       \

--- a/shaders/prepare/ssao.frag
+++ b/shaders/prepare/ssao.frag
@@ -6,10 +6,8 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-// Adapted from the methods proposed by Morgan McGuire et al. in "AlchemyAO" and "Scalable Ambient Obscurance"
-
-// SEE AlchemyAO: https://casual-effects.com/research/McGuire2011AlchemyAO/VV11AlchemyAO.pdf
-// SEE SAO:       https://research.nvidia.com/sites/default/files/pubs/2012-06_Scalable-Ambient-Obscurance/McGuire12SAO.pdf
+// Adapted from the method proposed by Morgan McGuire et al. in "Scalable Ambient Obscurance"
+// SEE SAO: https://research.nvidia.com/sites/default/files/pubs/2012-06_Scalable-Ambient-Obscurance/McGuire12SAO.pdf
 
 #version 330 core
 
@@ -35,7 +33,22 @@ uniform float uPower;
 
 /* === Constants === */
 
-const float SAMPLES_PER_TURN = 5.0;
+// Number of spiral turns for each sample count, ensuring coprime relationship.
+// Each entry ROTATIONS[i] is chosen such that GCD(i+1, ROTATIONS[i]) = 1,
+// preventing sample alignment artifacts in the spiral pattern.
+// Indexed by (sampleCount - 1). Supports 1 to 98 samples.
+const int ROTATIONS[98] = int[98](
+    1, 1, 2, 3, 2, 5, 2, 3, 2,
+    3, 3, 5, 5, 3, 4, 7, 5, 5, 7,
+    9, 8, 5, 5, 7, 7, 7, 8, 5, 8,
+    11, 12, 7, 10, 13, 8, 11, 8, 7, 14,
+    11, 11, 13, 12, 13, 19, 17, 13, 11, 18,
+    19, 11, 11, 14, 17, 21, 15, 16, 17, 18,
+    13, 17, 11, 17, 19, 18, 25, 18, 19, 19,
+    29, 21, 19, 27, 31, 29, 21, 18, 17, 29,
+    31, 31, 23, 18, 25, 26, 25, 23, 19, 34,
+    19, 27, 21, 25, 39, 29, 17, 21, 27
+);
 
 /* === Fragments === */
 
@@ -43,13 +56,12 @@ out float FragOcclusion;
 
 /* === Helper functions === */
 
-vec2 TapLocation(int i, float turns, float spin, out float rNorm)
+vec2 TapLocation(int i, float numSpiralTurns, float spin, out float rNorm)
 {
     float alpha = (float(i) + 0.5) / float(uSampleCount);
-    float angle = alpha * turns + spin;
+    float angle = alpha * (numSpiralTurns * M_TAU) + spin;
 
     rNorm = alpha;
-
     return vec2(cos(angle), sin(angle));
 }
 
@@ -57,48 +69,54 @@ vec2 TapLocation(int i, float turns, float spin, out float rNorm)
 
 void main()
 {
-    vec3 position = V_GetViewPosition(uDepthTex, ivec2(gl_FragCoord.xy));
-    vec3 normal = V_GetViewNormal(uNormalTex, ivec2(gl_FragCoord.xy));
+    FragOcclusion = 1.0;
 
-    // Compute the radius in screen space
-    float ssRadius = uRadius * uView.proj[1][1] / -position.z;
+    ivec2 pixelCoord = ivec2(gl_FragCoord.xy);
+    float depth = texture(uDepthTex, vTexCoord).r;
+    if (depth >= uView.far) return;
 
-    // Clamping the screen space radius could avoid big cache misses
-    // and possible artifacts when very close to an object. To test
-    //ssRadius = min(ssRadius, 0.1); // 10% of the screen
+    vec3 position = V_GetViewPosition(vTexCoord, depth);
+    vec3 normal = V_GetViewNormal(uNormalTex, pixelCoord);
 
-    // For the spin, the AlchemyAO method did this: float((3*px.x^px.y+px.x*px.y)*10)
-    // But I found that using a simple IGN produce a really more stable result
-    float turns = M_TAU * max(1.0, float(uSampleCount) / SAMPLES_PER_TURN);
-    float spin = M_TAU * M_HashIGN(gl_FragCoord.xy);
+    float projScale = abs(uView.proj[1][1]) * textureSize(uDepthTex, 0).y * 0.5;
+    float ssRadius = projScale * uRadius / max(depth, 0.1);
     float radiusSq = uRadius * uRadius;
-    float bias = uBias * ssRadius;
+
+    // Here we use an IGN instead of the hash from the HPG12 AlchemyAO paper.
+    // The result is much more pleasing and blurs much better.
+
+    float spin = M_TAU * M_HashIGN(gl_FragCoord.xy);
+    int numSpiralTurns = ROTATIONS[clamp(uSampleCount - 1, 0, 97)];
 
     float aoSum = 0.0;
     for (int i = 0; i < uSampleCount; ++i)
     {
         float rNorm;
-        vec2 dir = TapLocation(i, turns, spin, rNorm);
-        vec2 offset = vTexCoord + dir * ssRadius * rNorm;
-        if (V_OffScreen(offset)) continue;
+        vec2 unitDir = TapLocation(i, float(numSpiralTurns), spin, rNorm);
+        ivec2 pixelOffset = pixelCoord + ivec2(unitDir * ssRadius * rNorm);
 
-        // The "SAO" paper recommends using mipmaps of the linearized depth here, but hey
-        vec3 samplePos = V_GetViewPosition(uDepthTex, offset);
+        vec3 samplePos = V_GetViewPosition(uDepthTex, pixelOffset);
         vec3 v = samplePos - position;
 
         float vv = dot(v, v);
         float vn = dot(v, normal);
-        if (vv > radiusSq) continue; // Reject samples beyond the world space radius
 
-        // AlchemyAO formula (original, then our own with adaptive bias)
-        //aoSum += max(vn + position.z * uBias, 0.0) / (vv + 0.01);
-        aoSum += max(vn - bias, 0.0) / (vv + 0.01);
+        const float epsilon = 0.02;
+        float f = max(radiusSq - vv, 0.0);
+        aoSum += f * f * f * max((vn - uBias) / (epsilon + vv), 0.0);
     }
 
-    // Ignore the paper's factor of 2, it comes from
-    // hemispherical integration but just over darkens in practice...
-    float A = (uIntensity / float(uSampleCount)) * aoSum;
+    float temp = radiusSq * uRadius;
+    aoSum /= (temp * temp);
+    
+    float A = max(0.0, 1.0 - aoSum * uIntensity * (4.0 / float(uSampleCount)));
 
-    // Conversion to accessibility factor then apply contrast
-    FragOcclusion = pow(max(1.0 - A, 0.0), uPower);
+    // 1-pixel bilateral filter using derivatives (almost free)
+	if (abs(dFdx(depth)) < 0.2) A -= dFdx(A) * (float(pixelCoord.x & 1) - 0.5);
+    if (abs(dFdy(depth)) < 0.2) A -= dFdy(A) * (float(pixelCoord.y & 1) - 0.5);
+
+    // SAO tends to over-darken near surfaces; smoothly fade it out
+    A = mix(A, 1.0, 1.0 - clamp(0.5 * depth, 0.0, 1.0));
+
+    FragOcclusion = pow(A, uPower);
 }

--- a/shaders/prepare/ssao.frag
+++ b/shaders/prepare/ssao.frag
@@ -7,7 +7,7 @@
  */
 
 // Adapted from the method proposed by Morgan McGuire et al. in "Scalable Ambient Obscurance"
-// SEE SAO: https://research.nvidia.com/sites/default/files/pubs/2012-06_Scalable-Ambient-Obscurance/McGuire12SAO.pdf
+// SEE: https://research.nvidia.com/publication/2012-06_scalable-ambient-obscurance
 
 #version 330 core
 

--- a/shaders/prepare/ssao_blur.frag
+++ b/shaders/prepare/ssao_blur.frag
@@ -1,0 +1,79 @@
+/* ssao_blur.frag -- SSAO bilateral blur fragment shader
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+/* === Varyings === */
+
+noperspective in vec2 vTexCoord;
+
+/* === Uniforms === */
+
+uniform sampler2D uSsaoTex;
+uniform sampler2D uDepthTex;
+uniform vec2 uDirection;
+
+/* === Fragments === */
+
+layout(location = 0) out float FragColor;
+
+/* === Constants === */
+
+const float DEPTH_SHARPNESS = 200.0;
+
+// Generated using the Two-pass Gaussian blur coeffifients generator made by Lisyarus
+// Link: https://lisyarus.github.io/blog/posts/blur-coefficients-generator.html
+
+// Used parameters:
+// Blur radius: 4
+// Blur sigma: 2
+
+const int SAMPLE_COUNT = 5;
+
+const float OFFSETS[5] = float[5](
+    -3.2979348079914823,
+    -1.409199877085212,
+    0.469433779698372,
+    2.351564403533789,
+    4
+);
+
+const float WEIGHTS[5] = float[5](
+    0.095766798098283,
+    0.3030531945966437,
+    0.3814038792275628,
+    0.19124386547413952,
+    0.02853226260337099
+);
+
+/* === Main Functions === */
+
+void main()
+{
+    vec2 texelSize = 1.0 / vec2(textureSize(uSsaoTex, 0));
+    float centerDepth = texture(uDepthTex, vTexCoord).r;
+
+    float result = 0.0;
+    float wieghtSum = 0.0;
+
+    for (int i = 0; i < SAMPLE_COUNT; ++i)
+    {
+        vec2 offset = uDirection * OFFSETS[i] * texelSize;
+        float sampleAO = texture(uSsaoTex, vTexCoord + offset).r;
+        float sampleDepth = texture(uDepthTex, vTexCoord + offset).r;
+
+        float depthDiff = abs(centerDepth - sampleDepth);
+        float depthWeight = exp(-depthDiff * depthDiff * DEPTH_SHARPNESS);
+        float w = WEIGHTS[i] * depthWeight;
+
+        result += sampleAO * w;
+        wieghtSum += w;
+    }
+
+    FragColor = result / wieghtSum;
+}

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -30,6 +30,7 @@
 #include <shaders/blur_up.frag.h>
 #include <shaders/ssao_in_down.frag.h>
 #include <shaders/ssao.frag.h>
+#include <shaders/ssao_blur.frag.h>
 #include <shaders/ssil_in_down.frag.h>
 #include <shaders/ssil.frag.h>
 #include <shaders/ssr_in_down.frag.h>
@@ -325,6 +326,23 @@ bool r3d_shader_load_prepare_ssao(r3d_shader_custom_t* custom)
 
     SET_SAMPLER(ssao, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
     SET_SAMPLER(ssao, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+
+    return true;
+}
+
+bool r3d_shader_load_prepare_ssao_blur(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER_BLT(r3d_shader_prepare_ssao_blur_t, prepare, ssaoBlur);
+    LOAD_SHADER(ssaoBlur, SCREEN_VERT, SSAO_BLUR_FRAG);
+
+    SET_UNIFORM_BUFFER(ssaoBlur, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+
+    GET_LOCATION(ssaoBlur, uDirection);
+
+    USE_SHADER(ssaoBlur);
+
+    SET_SAMPLER(ssaoBlur, uSsaoTex, R3D_SHADER_SAMPLER_BUFFER_SSAO);
+    SET_SAMPLER(ssaoBlur, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 
     return true;
 }
@@ -1229,6 +1247,7 @@ void r3d_shader_quit()
     UNLOAD_SHADER(prepare.blurUp);
     UNLOAD_SHADER(prepare.ssaoInDown);
     UNLOAD_SHADER(prepare.ssao);
+    UNLOAD_SHADER(prepare.ssaoBlur);
     UNLOAD_SHADER(prepare.ssilInDown);
     UNLOAD_SHADER(prepare.ssil);
     UNLOAD_SHADER(prepare.ssrInDown);

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -609,6 +609,13 @@ typedef struct {
 
 typedef struct {
     unsigned int id;
+    r3d_shader_uniform_sampler_t uSsaoTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
+    r3d_shader_uniform_vec2_t uDirection;
+} r3d_shader_prepare_ssao_blur_t;
+
+typedef struct {
+    unsigned int id;
     r3d_shader_uniform_sampler_t uDiffuseTex;
     r3d_shader_uniform_sampler_t uNormalTex;
     r3d_shader_uniform_sampler_t uDepthTex;
@@ -1055,6 +1062,7 @@ extern struct r3d_mod_shader {
         r3d_shader_prepare_blur_up_t blurUp;
         r3d_shader_prepare_ssao_in_down_t ssaoInDown;
         r3d_shader_prepare_ssao_t ssao;
+        r3d_shader_prepare_ssao_blur_t ssaoBlur;
         r3d_shader_prepare_ssil_in_down_t ssilInDown;
         r3d_shader_prepare_ssil_t ssil;
         r3d_shader_prepare_ssr_in_down_t ssrInDown;
@@ -1115,6 +1123,7 @@ bool r3d_shader_load_prepare_blur_down(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_blur_up(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_ssao_in_down(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_ssao(r3d_shader_custom_t* custom);
+bool r3d_shader_load_prepare_ssao_blur(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_ssil_in_down(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_ssil(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_ssr_in_down(r3d_shader_custom_t* custom);
@@ -1159,6 +1168,7 @@ static const struct r3d_shader_loader {
         r3d_shader_loader_func blurUp;
         r3d_shader_loader_func ssaoInDown;
         r3d_shader_loader_func ssao;
+        r3d_shader_loader_func ssaoBlur;
         r3d_shader_loader_func ssilInDown;
         r3d_shader_loader_func ssil;
         r3d_shader_loader_func ssrInDown;
@@ -1215,6 +1225,7 @@ static const struct r3d_shader_loader {
         .blurUp = r3d_shader_load_prepare_blur_up,
         .ssaoInDown = r3d_shader_load_prepare_ssao_in_down,
         .ssao = r3d_shader_load_prepare_ssao,
+        .ssaoBlur = r3d_shader_load_prepare_ssao_blur,
         .ssilInDown = r3d_shader_load_prepare_ssil_in_down,
         .ssil = r3d_shader_load_prepare_ssil,
         .ssrInDown = r3d_shader_load_prepare_ssr_in_down,

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -298,14 +298,6 @@ void r3d_target_get_texel_size(float* w, float* h, r3d_target_t target, int leve
     }
 }
 
-r3d_target_t r3d_target_swap_ssao(r3d_target_t ssao)
-{
-    if (ssao == R3D_TARGET_SSAO_0) {
-        return R3D_TARGET_SSAO_1;
-    }
-    return R3D_TARGET_SSAO_0;
-}
-
 r3d_target_t r3d_target_swap_scene(r3d_target_t scene)
 {
     if (scene == R3D_TARGET_SCENE_0) {

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -111,15 +111,6 @@ typedef enum {
     )
 
 /*
- * Binds the target, then swaps to the alternate SSAO target.
- * Modifies the target parameter to point to the other buffer.
- */
-#define R3D_TARGET_BIND_AND_SWAP_SSAO(target) do {                      \
-    R3D_TARGET_BIND(false, target);                                     \
-    target = r3d_target_swap_ssao(target);                              \
-} while(0)
-
-/*
  * Binds the target, then swaps to the alternate scene target.
  * Modifies the target parameter to point to the other buffer.
  */
@@ -214,11 +205,6 @@ void r3d_target_get_resolution(int* w, int* h, r3d_target_t target, int level);
  * Returns the texel size for the specified mip level.
  */
 void r3d_target_get_texel_size(float* w, float* h, r3d_target_t target, int level);
-
-/*
- * Returns target '1' if target '0' is provided, otherwise returns target '0'.
- */
-r3d_target_t r3d_target_swap_ssao(r3d_target_t ssao);
 
 /*
  * Returns target '1' if target '0' is provided, otherwise returns target '0'.

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -29,7 +29,6 @@
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_draw.h"
 #include "./modules/r3d_env.h"
-#include "raylib.h"
 
 // ========================================
 // HELPER MACROS


### PR DESCRIPTION
Fix and complete the SSAO implementation!

Until now, the SSAO implementation was a somewhat odd mix between the concepts from [AlchemyAO](https://www.highperformancegraphics.org/previous/www_2012/media/Papers/HPG2012_Papers_McGuire.pdf) and [SAO](https://research.nvidia.com/sites/default/files/pubs/2012-06_Scalable-Ambient-Obscurance/McGuire12SAO.pdf) (Morgan McGuire et al.), and it contained a few errors.

The implementation is now almost entirely faithful to the SAO paper, with a minor change and some details omitted:

- The hash function from the [AlchemyAO](https://research.nvidia.com/publication/2011-08_alchemy-screen-space-ambient-obscurance-algorithm) has been replaced with an [IGN](https://blog.demofox.org/2022/01/01/interleaved-gradient-noise-a-different-kind-of-low-discrepancy-sequence/), giving much nicer results that work better with subsequent blurring.
- Some optional details are still missing, such as depth mipmap and a depth buffer guardband. The former improves sampling efficiency, and the latter allows off-screen objects to contribute slightly to the occlusion. I don't plan to implement the guardband, but depth mipmaps could be interesting in the future. Adding them would require significant changes, so it's something I'll keep in mind.

Additionally, the SSAO no longer reuses the SSIL denoiser, which was overkill. That was part of the previous implementation struggles, but everything is now clean and working as expected.

Finally, the default parameters of `R3D_ENVIRONMENT_BASE` have been slightly adjusted.

References:
- [Scalable Ambient Obscursance publication](https://research.nvidia.com/publication/2012-06_scalable-ambient-obscurance)
- [Bart Wronski's implementation for DX11](https://github.com/bartwronski/CSharpRenderer/blob/master/shaders/ssao.fx)
