### PR TITLE
Unified forward and deferred shadow map sampling functions

### DIFF
--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -14,9 +14,6 @@
 
 /* === Includes === */
 
-#include "../include/blocks/light.glsl"
-#include "../include/blocks/shadow.glsl"
-#include "../include/blocks/view.glsl"
 #include "../include/math.glsl"
 #include "../include/pbr.glsl"
 
@@ -34,6 +31,12 @@ uniform sampler2D uOrmTex;
 uniform sampler2DArrayShadow uShadowDirTex;
 uniform sampler2DArrayShadow uShadowSpotTex;
 uniform samplerCubeArrayShadow uShadowOmniTex;
+
+/* === Blocks === */
+
+#include "../include/blocks/light.glsl"
+#include "../include/blocks/shadow.glsl"
+#include "../include/blocks/view.glsl"
 
 /* === Fragments === */
 
@@ -100,10 +103,7 @@ void main()
 
     /* --- Calculating a random rotation matrix for shadow debanding --- */
 
-    float r = M_TAU * M_HashIGN(gl_FragCoord.xy);
-    float sr = sin(r), cr = cos(r);
-
-    mat2 diskRot = mat2(vec2(cr, -sr), vec2(sr, cr));
+    mat2 diskRot = S_DebandingRotationMatrix();
 
     /* Apply shadow factor if the light casts shadows */
 
@@ -111,9 +111,9 @@ void main()
 
     if (uLight.shadowLayer >= 0) {
         switch (uLight.type) {
-        case LIGHT_DIR:  shadow = S_SampleShadowDir(uLight, uShadowDirTex, uLight.viewProj * vec4(position, 1.0), cNdotL); break;
-        case LIGHT_SPOT: shadow = S_SampleShadowSpot(uLight, uShadowSpotTex, uLight.viewProj * vec4(position, 1.0), cNdotL); break;
-        case LIGHT_OMNI: shadow = S_SampleShadowOmni(uLight, uShadowOmniTex, position, cNdotL); break;
+        case LIGHT_DIR:  shadow = S_SampleShadowDir(uLight.viewProj * vec4(position, 1.0), cNdotL, diskRot); break;
+        case LIGHT_SPOT: shadow = S_SampleShadowSpot(uLight.viewProj * vec4(position, 1.0), cNdotL, diskRot); break;
+        case LIGHT_OMNI: shadow = S_SampleShadowOmni(position, cNdotL, diskRot); break;
         }
     }
 

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -101,19 +101,15 @@ void main()
     vec3 specular = L_Specular(F0, cLdotH, cNdotH, cNdotV, cNdotL, roughness);
     specular *= lightColE * uLight.specular;
 
-    /* --- Calculating a random rotation matrix for shadow debanding --- */
-
-    mat2 diskRot = S_DebandingRotationMatrix();
-
     /* Apply shadow factor if the light casts shadows */
 
     float shadow = 1.0;
 
     if (uLight.shadowLayer >= 0) {
         switch (uLight.type) {
-        case LIGHT_DIR:  shadow = S_SampleShadowDir(uLight.viewProj * vec4(position, 1.0), cNdotL, diskRot); break;
-        case LIGHT_SPOT: shadow = S_SampleShadowSpot(uLight.viewProj * vec4(position, 1.0), cNdotL, diskRot); break;
-        case LIGHT_OMNI: shadow = S_SampleShadowOmni(position, cNdotL, diskRot); break;
+        case LIGHT_DIR:  shadow = S_SampleShadowDir(uLight.viewProj * vec4(position, 1.0), cNdotL); break;
+        case LIGHT_SPOT: shadow = S_SampleShadowSpot(uLight.viewProj * vec4(position, 1.0), cNdotL); break;
+        case LIGHT_OMNI: shadow = S_SampleShadowOmni(position, cNdotL); break;
         }
     }
 

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -15,6 +15,7 @@
 /* === Includes === */
 
 #include "../include/blocks/light.glsl"
+#include "../include/blocks/shadow.glsl"
 #include "../include/blocks/view.glsl"
 #include "../include/math.glsl"
 #include "../include/pbr.glsl"
@@ -38,84 +39,6 @@ uniform samplerCubeArrayShadow uShadowOmniTex;
 
 layout(location = 0) out vec4 FragDiffuse;
 layout(location = 1) out vec4 FragSpecular;
