### PR TITLE
Materials loading functions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@
   SMAA appears to be the most suitable next step. Techniques such as TAA currently require
   deeper architectural changes...
 
-* [ ] **Material loading/import helpers**
+* [x] **Material loading/import helpers**
   Similar to existing skeleton and animation loading utilities, it would be useful to provide
   helper functions to import materials from files when needed.
 

--- a/include/r3d/r3d_material.h
+++ b/include/r3d/r3d_material.h
@@ -10,6 +10,7 @@
 #define R3D_MATERIAL_H
 
 #include "./r3d_surface_shader.h"
+#include "./r3d_importer.h"
 #include "./r3d_platform.h"
 #include <raylib.h>
 #include <stdint.h>
@@ -296,6 +297,41 @@ R3DAPI R3D_Material R3D_GetDefaultMaterial(void);
  * @param material Default material to define.
  */
 R3DAPI void R3D_SetDefaultMaterial(R3D_Material material);
+
+/**
+ * @brief Load materials from a file.
+ *
+ * Parses a 3D model file and loads its associated materials.
+ *
+ * @param filePath Path to the 3D model file.
+ * @param materialCount Pointer to an integer to store the number of loaded materials.
+ * @return Pointer to an array of loaded R3D_Material, or NULL on failure.
+ */
+R3DAPI R3D_Material* R3D_LoadMaterials(const char* filePath, int* materialCount);
+
+/**
+ * @brief Load materials from memory.
+ *
+ * Loads materials directly from a memory buffer containing 3D model data.
+ *
+ * @param data Pointer to the memory buffer containing the model data.
+ * @param size Size of the data buffer in bytes.
+ * @param hint Hint on the model format (can be NULL).
+ * @param materialCount Pointer to an integer to store the number of loaded materials.
+ * @return Pointer to an array of loaded R3D_Material, or NULL on failure.
+ */
+R3DAPI R3D_Material* R3D_LoadMaterialsFromMemory(const void* data, unsigned int size, const char* hint, int* materialCount);
+
+/**
+ * @brief Load materials from an importer.
+ *
+ * Loads materials that were previously imported via an R3D_Importer instance.
+ *
+ * @param importer Pointer to a valid R3D_Importer.
+ * @param materialCount Pointer to an integer to store the number of loaded materials.
+ * @return Pointer to an array of loaded R3D_Material, or NULL on failure.
+ */
+R3DAPI R3D_Material* R3D_LoadMaterialsFromImporter(const R3D_Importer* importer, int* materialCount);
 
 /**
  * @brief Unload a material and its associated textures.

--- a/src/importer/r3d_importer_internal.h
+++ b/src/importer/r3d_importer_internal.h
@@ -122,7 +122,7 @@ bool r3d_importer_load_skeleton(const R3D_Importer* importer, R3D_Skeleton* skel
  * Load all materials from the importer into the model
  * Returns true on success, false on failure
  */
-bool r3d_importer_load_materials(const R3D_Importer* importer, R3D_Model* model, r3d_importer_texture_cache_t* textureCache);
+bool r3d_importer_load_materials(const R3D_Importer* importer, R3D_Material** materials, int* materialCount, r3d_importer_texture_cache_t* textureCache);
 
 /**
  * Load all animations from the imported scene

--- a/src/importer/r3d_importer_material.c
+++ b/src/importer/r3d_importer_material.c
@@ -144,23 +144,23 @@ static void load_material(R3D_Material* material, const R3D_Importer* importer, 
 // PUBLIC FUNCTIONS
 // ========================================
 
-bool r3d_importer_load_materials(const R3D_Importer* importer, R3D_Model* model, r3d_importer_texture_cache_t* textureCache)
+bool r3d_importer_load_materials(const R3D_Importer* importer, R3D_Material** materials, int* materialCount, r3d_importer_texture_cache_t* textureCache)
 {
-    if (!model || !importer || !textureCache || !r3d_importer_is_valid(importer)) {
+    if (!materials || !materialCount || !importer || !textureCache || !r3d_importer_is_valid(importer)) {
         R3D_TRACELOG(LOG_ERROR, "Invalid parameters for material loading");
         return false;
     }
 
-    model->materialCount = r3d_importer_get_material_count(importer);
-    model->materials = RL_CALLOC(model->materialCount, sizeof(R3D_Material));
+    *materialCount = r3d_importer_get_material_count(importer);
+    *materials = RL_CALLOC(*materialCount, sizeof(R3D_Material));
 
-    if (!model->materials) {
+    if (*materials == NULL) {
         R3D_TRACELOG(LOG_ERROR, "Unable to allocate memory for materials");
         return false;
     }
 
-    for (int i = 0; i < model->materialCount; i++) {
-        load_material(&model->materials[i], importer, textureCache, i);
+    for (int i = 0; i < *materialCount; i++) {
+        load_material(&(*materials)[i], importer, textureCache, i);
     }
 
     return true;

--- a/src/r3d_model.c
+++ b/src/r3d_model.c
@@ -34,7 +34,7 @@ static bool load_model_components(R3D_Model* model, const R3D_Importer* importer
         return false;
     }
 
-    if (!r3d_importer_load_materials(importer, model, textureCache)) {
+    if (!r3d_importer_load_materials(importer, &model->materials, &model->materialCount, textureCache)) {
         r3d_importer_unload_texture_cache(textureCache, true);
         return false;
     }


### PR DESCRIPTION
Adds three functions to the API to load/import materials from a file:
```c
R3D_Material* R3D_LoadMaterials(const char* filePath, int* materialCount);
R3D_Material* R3D_LoadMaterialsFromMemory(const void* data, unsigned int size, const char* hint, int* materialCount);
R3D_Material* R3D_LoadMaterialsFromImporter(const R3D_Importer* importer, int* materialCount);
```