### PR TITLE
SSE checks for MSVC

### DIFF
--- a/src/common/r3d_simd.h
+++ b/src/common/r3d_simd.h
@@ -49,13 +49,13 @@
 #endif
 
 #if defined(__SSE2__) || _M_IX86_FP == 2 || (defined(_M_AMD64) || defined(_M_X64)) 
-#define R3D_HAS_SSE2
-#include <emmintrin.h>
+    #define R3D_HAS_SSE2
+    #include <emmintrin.h>
 #endif
 
 #if defined(__SSE__) || _M_IX86_FP == 1
-#define R3D_HAS_SSE
-#include <xmmintrin.h>
+   #define R3D_HAS_SSE
+   #include <xmmintrin.h>
 #endif
 
 #if defined(__ARM_NEON) || defined(__aarch64__)

--- a/src/common/r3d_simd.h
+++ b/src/common/r3d_simd.h
@@ -48,14 +48,14 @@
     #include <pmmintrin.h>
 #endif
 
-#if defined(__SSE2__)
-    #define R3D_HAS_SSE2
-    #include <emmintrin.h>
+#if defined(__SSE2__) || _M_IX86_FP == 2 || (defined(_M_AMD64) || defined(_M_X64)) 
+#define R3D_HAS_SSE2
+#include <emmintrin.h>
 #endif
 
-#if defined(__SSE__)
-    #define R3D_HAS_SSE
-    #include <xmmintrin.h>
+#if defined(__SSE__) || _M_IX86_FP == 1
+#define R3D_HAS_SSE
+#include <xmmintrin.h>
 #endif
 
 #if defined(__ARM_NEON) || defined(__aarch64__)

--- a/src/common/r3d_simd.h
+++ b/src/common/r3d_simd.h
@@ -54,8 +54,8 @@
 #endif
 
 #if defined(__SSE__) || _M_IX86_FP == 1
-   #define R3D_HAS_SSE
-   #include <xmmintrin.h>
+    #define R3D_HAS_SSE
+    #include <xmmintrin.h>
 #endif
 
 #if defined(__ARM_NEON) || defined(__aarch64__)


### PR DESCRIPTION
MSVC does not define any SSE preprocessor macros. This adds checks using the available predefined macros, which as far as I'm aware are only able to determine up to SSE2. Anything beyond that (SSE3+) would need to be manually defined or require a more involved method such as an extra script to test and define them.

Note that the `_M_IX86_FP` checks are only for x86 processors and might be considered unneeded.

`__AVX__` and `__AVX2__` are available and do work correctly so there is no issue with those.