-
-/* === Constants === */
-
-#define SHADOW_SAMPLES 8
-
-const vec2 VOGEL_DISK[8] = vec2[8](
-    vec2(0.250000, 0.000000),
-    vec2(-0.319290, 0.292496),
-    vec2(0.048872, -0.556877),
-    vec2(0.402444, 0.524918),
-    vec2(-0.738535, -0.130636),
-    vec2(0.699605, -0.445031),
-    vec2(-0.234004, 0.870484),
-    vec2(-0.446271, -0.859268)
-);
-
-/* === Shadow functions === */
-
-float ShadowDir(vec3 position, float cNdotL, mat2 diskRot)
-{
-    vec4 projPos = uLight.viewProj * vec4(position, 1.0);
-    vec3 projCoords = projPos.xyz / projPos.w * 0.5 + 0.5;
-
-    float bias = uLight.shadowSlopeBias * (1.0 - cNdotL);
-    bias = max(bias, uLight.shadowDepthBias * projCoords.z);
-    float compareDepth = projCoords.z - bias;
-
-    float shadow = 0.0;
-    for (int i = 0; i < SHADOW_SAMPLES; ++i) {
-        vec2 offset = diskRot * VOGEL_DISK[i] * uLight.shadowSoftness;
-        shadow += texture(uShadowDirTex, vec4(projCoords.xy + offset, uLight.shadowLayer, compareDepth));
-    }
-    shadow /= float(SHADOW_SAMPLES);
-
-    vec3 distToBorder = min(projCoords, 1.0 - projCoords);
-    float edgeFade = smoothstep(0.0, 0.15, min(distToBorder.x, min(distToBorder.y, distToBorder.z)));
-    shadow = mix(1.0, shadow, edgeFade);
-
-    return shadow;
-}
-
-float ShadowSpot(vec3 position, float cNdotL, mat2 diskRot)
-{
-    vec4 projPos = uLight.viewProj * vec4(position, 1.0);
-    vec3 projCoords = projPos.xyz / projPos.w * 0.5 + 0.5;
-
-    float bias = uLight.shadowSlopeBias * (1.0 - cNdotL);
-    bias = max(bias, uLight.shadowDepthBias * projCoords.z);
-    float compareDepth = projCoords.z - bias;
-
-    float shadow = 0.0;
-    for (int i = 0; i < SHADOW_SAMPLES; ++i) {
-        vec2 offset = diskRot * VOGEL_DISK[i] * uLight.shadowSoftness;
-        shadow += texture(uShadowSpotTex, vec4(projCoords.xy + offset, uLight.shadowLayer, compareDepth));
-    }
-
-    return shadow / float(SHADOW_SAMPLES);
-}
-
-float ShadowOmni(vec3 position, float cNdotL, mat2 diskRot)
-{
-    vec3 lightToFrag = position - uLight.position;
-    float currentDepth = length(lightToFrag);
-
-    float bias = uLight.shadowSlopeBias * (1.0 - cNdotL * 0.5);
-    bias = max(bias, uLight.shadowDepthBias * currentDepth);
-    float compareDepth = (currentDepth - bias) / uLight.far;
-
-    mat3 OBN = M_OrthonormalBasis(lightToFrag / currentDepth);
-
-    float shadow = 0.0;
-    for (int i = 0; i < SHADOW_SAMPLES; ++i) {
-        vec2 diskOffset = diskRot * VOGEL_DISK[i] * uLight.shadowSoftness;
-        shadow += texture(uShadowOmniTex, vec4(OBN * vec3(diskOffset.xy, 1.0), uLight.shadowLayer), compareDepth);
-    }
-
-    return shadow / float(SHADOW_SAMPLES);
-}
 
 /* === Main === */
 
