### PR TITLE
Custom instance attribute

### DIFF
--- a/docs/shaders/surface_shader.md
+++ b/docs/shaders/surface_shader.md
@@ -109,6 +109,7 @@ All vertex-stage variables are initialized with local (pre-transformation) attri
 | `INSTANCE_ROTATION` | `vec4` | Instance rotation (quaternion: x, y, z, w) |
 | `INSTANCE_SCALE` | `vec3` | Instance scale |
 | `INSTANCE_COLOR` | `vec4` | Instance color |
+| `INSTANCE_CUSTOM` | `vec4` | Custom user-defined instance data |
 
 **Example:**
 ```glsl
@@ -128,10 +129,33 @@ INSTANCE_POSITION = vec3(0.0);
 INSTANCE_ROTATION = vec4(0.0, 0.0, 0.0, 1.0);  // Identity quaternion
 INSTANCE_SCALE = vec3(1.0);
 INSTANCE_COLOR = vec4(1.0);
+INSTANCE_CUSTOM = vec4(0.0);
 ```
 
 You can modify mesh-local attributes (`POSITION`, `NORMAL`, etc.) and instance attributes (`INSTANCE_*`) independently.
 R3D automatically composes them internally, so you don't need to manually combine them.
+
+**Custom Instance Data:**
+
+`INSTANCE_CUSTOM` is reserved for user-defined data. Unlike other instance attributes, it has no predefined meaning and can store any data you need.
+If you want to use it in the fragment stage, pass it through a varying:
+
+```glsl
+varying vec4 v_custom_data;
+
+void vertex() {
+    // Use custom data however you want
+    v_custom_data = INSTANCE_CUSTOM;
+    
+    // Example: use as animation offset
+    POSITION.y += INSTANCE_CUSTOM.x * sin(INSTANCE_CUSTOM.y);
+}
+
+void fragment() {
+    // Access custom data passed from vertex stage
+    ALBEDO *= v_custom_data.rgb;
+}
+```
 
 **Example:**
 ```glsl

--- a/docs/shaders/surface_shader.md
+++ b/docs/shaders/surface_shader.md
@@ -99,18 +99,52 @@ All vertex-stage variables are initialized with local (pre-transformation) attri
 
 | Variable | Type | Description |
 |----------|------|-------------|
-| `POSITION` | `vec3` | Vertex position |
+| `POSITION` | `vec3` | Vertex position (local space) |
 | `TEXCOORD` | `vec2` | Texture coordinates |
-| `NORMAL` | `vec3` | Vertex normal |
+| `NORMAL` | `vec3` | Vertex normal (local space) |
 | `TANGENT` | `vec4` | Vertex tangent (w = handedness) |
 | `COLOR` | `vec4` | Vertex color |
 | `EMISSION` | `vec3` | Vertex emission |
+| `INSTANCE_POSITION` | `vec3` | Instance position (world space) |
+| `INSTANCE_ROTATION` | `vec4` | Instance rotation (quaternion: x, y, z, w) |
+| `INSTANCE_SCALE` | `vec3` | Instance scale |
+| `INSTANCE_COLOR` | `vec4` | Instance color |
 
 **Example:**
 ```glsl
 void vertex() {
     POSITION *= 1.5; // Scale vertex position
     COLOR.rgb *= 0.5; // Darken vertex color
+}
+```
+
+**Instance Variables:**
+
+The `INSTANCE_*` variables are always available, even for non-instanced rendering.
+When instancing is not used or when an instance buffer doesn't define certain attributes, they default to:
+
+```glsl
+INSTANCE_POSITION = vec3(0.0);
+INSTANCE_ROTATION = vec4(0.0, 0.0, 0.0, 1.0);  // Identity quaternion
+INSTANCE_SCALE = vec3(1.0);
+INSTANCE_COLOR = vec4(1.0);
+```
+
+You can modify mesh-local attributes (`POSITION`, `NORMAL`, etc.) and instance attributes (`INSTANCE_*`) independently.
+R3D automatically composes them internally, so you don't need to manually combine them.
+
+**Example:**
+```glsl
+void vertex() {
+    // Modify local mesh attributes
+    POSITION *= 1.5; // Scale vertex position
+    COLOR.rgb *= 0.5; // Darken vertex color
+    
+    // Modify instance attributes separately
+    INSTANCE_SCALE *= 2.0; // Double instance scale
+    INSTANCE_COLOR.a *= 0.8; // Make instance more transparent
+    
+    // R3D will compose these automatically
 }
 ```
 

--- a/docs/shaders/surface_shader.md
+++ b/docs/shaders/surface_shader.md
@@ -111,14 +111,6 @@ All vertex-stage variables are initialized with local (pre-transformation) attri
 | `INSTANCE_COLOR` | `vec4` | Instance color |
 | `INSTANCE_CUSTOM` | `vec4` | Custom user-defined instance data |
 
-**Example:**
-```glsl
-void vertex() {
-    POSITION *= 1.5; // Scale vertex position
-    COLOR.rgb *= 0.5; // Darken vertex color
-}
-```
-
 **Instance Variables:**
 
 The `INSTANCE_*` variables are always available, even for non-instanced rendering.

--- a/include/r3d/r3d_instance.h
+++ b/include/r3d/r3d_instance.h
@@ -21,7 +21,7 @@
 // CONSTANTS
 // ========================================
 
-#define R3D_INSTANCE_ATTRIBUTE_COUNT 4
+#define R3D_INSTANCE_ATTRIBUTE_COUNT 5
 
 // ========================================
 // ENUM / FLAGS
@@ -36,6 +36,7 @@ typedef int R3D_InstanceFlags;
 #define R3D_INSTANCE_ROTATION   (1 << 1)    /*< Quaternion  */
 #define R3D_INSTANCE_SCALE      (1 << 2)    /*< Vector3     */
 #define R3D_INSTANCE_COLOR      (1 << 3)    /*< Color       */
+#define R3D_INSTANCE_CUSTOM     (1 << 4)    /*< Vector4     */
 
 // ========================================
 // STRUCT TYPES

--- a/shaders/include/user/scene.vert
+++ b/shaders/include/user/scene.vert
@@ -17,6 +17,7 @@ vec3 INSTANCE_POSITION;
 vec4 INSTANCE_ROTATION;
 vec3 INSTANCE_SCALE;
 vec4 INSTANCE_COLOR;
+vec4 INSTANCE_CUSTOM;
 
 #define vertex()
 
@@ -26,6 +27,7 @@ void SceneVertex()
     INSTANCE_ROTATION = iRotation;
     INSTANCE_SCALE = iScale;
     INSTANCE_COLOR = iColor;
+    INSTANCE_CUSTOM = iCustom;
 
     POSITION = aPosition;
     TEXCOORD = uTexCoordOffset + aTexCoord * uTexCoordScale;

--- a/shaders/include/user/scene.vert
+++ b/shaders/include/user/scene.vert
@@ -13,14 +13,24 @@ vec4 COLOR;
 vec4 TANGENT;
 vec3 NORMAL;
 
+vec3 INSTANCE_POSITION;
+vec4 INSTANCE_ROTATION;
+vec3 INSTANCE_SCALE;
+vec4 INSTANCE_COLOR;
+
 #define vertex()
 
 void SceneVertex()
 {
+    INSTANCE_POSITION = iPosition;
+    INSTANCE_ROTATION = iRotation;
+    INSTANCE_SCALE = iScale;
+    INSTANCE_COLOR = iColor;
+
     POSITION = aPosition;
     TEXCOORD = uTexCoordOffset + aTexCoord * uTexCoordScale;
     EMISSION = uEmissionColor * uEmissionEnergy;
-    COLOR = aColor * iColor * uAlbedoColor;
+    COLOR = aColor * uAlbedoColor;
     TANGENT = aTangent;
     NORMAL = aNormal;
 

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -188,15 +188,15 @@ void main()
     vec3 finalTangent = mat3(uMatNormal) * localTangent;
 
     if (uInstancing) {
-        billboardCenter += iPosition;
-        finalPosition = finalPosition * iScale;
-        finalPosition = M_Rotate3D(finalPosition, iRotation);
-        finalPosition = finalPosition + iPosition;
-        finalNormal = M_Rotate3D(finalNormal, iRotation);
-        finalTangent = M_Rotate3D(finalTangent, iRotation);
+        billboardCenter += INSTANCE_POSITION;
+        finalPosition = finalPosition * INSTANCE_SCALE;
+        finalPosition = M_Rotate3D(finalPosition, INSTANCE_ROTATION);
+        finalPosition = finalPosition + INSTANCE_POSITION;
+        finalNormal = M_Rotate3D(finalNormal, INSTANCE_ROTATION);
+        finalTangent = M_Rotate3D(finalTangent, INSTANCE_ROTATION);
 
     #if defined(DECAL)
-        mat4 iMatModel = MatrixTransform(iPosition, iRotation, iScale);
+        mat4 iMatModel = MatrixTransform(INSTANCE_POSITION, INSTANCE_ROTATION, INSTANCE_SCALE);
         finalMatModel = iMatModel * finalMatModel;
     #endif // DECAL
     }
@@ -224,7 +224,7 @@ void main()
     vPosition = finalPosition;
     vTexCoord = TEXCOORD;
     vEmission = EMISSION;
-    vColor = COLOR;
+    vColor = COLOR * INSTANCE_COLOR;
     vTBN = mat3(T, B, N);
 
 #if defined(GEOMETRY)

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -34,6 +34,7 @@ layout(location = 10) in vec3 iPosition;
 layout(location = 11) in vec4 iRotation;
 layout(location = 12) in vec3 iScale;
 layout(location = 13) in vec4 iColor;
+layout(location = 14) in vec4 iCustom;
 
 /* === Uniforms === */
 

--- a/src/modules/r3d_draw.c
+++ b/src/modules/r3d_draw.c
@@ -73,6 +73,10 @@ static void setup_shape_vertex_attribs(void)
     // instance color (vec4) (disabled)
     glVertexAttribDivisor(13, 1);
     glVertexAttrib4f(13, 1.0f, 1.0f, 1.0f, 1.0f);
+
+    // instance custom (vec4) (disabled)
+    glVertexAttribDivisor(14, 1);
+    glVertexAttrib4f(14, 0.0f, 0.0f, 0.0f, 0.0f);
 }
 
 static void load_shape(r3d_draw_shape_t* shape, const R3D_Vertex* verts, int vertCount, const GLubyte* indices, int idxCount)
@@ -805,6 +809,15 @@ void r3d_draw_instanced(const r3d_draw_call_t* call)
     }
     else {
         glDisableVertexAttribArray(13);
+    }
+
+    if (BIT_TEST(instances->flags, R3D_INSTANCE_CUSTOM)) {
+        glBindBuffer(GL_ARRAY_BUFFER, instances->buffers[4]);
+        glEnableVertexAttribArray(14);
+        glVertexAttribPointer(14, 4, GL_FLOAT, GL_FALSE, sizeof(Vector4), 0);
+    }
+    else {
+        glDisableVertexAttribArray(14);
     }
 
     if (elemCount == 0) {

--- a/src/r3d_instance.c
+++ b/src/r3d_instance.c
@@ -22,7 +22,8 @@ static const size_t INSTANCE_ATTRIBUTE_SIZE[R3D_INSTANCE_ATTRIBUTE_COUNT] = {
     /* POSITION */  sizeof(Vector3),
     /* ROTATION */  sizeof(Quaternion),
     /* SCALE    */  sizeof(Vector3),
-    /* COLOR    */  sizeof(Color)
+    /* COLOR    */  sizeof(Color),
+    /* CUSTOM   */  sizeof(Vector4),
 };
 
 // ========================================

--- a/src/r3d_mesh.c
+++ b/src/r3d_mesh.c
@@ -91,6 +91,10 @@ R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, R3D_MeshData data, const BoundingB
     glVertexAttribDivisor(13, 1);
     glVertexAttrib4f(13, 1.0f, 1.0f, 1.0f, 1.0f);
 
+    // instance color (vec4) (disabled)
+    glVertexAttribDivisor(14, 1);
+    glVertexAttrib4f(14, 0.0f, 0.0f, 0.0f, 0.0f);
+
     // EBO if indices present
     if (data.indexCount > 0 && data.indices) {
         glGenBuffers(1, &mesh.ebo);


### PR DESCRIPTION
This PR exposes all instance attributes in the vertex stage of surface shaders, as well as a new `INSTANCE_CUSTOM` attribute type.

The following new attributes are now accessible from the vertex stage with their default values:
```glsl
vec3 INSTANCE_POSITION = vec3(0.0);
vec4 INSTANCE_ROTATION = vec4(0.0, 0.0, 0.0, 1.0);  // quaternion (identity)
vec3 INSTANCE_SCALE = vec3(1.0);
vec4 INSTANCE_COLOR = vec4(1.0);
vec4 INSTANCE_CUSTOM = vec4(0.0);
```

These attributes are always available, even for non-instanced rendering. When instancing is not used or when an instance buffer doesn't define certain attributes, the default values shown above are used.

Mesh-local attributes (eg., `POSITION`, `NORMAL`) and instance attributes (e.g., `INSTANCE_*`) can be modified independently in the vertex shader. R3D automatically composes them internally.

`INSTANCE_CUSTOM` is a user-defined attribute reserved for custom shader data. Unlike other instance attributes, it has no predefined purpose and can store any data needed by the shader. To use it in the fragment stage, pass it through a varying.

This PR also adds the `R3D_INSTANCE_CUSTOM` flag for `R3D_InstanceBuffer`.