### PR TITLE
Thread safe image format hint

### DIFF
--- a/src/importer/r3d_importer_texture.c
+++ b/src/importer/r3d_importer_texture.c
@@ -13,6 +13,7 @@
 #include <assimp/material.h>
 #include <assimp/texture.h>
 
+
 #ifdef _WIN32
 #   define NOGDI
 #   define NOUSER
@@ -248,9 +249,13 @@ static bool load_image_base(Image* outImage, bool* outOwned, const R3D_Importer*
         int textureIndex = atoi(&path[1]);
         const struct aiTexture* aiTex = r3d_importer_get_texture(importer, textureIndex);
 
+        char* formatHint = (char*)malloc(strlen(aiTex->achFormatHint) + 2);
+        formatHint[0] = '.';
+        strcpy(formatHint + 1, aiTex->achFormatHint);
+
         if (aiTex->mHeight == 0) {
             *outImage = LoadImageFromMemory(
-                TextFormat(".%s", aiTex->achFormatHint),
+                formatHint,
                 (const unsigned char*)aiTex->pcData,
                 aiTex->mWidth
             );
@@ -264,6 +269,8 @@ static bool load_image_base(Image* outImage, bool* outOwned, const R3D_Importer*
             outImage->data = aiTex->pcData;
             *outOwned = false;
         }
+
+        free(formatHint);
     }
     else {
         *outImage = LoadImage(path);

--- a/src/importer/r3d_importer_texture.c
+++ b/src/importer/r3d_importer_texture.c
@@ -13,7 +13,6 @@
 #include <assimp/material.h>
 #include <assimp/texture.h>
 
-
 #ifdef _WIN32
 #   define NOGDI
 #   define NOUSER
@@ -251,8 +250,7 @@ static bool load_image_base(Image* outImage, bool* outOwned, const R3D_Importer*
 
         if (aiTex->mHeight == 0) {
             char* formatHint = RL_MALLOC(strlen(aiTex->achFormatHint) + 2);
-            formatHint[0] = '.';
-            strcpy(formatHint + 1, aiTex->achFormatHint);
+            snprintf(formatHint, strlen(aiTex->achFormatHint) + 2, ".%s", aiTex->achFormatHint);
 
             *outImage = LoadImageFromMemory(
                 formatHint,

--- a/src/importer/r3d_importer_texture.c
+++ b/src/importer/r3d_importer_texture.c
@@ -249,17 +249,19 @@ static bool load_image_base(Image* outImage, bool* outOwned, const R3D_Importer*
         int textureIndex = atoi(&path[1]);
         const struct aiTexture* aiTex = r3d_importer_get_texture(importer, textureIndex);
 
-        char* formatHint = (char*)malloc(strlen(aiTex->achFormatHint) + 2);
-        formatHint[0] = '.';
-        strcpy(formatHint + 1, aiTex->achFormatHint);
-
         if (aiTex->mHeight == 0) {
+            char* formatHint = RL_MALLOC(strlen(aiTex->achFormatHint) + 2);
+            formatHint[0] = '.';
+            strcpy(formatHint + 1, aiTex->achFormatHint);
+
             *outImage = LoadImageFromMemory(
                 formatHint,
                 (const unsigned char*)aiTex->pcData,
                 aiTex->mWidth
             );
             *outOwned = (outImage->data != NULL);
+
+            RL_FREE(formatHint);
         }
         else {
             outImage->width = aiTex->mWidth;
@@ -269,8 +271,6 @@ static bool load_image_base(Image* outImage, bool* outOwned, const R3D_Importer*
             outImage->data = aiTex->pcData;
             *outOwned = false;
         }
-
-        free(formatHint);
     }
     else {
         *outImage = LoadImage(path);

--- a/src/importer/r3d_importer_texture.c
+++ b/src/importer/r3d_importer_texture.c
@@ -249,8 +249,8 @@ static bool load_image_base(Image* outImage, bool* outOwned, const R3D_Importer*
         const struct aiTexture* aiTex = r3d_importer_get_texture(importer, textureIndex);
 
         if (aiTex->mHeight == 0) {
-            char* formatHint = RL_MALLOC(strlen(aiTex->achFormatHint) + 2);
-            snprintf(formatHint, strlen(aiTex->achFormatHint) + 2, ".%s", aiTex->achFormatHint);
+            char formatHint[HINTMAXTEXTURELEN + 1];
+            snprintf(formatHint, sizeof(formatHint), ".%s", aiTex->achFormatHint);
 
             *outImage = LoadImageFromMemory(
                 formatHint,
@@ -258,8 +258,6 @@ static bool load_image_base(Image* outImage, bool* outOwned, const R3D_Importer*
                 aiTex->mWidth
             );
             *outOwned = (outImage->data != NULL);
-
-            RL_FREE(formatHint);
         }
         else {
             outImage->width = aiTex->mWidth;


### PR DESCRIPTION
Using Raylib's `TextFormat` was causing problems when creating the image format hint to pass to `LoadImageFromMemory` when using multiple threads. `TextFormat` keeps a fixed number of buffers and these were being overwitten when the number of threads using it to create strings exceeded the amount of buffers being used.

Feel free to handle this in a different manner, but this was the cause of textures not loading correctly when using `R3D_LoadModel`.