@@ -188,9 +111,9 @@ void main()
 
     if (uLight.shadowLayer >= 0) {
         switch (uLight.type) {
-        case LIGHT_DIR: shadow = ShadowDir(position, cNdotL, diskRot); break;
-        case LIGHT_SPOT: shadow = ShadowSpot(position, cNdotL, diskRot); break;
-        case LIGHT_OMNI: shadow = ShadowOmni(position, cNdotL, diskRot); break;
+        case LIGHT_DIR:  shadow = S_SampleShadowDir(uLight, uShadowDirTex, uLight.viewProj * vec4(position, 1.0), cNdotL); break;
+        case LIGHT_SPOT: shadow = S_SampleShadowSpot(uLight, uShadowSpotTex, uLight.viewProj * vec4(position, 1.0), cNdotL); break;
+        case LIGHT_OMNI: shadow = S_SampleShadowOmni(uLight, uShadowOmniTex, position, cNdotL); break;
         }
     }
 

--- a/shaders/include/blocks/shadow.glsl
+++ b/shaders/include/blocks/shadow.glsl
@@ -36,11 +36,11 @@ mat2 S_DebandingRotationMatrix()
 }
 
 #ifdef NUM_FORWARD_LIGHTS
-float S_SampleShadowDir(int lightIndex, vec4 projPos, float cNdotL, mat2 diskRot)
+float S_SampleShadowDir(int lightIndex, vec4 projPos, float cNdotL)
 {
     #define light uLights[lightIndex]
 #else
-float S_SampleShadowDir(vec4 projPos, float cNdotL, mat2 diskRot)
+float S_SampleShadowDir(vec4 projPos, float cNdotL)
 {
     #define light uLight
 #endif 
@@ -49,6 +49,8 @@ float S_SampleShadowDir(vec4 projPos, float cNdotL, mat2 diskRot)
     float bias = light.shadowSlopeBias * (1.0 - cNdotL);
     bias = max(bias, light.shadowDepthBias * projCoords.z);
     float compareDepth = projCoords.z - bias;
+
+    mat2 diskRot = S_DebandingRotationMatrix();
 
     float shadow = 0.0;
     for (int i = 0; i < SHADOW_SAMPLES; ++i) {
@@ -67,11 +69,11 @@ float S_SampleShadowDir(vec4 projPos, float cNdotL, mat2 diskRot)
 }
 
 #ifdef NUM_FORWARD_LIGHTS
-float S_SampleShadowSpot(int lightIndex, vec4 projPos, float cNdotL, mat2 diskRot)
+float S_SampleShadowSpot(int lightIndex, vec4 projPos, float cNdotL)
 {
     #define light uLights[lightIndex]
 #else
-float S_SampleShadowSpot(vec4 projPos, float cNdotL, mat2 diskRot)
+float S_SampleShadowSpot(vec4 projPos, float cNdotL)
 {
     #define light uLight
 #endif 
@@ -80,6 +82,8 @@ float S_SampleShadowSpot(vec4 projPos, float cNdotL, mat2 diskRot)
     float bias = light.shadowSlopeBias * (1.0 - cNdotL);
     bias = max(bias, light.shadowDepthBias * projCoords.z);
     float compareDepth = projCoords.z - bias;
+
+    mat2 diskRot = S_DebandingRotationMatrix();
 
     float shadow = 0.0;
     for (int i = 0; i < SHADOW_SAMPLES; ++i) {
@@ -93,11 +97,11 @@ float S_SampleShadowSpot(vec4 projPos, float cNdotL, mat2 diskRot)
 }
 
 #ifdef NUM_FORWARD_LIGHTS
-float S_SampleShadowOmni(int lightIndex, vec3 fragPos, float cNdotL, mat2 diskRot)
+float S_SampleShadowOmni(int lightIndex, vec3 fragPos, float cNdotL)
 {
     #define light uLights[lightIndex]
 #else
-float S_SampleShadowOmni(vec3 fragPos, float cNdotL, mat2 diskRot)
+float S_SampleShadowOmni(vec3 fragPos, float cNdotL)
 {
     #define light uLight
 #endif 
@@ -107,6 +111,8 @@ float S_SampleShadowOmni(vec3 fragPos, float cNdotL, mat2 diskRot)
     float bias = light.shadowSlopeBias * (1.0 - cNdotL * 0.5);
     bias = max(bias, light.shadowDepthBias * currentDepth);
     float compareDepth = (currentDepth - bias) / light.far;
+
+    mat2 diskRot = S_DebandingRotationMatrix();    
 
     mat3 OBN = M_OrthonormalBasis(lightToFrag / currentDepth);
 

--- a/shaders/include/blocks/shadow.glsl
+++ b/shaders/include/blocks/shadow.glsl
@@ -1,0 +1,101 @@
+/* light.glsl -- Contains shadow map sampling functions
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+/* === Includes === */
+
+#include "light.glsl"
+#include "../math.glsl"
+
+/* === Constants === */
+
+#define SHADOW_SAMPLES 8
+
+const vec2 VOGEL_DISK[8] = vec2[8](
+    vec2(0.250000, 0.000000),
+    vec2(-0.319290, 0.292496),
+    vec2(0.048872, -0.556877),
+    vec2(0.402444, 0.524918),
+    vec2(-0.738535, -0.130636),
+    vec2(0.699605, -0.445031),
+    vec2(-0.234004, 0.870484),
+    vec2(-0.446271, -0.859268)
+);
+
+/* === Functions === */
+
+mat2 S_DebandingRotationMatrix()
+{
+    float r = M_TAU * M_HashIGN(gl_FragCoord.xy);
+    float sr = sin(r), cr = cos(r);
+    return mat2(vec2(cr, -sr), vec2(sr, cr));
+}
+float S_SampleShadowDir(Light light, sampler2DArrayShadow shadowTex, vec4 projPos, float cNdotL)
+{
+    vec3 projCoords = projPos.xyz / projPos.w * 0.5 + 0.5;
+
+    float bias = light.shadowSlopeBias * (1.0 - cNdotL);
+    bias = max(bias, light.shadowDepthBias * projCoords.z);
+    float compareDepth = projCoords.z - bias;
+
+    mat2 diskRot = S_DebandingRotationMatrix();
+
+    float shadow = 0.0;
+    for (int i = 0; i < SHADOW_SAMPLES; ++i) {
+        vec2 offset = diskRot * VOGEL_DISK[i] * light.shadowSoftness;
+        shadow += texture(shadowTex, vec4(projCoords.xy + offset, light.shadowLayer, compareDepth));
+    }
+    shadow /= float(SHADOW_SAMPLES);
+
+    vec3 distToBorder = min(projCoords, 1.0 - projCoords);
+    float edgeFade = smoothstep(0.0, 0.15, min(distToBorder.x, min(distToBorder.y, distToBorder.z)));
+    shadow = mix(1.0, shadow, edgeFade);
+
+    return shadow;
+}
+
+float S_SampleShadowSpot(Light light, sampler2DArrayShadow shadowTex, vec4 projPos, float cNdotL)
+{
+    vec3 projCoords = projPos.xyz / projPos.w * 0.5 + 0.5;
+
+    float bias = light.shadowSlopeBias * (1.0 - cNdotL);
+    bias = max(bias, light.shadowDepthBias * projCoords.z);
+    float compareDepth = projCoords.z - bias;
+
+    mat2 diskRot = S_DebandingRotationMatrix();
+
+    float shadow = 0.0;
+    for (int i = 0; i < SHADOW_SAMPLES; ++i) {
+        vec2 offset = diskRot * VOGEL_DISK[i] * light.shadowSoftness;
+        shadow += texture(shadowTex, vec4(projCoords.xy + offset, light.shadowLayer, compareDepth));
+    }
+
+   return shadow / float(SHADOW_SAMPLES);
+}
+
+float S_SampleShadowOmni(Light light, samplerCubeArrayShadow shadowTex, vec3 fragPos, float cNdotL)
+{
+    vec3 lightToFrag = fragPos - light.position;
+    float currentDepth = length(lightToFrag);
+
+    float bias = light.shadowSlopeBias * (1.0 - cNdotL * 0.5);
+    bias = max(bias, light.shadowDepthBias * currentDepth);
+    float compareDepth = (currentDepth - bias) / light.far;
+
+    mat3 OBN = M_OrthonormalBasis(lightToFrag / currentDepth);
+
+    mat2 diskRot = S_DebandingRotationMatrix();
+
+    float shadow = 0.0;
+    for (int i = 0; i < SHADOW_SAMPLES; ++i) {
+        vec2 diskOffset = diskRot * VOGEL_DISK[i] * light.shadowSoftness;
+        shadow += texture(shadowTex, vec4(OBN * vec3(diskOffset.xy, 1.0), light.shadowLayer), compareDepth);
+    }
+
+    return shadow / float(SHADOW_SAMPLES);
+}
+

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -96,6 +96,10 @@ void main()
     float NdotV = dot(N, V);
     float cNdotV = max(NdotV, 1e-4);  // Clamped to avoid division by zero
 
+    /*  Create a random rotation matrix for shadow debanding */
+
+    mat2 diskRot = S_DebandingRotationMatrix();
+
     /* Loop through all light sources accumulating diffuse and specular light */
 
     vec3 diffuse = vec3(0.0);
@@ -141,22 +145,15 @@ void main()
         vec3 specLight =  L_Specular(F0, cLdotH, cNdotH, cNdotV, cNdotL, ROUGHNESS);
         specLight *= lightColE * light.specular;
 
-        /*  Calculating a random rotation matrix for shadow debanding */
-
-        float r = M_TAU * M_HashIGN(gl_FragCoord.xy);
-        float sr = sin(r), cr = cos(r);
-
-        mat2 diskRot = mat2(vec2(cr, -sr), vec2(sr, cr));
-
         /* Apply shadow factor if the light casts shadows */
 
         float shadow = 1.0;
 
         if (light.shadowLayer >= 0) {
             switch (light.type) {
-            case LIGHT_DIR:  shadow = S_SampleShadowDir(light, uShadowDirTex, vPosLightSpace[i], cNdotL); break;
-            case LIGHT_SPOT: shadow = S_SampleShadowSpot(light, uShadowSpotTex, vPosLightSpace[i], cNdotL); break;
-            case LIGHT_OMNI: shadow = S_SampleShadowOmni(light, uShadowOmniTex, vPosition, cNdotL); break;
+            case LIGHT_DIR:  shadow = S_SampleShadowDir(i, vPosLightSpace[i], cNdotL, diskRot); break;
+            case LIGHT_SPOT: shadow = S_SampleShadowSpot(i, vPosLightSpace[i], cNdotL, diskRot); break;
+            case LIGHT_OMNI: shadow = S_SampleShadowOmni(i, vPosition, cNdotL, diskRot); break;
             }
         }
 

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -96,10 +96,6 @@ void main()
     float NdotV = dot(N, V);
     float cNdotV = max(NdotV, 1e-4);  // Clamped to avoid division by zero
 
-    /*  Create a random rotation matrix for shadow debanding */
-
-    mat2 diskRot = S_DebandingRotationMatrix();
-
     /* Loop through all light sources accumulating diffuse and specular light */
 
     vec3 diffuse = vec3(0.0);
@@ -151,9 +147,9 @@ void main()
 
         if (light.shadowLayer >= 0) {
             switch (light.type) {
-            case LIGHT_DIR:  shadow = S_SampleShadowDir(i, vPosLightSpace[i], cNdotL, diskRot); break;
-            case LIGHT_SPOT: shadow = S_SampleShadowSpot(i, vPosLightSpace[i], cNdotL, diskRot); break;
-            case LIGHT_OMNI: shadow = S_SampleShadowOmni(i, vPosition, cNdotL, diskRot); break;
+            case LIGHT_DIR:  shadow = S_SampleShadowDir(i, vPosLightSpace[i], cNdotL); break;
+            case LIGHT_SPOT: shadow = S_SampleShadowSpot(i, vPosLightSpace[i], cNdotL); break;
+            case LIGHT_OMNI: shadow = S_SampleShadowOmni(i, vPosition, cNdotL); break;
             }
         }
 

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -56,95 +56,12 @@ uniform bool uProbeInterior;
 /* === Blocks === */
 
 #include "../include/blocks/light.glsl"
+#include "../include/blocks/shadow.glsl"
 #include "../include/blocks/env.glsl"
-
-/* === Constants === */
-
-#define SHADOW_SAMPLES 8
-
-const vec2 VOGEL_DISK[8] = vec2[8](
-    vec2(0.250000, 0.000000),
-    vec2(-0.319290, 0.292496),
-    vec2(0.048872, -0.556877),
-    vec2(0.402444, 0.524918),
-    vec2(-0.738535, -0.130636),
-    vec2(0.699605, -0.445031),
-    vec2(-0.234004, 0.870484),
-    vec2(-0.446271, -0.859268)
-);
 
 /* === Fragments === */
 
 layout(location = 0) out vec4 FragColor;
-
-/* === Shadow functions === */
-
-float ShadowDir(int i, float cNdotL, mat2 diskRot)
-{
-    Light light = uLights[i];
-
-    vec4 p = vPosLightSpace[i];
-    vec3 projCoords = p.xyz / p.w * 0.5 + 0.5;
-
-    float bias = light.shadowSlopeBias * (1.0 - cNdotL);
-    bias = max(bias, light.shadowDepthBias * projCoords.z);
-    float compareDepth = projCoords.z - bias;
-
-    float shadow = 0.0;
-    for (int j = 0; j < SHADOW_SAMPLES; ++j) {
-        vec2 offset = diskRot * VOGEL_DISK[j] * light.shadowSoftness;
-        shadow += texture(uShadowDirTex, vec4(projCoords.xy + offset, float(light.shadowLayer), compareDepth));
-    }
-    shadow /= float(SHADOW_SAMPLES);
-
-    vec3 distToBorder = min(projCoords, 1.0 - projCoords);
-    float edgeFade = smoothstep(0.0, 0.15, min(distToBorder.x, min(distToBorder.y, distToBorder.z)));
-    shadow = mix(1.0, shadow, edgeFade);
-
-    return shadow;
-}
-
-float ShadowSpot(int i, float cNdotL, mat2 diskRot)
-{
-    Light light = uLights[i];
-
-    vec4 p = vPosLightSpace[i];
-    vec3 projCoords = p.xyz / p.w * 0.5 + 0.5;
-
-    float bias = light.shadowSlopeBias * (1.0 - cNdotL);
-    bias = max(bias, light.shadowDepthBias * projCoords.z);
-    float compareDepth = projCoords.z - bias;
-
-    float shadow = 0.0;
-    for (int j = 0; j < SHADOW_SAMPLES; ++j) {
-        vec2 offset = diskRot * VOGEL_DISK[j] * light.shadowSoftness;
-        shadow += texture(uShadowSpotTex, vec4(projCoords.xy + offset, float(light.shadowLayer), compareDepth));
-    }
-
-    return shadow / float(SHADOW_SAMPLES);
-}
-
-float ShadowOmni(int i, float cNdotL, mat2 diskRot)
-{
-    Light light = uLights[i];
-
-    vec3 lightToFrag = vPosition - light.position;
-    float currentDepth = length(lightToFrag);
-
-    float bias = light.shadowSlopeBias * (1.0 - cNdotL * 0.5);
-    bias = max(bias, light.shadowDepthBias * currentDepth);
-    float compareDepth = (currentDepth - bias) / light.far;
-
-    mat3 OBN = M_OrthonormalBasis(lightToFrag / currentDepth);
-
-    float shadow = 0.0;
-    for (int j = 0; j < SHADOW_SAMPLES; ++j) {
-        vec2 diskOffset = diskRot * VOGEL_DISK[j] * light.shadowSoftness;
-        shadow += texture(uShadowOmniTex, vec4(OBN * vec3(diskOffset.xy, 1.0), float(light.shadowLayer)), compareDepth);
-    }
-
-    return shadow / float(SHADOW_SAMPLES);
-}
 
 /* === User override === */
 
@@ -237,9 +154,9 @@ void main()
 
         if (light.shadowLayer >= 0) {
             switch (light.type) {
-            case LIGHT_DIR: shadow = ShadowDir(i, cNdotL, diskRot); break;
-            case LIGHT_SPOT: shadow = ShadowSpot(i, cNdotL, diskRot); break;
-            case LIGHT_OMNI: shadow = ShadowOmni(i, cNdotL, diskRot); break;
+            case LIGHT_DIR:  shadow = S_SampleShadowDir(light, uShadowDirTex, vPosLightSpace[i], cNdotL); break;
+            case LIGHT_SPOT: shadow = S_SampleShadowSpot(light, uShadowSpotTex, vPosLightSpace[i], cNdotL); break;
+            case LIGHT_OMNI: shadow = S_SampleShadowOmni(light, uShadowOmniTex, vPosition, cNdotL); break;
             }
         }
 


### PR DESCRIPTION
Replaces the mostly duplicated shadow sampling functions in forward and deferred rendering with a new shared included block. The main purpose being to eliminate duplicate code to make maintenance and customizing shadow sampling easier.

Any feedback welcomed.