### PR TITLE
New built-in variables for custom shaders

### DIFF
--- a/docs/shaders/screen_shader.md
+++ b/docs/shaders/screen_shader.md
@@ -78,6 +78,8 @@ Screen shaders provide built-in variables for screen-space operations:
 | `TEXEL_SIZE` | `vec2` | Size of one texel (1.0 / RESOLUTION) |
 | `RESOLUTION` | `vec2` | Screen resolution in pixels |
 | `ASPECT` | `float` | Screen aspect ratio |
+| `FRAME_INDEX` | `int` | Index incremented at each frame |
+| `TIME` | `float` | Time provided by the raylib's `GetTime()` |
 | `COLOR` | `vec3` | Output color (write to this) |
 
 ### Usage Examples

--- a/docs/shaders/surface_shader.md
+++ b/docs/shaders/surface_shader.md
@@ -99,6 +99,10 @@ All vertex-stage variables are initialized with local (pre-transformation) attri
 
 | Variable | Type | Description |
 |----------|------|-------------|
+| `MATRIX_MODEL` | `mat4` | Model matrix (read-only). |
+| `MATRIX_NORMAL` | `mat3` | Normal matrix (read-only). |
+| `MATRIX_INV_VIEW` | `mat4` | Inverse view matrix (read-only). |
+| `MATRIX_VIEW_PROJECTION` | `mat4` | View-projection matrix (read-only). |
 | `POSITION` | `vec3` | Vertex position (local space) |
 | `TEXCOORD` | `vec2` | Texture coordinates |
 | `NORMAL` | `vec3` | Vertex normal (local space) |
@@ -112,6 +116,10 @@ All vertex-stage variables are initialized with local (pre-transformation) attri
 | `INSTANCE_CUSTOM` | `vec4` | Custom user-defined instance data |
 | `FRAME_INDEX` | `int` | Index incremented at each frame |
 | `TIME` | `float` | Time provided by the raylib's `GetTime()` |
+
+> [!WARNING]
+> Mesh attributes (`POSITION`, `NORMAL`, etc.) are provided in **local space** and must remain in local space.
+> You should **not manually apply model, view, or projection transformations** to them.
 
 **Instance Variables:**
 

--- a/docs/shaders/surface_shader.md
+++ b/docs/shaders/surface_shader.md
@@ -110,6 +110,8 @@ All vertex-stage variables are initialized with local (pre-transformation) attri
 | `INSTANCE_SCALE` | `vec3` | Instance scale |
 | `INSTANCE_COLOR` | `vec4` | Instance color |
 | `INSTANCE_CUSTOM` | `vec4` | Custom user-defined instance data |
+| `FRAME_INDEX` | `int` | Index incremented at each frame |
+| `TIME` | `float` | Time provided by the raylib's `GetTime()` |
 
 **Instance Variables:**
 
@@ -181,6 +183,8 @@ Fragment-stage variables are pre-initialized with material values (unless `R3D_N
 | `OCCLUSION` | `float` | Ambient occlusion |
 | `ROUGHNESS` | `float` | Surface roughness (0 = smooth, 1 = rough) |
 | `METALNESS` | `float` | Metallic property (0 = dielectric, 1 = metal) |
+| `FRAME_INDEX` | `int` | Index incremented at each frame |
+| `TIME` | `float` | Time provided by the raylib's `GetTime()` |
 
 **Example:**
 ```glsl

--- a/docs/shaders/surface_shader.md
+++ b/docs/shaders/surface_shader.md
@@ -99,10 +99,10 @@ All vertex-stage variables are initialized with local (pre-transformation) attri
 
 | Variable | Type | Description |
 |----------|------|-------------|
-| `MATRIX_MODEL` | `mat4` | Model matrix (read-only). |
-| `MATRIX_NORMAL` | `mat3` | Normal matrix (read-only). |
-| `MATRIX_INV_VIEW` | `mat4` | Inverse view matrix (read-only). |
-| `MATRIX_VIEW_PROJECTION` | `mat4` | View-projection matrix (read-only). |
+| `MATRIX_MODEL` | `mat4` | Model matrix (read-only) |
+| `MATRIX_NORMAL` | `mat3` | Normal matrix (read-only) |
+| `MATRIX_INV_VIEW` | `mat4` | Inverse view matrix (read-only) |
+| `MATRIX_VIEW_PROJECTION` | `mat4` | View-projection matrix (read-only) |
 | `POSITION` | `vec3` | Vertex position (local space) |
 | `TEXCOORD` | `vec2` | Texture coordinates |
 | `NORMAL` | `vec3` | Vertex normal (local space) |
@@ -181,6 +181,7 @@ Fragment-stage variables are pre-initialized with material values (unless `R3D_N
 | Variable | Type | Description |
 |----------|------|-------------|
 | `TEXCOORD` | `vec2` | Interpolated texture coordinates |
+| `POSITION` | `vec3` | Interpolated fragments's world position (read-only) |
 | `NORMAL` | `vec3` | Surface normal (world space) |
 | `TANGENT` | `vec3` | Surface tangent |
 | `BITANGENT` | `vec3` | Surface bitangent |

--- a/examples/resources/shaders/material.glsl
+++ b/examples/resources/shaders/material.glsl
@@ -1,12 +1,12 @@
 #pragma usage opaque shadow
 
 uniform sampler2D u_texture;
-uniform float u_time;
+uniform float u_time_scale;
 
 flat varying float v_time;
 
 void vertex() {
-    v_time = 0.5 * sin(u_time) + 0.5;
+    v_time = 0.5 * sin(TIME * u_time_scale) + 0.5;
     POSITION *= 1.0 + v_time;
 }
 

--- a/examples/resources/shaders/screen.glsl
+++ b/examples/resources/shaders/screen.glsl
@@ -1,8 +1,9 @@
-uniform float u_time;
+uniform float u_time_scale;
 
 void fragment() {
     vec2 uv = TEXCOORD * 2.0 - 1.0;
-    uv.x += sin(uv.y * 10.0 + u_time * 3.0) * 0.01;
-    uv.y += sin(uv.x * 10.0 + u_time * 2.0) * 0.01;
+    float time = TIME * u_time_scale;
+    uv.x += sin(uv.y * 10.0 + time * 3.0) * 0.01;
+    uv.y += sin(uv.x * 10.0 + time * 2.0) * 0.01;
     COLOR = SampleColor(uv * 0.5 + 0.5);
 }

--- a/examples/shader.c
+++ b/examples/shader.c
@@ -31,12 +31,16 @@ int main(void)
     Texture texture = LoadTextureFromImage(image);
     UnloadImage(image);
 
-    // Set custom sampler
+    // Set material custom uniform/sampler
     R3D_SetSurfaceShaderSampler(material.shader, "u_texture", texture);
+    R3D_SetSurfaceShaderUniform(material.shader, "u_time_scale", (float[]){0.75f});
 
     // Load a screen shader
     R3D_ScreenShader* shader = R3D_LoadScreenShader(RESOURCES_PATH "shaders/screen.glsl");
     R3D_SetScreenShaderChain(&shader, 1);
+
+    // Set screen custom unforms
+    R3D_SetScreenShaderUniform(shader, "u_time_scale", (float[]){2.5f});
 
     // Create light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
@@ -59,16 +63,10 @@ int main(void)
 
         BeginDrawing();
             ClearBackground(RAYWHITE);
-
-            float time = 2.0f * GetTime();
-            R3D_SetScreenShaderUniform(shader, "u_time", &time);
-            R3D_SetSurfaceShaderUniform(material.shader, "u_time", &time);
-
             R3D_Begin(camera);
                 R3D_DrawMesh(plane, R3D_MATERIAL_BASE, (Vector3) {0, -0.5f, 0}, 1.0f);
                 R3D_DrawMesh(torus, material, Vector3Zero(), 1.0f);
             R3D_End();
-
         EndDrawing();
     }
 

--- a/shaders/include/blocks/frame.glsl
+++ b/shaders/include/blocks/frame.glsl
@@ -1,0 +1,18 @@
+/* frame.glsl -- Contains all the information about the current frame.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+struct Frame {
+    vec2 screenSize;
+    vec2 texelSize;
+    float time;
+    int index;
+};
+
+layout(std140) uniform FrameBlock {
+    Frame uFrame;
+};

--- a/shaders/include/smaa.glsl
+++ b/shaders/include/smaa.glsl
@@ -6,10 +6,10 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-uniform vec4 uMetrics;
+#include "../include/blocks/frame.glsl"
 
 #define SMAA_GLSL_3
-#define SMAA_RT_METRICS uMetrics
+#define SMAA_RT_METRICS vec4(uFrame.texelSize, uFrame.screenSize)
 
 #if QUALITY_PRESET == 0
 #   define SMAA_PRESET_LOW

--- a/shaders/include/user/scene.frag
+++ b/shaders/include/user/scene.frag
@@ -6,6 +6,10 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
+/* === Built-In Constants === */
+
+#define POSITION vPosition
+
 /* === Built-In Input Variables === */
 
 vec2 TEXCOORD  = vec2(0.0);

--- a/shaders/include/user/scene.frag
+++ b/shaders/include/user/scene.frag
@@ -23,6 +23,11 @@ float OCCLUSION     = 0.0;
 float ROUGHNESS     = 0.0;
 float METALNESS     = 0.0;
 
+/* === Built-In Constants === */
+
+int FRAME_INDEX = 0;
+float TIME = 0.0;
+
 /* === User Callable === */
 
 vec4 SampleAlbedo(vec2 texCoord)
@@ -107,6 +112,11 @@ void SceneFragment(vec2 texCoord, mat3 tbn, float alphaCutoff)
 
 #endif // !R3D_NO_AUTO_FETCH && !UNLIT && !DEPTH && !DEPTH_CUBE
 #endif // !R3D_NO_AUTO_FETCH
+
+    /* --- Fill constants --- */
+
+    FRAME_INDEX = uFrame.index;
+    TIME = uFrame.time;
 
     /* --- Execute user code --- */
 

--- a/shaders/include/user/scene.frag
+++ b/shaders/include/user/scene.frag
@@ -8,22 +8,22 @@
 
 /* === Built-In Input Variables === */
 
-vec2 TEXCOORD       = vec2(0.0);
-vec3 TANGENT        = vec3(0.0);
-vec3 BITANGENT      = vec3(0.0);
-vec3 NORMAL         = vec3(0.0);
+vec2 TEXCOORD  = vec2(0.0);
+vec3 TANGENT   = vec3(0.0);
+vec3 BITANGENT = vec3(0.0);
+vec3 NORMAL    = vec3(0.0);
 
 /* === Built-In Output Variables === */
 
-vec3 ALBEDO         = vec3(0.0);
-float ALPHA         = 0.0;
-vec3 EMISSION       = vec3(0.0);
-vec3 NORMAL_MAP     = vec3(0.0);
-float OCCLUSION     = 0.0;
-float ROUGHNESS     = 0.0;
-float METALNESS     = 0.0;
+vec3 ALBEDO     = vec3(0.0);
+float ALPHA     = 0.0;
+vec3 EMISSION   = vec3(0.0);
+vec3 NORMAL_MAP = vec3(0.0);
+float OCCLUSION = 0.0;
+float ROUGHNESS = 0.0;
+float METALNESS = 0.0;
 
-/* === Built-In Constants === */
+/* === Built-In Globals === */
 
 int FRAME_INDEX = 0;
 float TIME = 0.0;

--- a/shaders/include/user/scene.vert
+++ b/shaders/include/user/scene.vert
@@ -6,6 +6,19 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
+/* === Built-In Constants === */
+
+#define MATRIX_MODEL    uMatModel
+#define MATRIX_NORMAL   mat3(uMatNormal)
+
+#if defined(UNLIT) || defined(DEPTH) || defined(DEPTH_CUBE) || defined(PROBE)
+#   define MATRIX_INV_VIEW          uMatInvView
+#   define MATRIX_VIEW_PROJECTION   uMatViewProj
+#else
+#   define MATRIX_INV_VIEW          uView.invView
+#   define MATRIX_VIEW_PROJECTION   uView.viewProj
+#endif
+
 /* === Built-In Output Variables === */
 
 vec3 POSITION = vec3(0.0);
@@ -21,7 +34,7 @@ vec3 INSTANCE_SCALE    = vec3(0.0);
 vec4 INSTANCE_COLOR    = vec4(0.0);
 vec4 INSTANCE_CUSTOM   = vec4(0.0);
 
-/* === Built-In Constants === */
+/* === Built-In Globals === */
 
 int FRAME_INDEX = 0;
 float TIME = 0.0;

--- a/shaders/include/user/scene.vert
+++ b/shaders/include/user/scene.vert
@@ -6,18 +6,27 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-vec3 POSITION;
-vec2 TEXCOORD;
-vec3 EMISSION;
-vec4 COLOR;
-vec4 TANGENT;
-vec3 NORMAL;
+/* === Built-In Output Variables === */
 
-vec3 INSTANCE_POSITION;
-vec4 INSTANCE_ROTATION;
-vec3 INSTANCE_SCALE;
-vec4 INSTANCE_COLOR;
-vec4 INSTANCE_CUSTOM;
+vec3 POSITION = vec3(0.0);
+vec2 TEXCOORD = vec2(0.0);
+vec3 EMISSION = vec3(0.0);
+vec4 COLOR    = vec4(0.0);
+vec4 TANGENT  = vec4(0.0);
+vec3 NORMAL   = vec3(0.0);
+
+vec3 INSTANCE_POSITION = vec3(0.0);
+vec4 INSTANCE_ROTATION = vec4(0.0);
+vec3 INSTANCE_SCALE    = vec3(0.0);
+vec4 INSTANCE_COLOR    = vec4(0.0);
+vec4 INSTANCE_CUSTOM   = vec4(0.0);
+
+/* === Built-In Constants === */
+
+int FRAME_INDEX = 0;
+float TIME = 0.0;
+
+/* === Internal Vertex Stage === */
 
 #define vertex()
 
@@ -35,6 +44,9 @@ void SceneVertex()
     COLOR = aColor * uAlbedoColor;
     TANGENT = aTangent;
     NORMAL = aNormal;
+
+    FRAME_INDEX = uFrame.index;
+    TIME = uFrame.time;
 
     vertex();
 }

--- a/shaders/post/fxaa.frag
+++ b/shaders/post/fxaa.frag
@@ -47,6 +47,10 @@
 
 #include "../external/Fxaa3_11.h"
 
+/* === Includes === */
+
+#include "../include/blocks/frame.glsl"
+
 /* === Varyings === */
 
 noperspective in vec2 vTexCoord;
@@ -54,7 +58,6 @@ noperspective in vec2 vTexCoord;
 /* === Uniforms === */
 
 uniform sampler2D uSceneTex;
-uniform vec2 uSceneTexel;
 
 /* === Fragments === */
 
@@ -65,8 +68,8 @@ out vec4 FragColor;
 void main()
 {
     vec4 fxaaConsolePosPos = FxaaFloat4(
-        vTexCoord - (0.5 * uSceneTexel),
-        vTexCoord + (0.5 * uSceneTexel)
+        vTexCoord - (0.5 * uFrame.texelSize),
+        vTexCoord + (0.5 * uFrame.texelSize)
     );
 
     vec4 dummy = vec4(0.0);
@@ -77,7 +80,7 @@ void main()
         uSceneTex,                  // tex
         uSceneTex,                  // fxaaConsole360TexExpBiasNegOne
         uSceneTex,                  // fxaaConsole360TexExpBiasNegTwo
-        uSceneTexel,                // fxaaQualityRcpFrame
+        uFrame.texelSize,           // fxaaQualityRcpFrame
         vec4(0.0),                  // fxaaConsoleRcpFrameOpt
         vec4(0.0),                  // fxaaConsoleRcpFrameOpt2
         vec4(0.0),                  // fxaaConsole360RcpFrameOpt2

--- a/shaders/post/screen.frag
+++ b/shaders/post/screen.frag
@@ -10,6 +10,7 @@
 
 /* === Includes === */
 
+#include "../include/blocks/frame.glsl"
 #include "../include/blocks/view.glsl"
 
 /* === Varyings === */
@@ -21,8 +22,6 @@ noperspective in vec2 vTexCoord;
 uniform sampler2D uSceneTex;
 uniform sampler2D uNormalTex;
 uniform sampler2D uDepthTex;
-uniform vec2 uResolution;
-uniform vec2 uTexelSize;
 
 /* === Fragments === */
 
@@ -104,8 +103,8 @@ void main()
     TEXCOORD = vTexCoord;
     PIXCOORD = ivec2(gl_FragCoord.xy);
 
-    TEXEL_SIZE = uTexelSize;
-    RESOLUTION = uResolution;
+    TEXEL_SIZE = uFrame.texelSize;
+    RESOLUTION = uFrame.screenSize;
     ASPECT = uView.aspect;
 
     fragment();

--- a/shaders/post/screen.frag
+++ b/shaders/post/screen.frag
@@ -36,6 +36,9 @@ vec2 TEXEL_SIZE = vec2(0.0);
 vec2 RESOLUTION = vec2(0.0);
 float ASPECT = 0.0;
 
+int FRAME_INDEX = 0;
+float TIME = 0.0;
+
 /* === Built-In Output Variables === */
 
 vec3 COLOR = vec3(0.0);
@@ -106,6 +109,9 @@ void main()
     TEXEL_SIZE = uFrame.texelSize;
     RESOLUTION = uFrame.screenSize;
     ASPECT = uView.aspect;
+
+    FRAME_INDEX = uFrame.index;
+    TIME = uFrame.time;
 
     fragment();
 

--- a/shaders/scene/decal.frag
+++ b/shaders/scene/decal.frag
@@ -11,6 +11,7 @@
 
 /* === Includes === */
 
+#include "../include/blocks/frame.glsl"
 #include "../include/blocks/view.glsl"
 #include "../include/math.glsl"
 

--- a/shaders/scene/decal.frag
+++ b/shaders/scene/decal.frag
@@ -17,6 +17,7 @@
 
 /* === Varyings === */
 
+smooth in vec3 vPosition;           //< For custom shaders
 smooth in mat4 vDecalProjection;
 smooth in mat3 vDecalAxes;
 flat   in vec3 vEmission;

--- a/shaders/scene/depth.frag
+++ b/shaders/scene/depth.frag
@@ -8,6 +8,10 @@
 
 #version 330 core
 
+/* === Includes === */
+
+#include "../include/blocks/frame.glsl"
+
 /* === Varyings === */
 
 smooth in vec2 vTexCoord;

--- a/shaders/scene/depth.frag
+++ b/shaders/scene/depth.frag
@@ -14,6 +14,7 @@
 
 /* === Varyings === */
 
+smooth in vec3 vPosition;       //< For custom shaders
 smooth in vec2 vTexCoord;
 smooth in vec4 vColor;
 

--- a/shaders/scene/depth_cube.frag
+++ b/shaders/scene/depth_cube.frag
@@ -8,6 +8,10 @@
 
 #version 330 core
 
+/* === Includes === */
+
+#include "../include/blocks/frame.glsl"
+
 /* === Varyings === */
 
 smooth in vec3 vPosition;

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -57,6 +57,7 @@ uniform bool uProbeInterior;
 
 #define L_SHADOW_IMPL   //< Shadow functions in blocks/light.glsl
 
+#include "../include/blocks/frame.glsl"
 #include "../include/blocks/light.glsl"
 #include "../include/blocks/env.glsl"
 

--- a/shaders/scene/geometry.frag
+++ b/shaders/scene/geometry.frag
@@ -16,6 +16,7 @@
 
 /* === Varyings === */
 
+smooth in vec3 vPosition;       //< For custom shaders
 smooth in vec2 vTexCoord;
 flat   in vec3 vEmission;
 smooth in vec4 vColor;

--- a/shaders/scene/geometry.frag
+++ b/shaders/scene/geometry.frag
@@ -10,6 +10,7 @@
 
 /* === Includes === */
 
+#include "../include/blocks/frame.glsl"
 #include "../include/blocks/view.glsl"
 #include "../include/math.glsl"
 

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -16,6 +16,7 @@
 
 /* === Includes === */
 
+#include "../include/blocks/frame.glsl"
 #include "../include/blocks/light.glsl"
 #include "../include/blocks/view.glsl"
 #include "../include/math.glsl"

--- a/shaders/scene/unlit.frag
+++ b/shaders/scene/unlit.frag
@@ -8,6 +8,10 @@
 
 #version 330 core
 
+/* === Includes === */
+
+#include "../include/blocks/frame.glsl"
+
 /* === Varyings === */
 
 smooth in vec2 vTexCoord;

--- a/shaders/scene/unlit.frag
+++ b/shaders/scene/unlit.frag
@@ -14,6 +14,7 @@
 
 /* === Varyings === */
 
+smooth in vec3 vPosition;       //< For custom shaders
 smooth in vec2 vTexCoord;
 smooth in vec4 vColor;
 

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -566,7 +566,7 @@ static bool load_prepare_smaa_edge_detection(r3d_shader_custom_t* custom, int in
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    GET_LOCATION(smaaEdgeDetection, uMetrics);
+    SET_UNIFORM_BUFFER(smaaEdgeDetection, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
 
     USE_SHADER(smaaEdgeDetection);
     SET_SAMPLER(smaaEdgeDetection, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
@@ -611,7 +611,7 @@ static bool load_prepare_smaa_blending_weights(r3d_shader_custom_t* custom, int 
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    GET_LOCATION(smaaBlendingWeights, uMetrics);
+    SET_UNIFORM_BUFFER(smaaBlendingWeights, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
 
     USE_SHADER(smaaBlendingWeights);
     SET_SAMPLER(smaaBlendingWeights, uEdgesTex, R3D_SHADER_SAMPLER_BUFFER_SMAA_EDGES);
@@ -733,6 +733,7 @@ bool r3d_shader_load_scene_geometry(r3d_shader_custom_t* custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
+    SET_UNIFORM_BUFFER(geometry, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
     SET_UNIFORM_BUFFER(geometry, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
@@ -798,6 +799,7 @@ bool r3d_shader_load_scene_forward(r3d_shader_custom_t* custom)
     RL_FREE(fsCode);
 
     SET_UNIFORM_BUFFER(forward, LightArrayBlock, R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT);
+    SET_UNIFORM_BUFFER(forward, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
     SET_UNIFORM_BUFFER(forward, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(forward, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
@@ -862,6 +864,8 @@ bool r3d_shader_load_scene_unlit(r3d_shader_custom_t *custom)
 
     RL_FREE(vsCode);
     RL_FREE(fsCode);
+
+    SET_UNIFORM_BUFFER(unlit, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
         SET_UNIFORM_BUFFER(unlit, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
@@ -939,6 +943,8 @@ bool r3d_shader_load_scene_depth(r3d_shader_custom_t* custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
+    SET_UNIFORM_BUFFER(depth, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
+
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
         SET_UNIFORM_BUFFER(depth, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
     }
@@ -986,6 +992,8 @@ bool r3d_shader_load_scene_depth_cube(r3d_shader_custom_t* custom)
 
     RL_FREE(vsCode);
     RL_FREE(fsCode);
+
+    SET_UNIFORM_BUFFER(depthCube, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
         SET_UNIFORM_BUFFER(depthCube, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
@@ -1044,6 +1052,7 @@ bool r3d_shader_load_scene_probe(r3d_shader_custom_t* custom)
     RL_FREE(fsCode);
 
     SET_UNIFORM_BUFFER(probe, LightArrayBlock, R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT);
+    SET_UNIFORM_BUFFER(probe, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
     SET_UNIFORM_BUFFER(probe, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
     SET_UNIFORM_BUFFER(probe, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
 
@@ -1112,6 +1121,7 @@ bool r3d_shader_load_scene_decal(r3d_shader_custom_t* custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
+    SET_UNIFORM_BUFFER(decal, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
     SET_UNIFORM_BUFFER(decal, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
@@ -1287,12 +1297,12 @@ bool r3d_shader_load_post_screen(r3d_shader_custom_t* custom)
     LOAD_SHADER(screen, SCREEN_VERT, fragCode);
     RL_FREE(fragCode);
 
+    SET_UNIFORM_BUFFER(screen, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
+    SET_UNIFORM_BUFFER(screen, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+
     if (custom->userCode && strstr(custom->userCode, "UserBlock") != NULL) {
         SET_UNIFORM_BUFFER(screen, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
     }
-
-    GET_LOCATION(screen, uResolution);
-    GET_LOCATION(screen, uTexelSize);
 
     USE_SHADER(screen);
     SET_SAMPLER(screen, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
@@ -1337,7 +1347,7 @@ static bool load_post_fxaa(r3d_shader_custom_t* custom, int index)
 
     RL_FREE(fsCode);
 
-    GET_LOCATION(fxaa, uSceneTexel);
+    SET_UNIFORM_BUFFER(fxaa, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
 
     USE_SHADER(fxaa);
     SET_SAMPLER(fxaa, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
@@ -1382,7 +1392,7 @@ static bool load_post_smaa(r3d_shader_custom_t* custom, int index)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    GET_LOCATION(smaa, uMetrics);
+    SET_UNIFORM_BUFFER(smaa, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
 
     USE_SHADER(smaa);
     SET_SAMPLER(smaa, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
@@ -1433,6 +1443,7 @@ bool r3d_shader_init()
     memset(&R3D_MOD_SHADER, 0, sizeof(R3D_MOD_SHADER));
 
     const int UNIFORM_BUFFER_SIZES[R3D_SHADER_BLOCK_COUNT] = {
+        [R3D_SHADER_BLOCK_FRAME] = sizeof(r3d_shader_block_frame_t),
         [R3D_SHADER_BLOCK_VIEW] = sizeof(r3d_shader_block_view_t),
         [R3D_SHADER_BLOCK_ENV] = sizeof(r3d_shader_block_env_t),
         [R3D_SHADER_BLOCK_LIGHT] = sizeof(r3d_shader_block_light_t),
@@ -1530,6 +1541,10 @@ void r3d_shader_set_uniform_block(r3d_shader_block_t block, const void* data)
     int blockSize = 0;
 
     switch (block) {
+    case R3D_SHADER_BLOCK_FRAME:
+        blockSlot = R3D_SHADER_BLOCK_FRAME_SLOT;
+        blockSize = sizeof(r3d_shader_block_frame_t);
+        break;
     case R3D_SHADER_BLOCK_VIEW:
         blockSlot = R3D_SHADER_BLOCK_VIEW_SLOT;
         blockSize = sizeof(r3d_shader_block_view_t);

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -24,11 +24,12 @@
 // MODULE CONSTANTS
 // ========================================
 
-#define R3D_SHADER_BLOCK_VIEW_SLOT          0
-#define R3D_SHADER_BLOCK_ENV_SLOT           1
-#define R3D_SHADER_BLOCK_LIGHT_SLOT         2
-#define R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT   3
-#define R3D_SHADER_BLOCK_USER_SLOT          4
+#define R3D_SHADER_BLOCK_FRAME_SLOT         0
+#define R3D_SHADER_BLOCK_VIEW_SLOT          1
+#define R3D_SHADER_BLOCK_ENV_SLOT           2
+#define R3D_SHADER_BLOCK_LIGHT_SLOT         3
+#define R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT   4
+#define R3D_SHADER_BLOCK_USER_SLOT          5
 
 // ========================================
 // SHADER MANAGEMENT MACROS
@@ -461,6 +462,7 @@ typedef struct { int loc; } r3d_shader_uniform_mat4_t;
 // ========================================
 
 typedef enum {
+    R3D_SHADER_BLOCK_FRAME,
     R3D_SHADER_BLOCK_VIEW,
     R3D_SHADER_BLOCK_ENV,
     R3D_SHADER_BLOCK_LIGHT,
@@ -471,6 +473,13 @@ typedef enum {
 // ========================================
 // UNIFORM BLOCK STRUCTS
 // ========================================
+
+typedef struct {
+    alignas(8) Vector2 screenSize;
+    alignas(8) Vector2 texelSize;
+    alignas(4) float time;
+    alignas(4) int index;
+} r3d_shader_block_frame_t;
 
 typedef struct {
     alignas(16) Vector3 position;
@@ -702,7 +711,6 @@ typedef struct {
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSceneTex;
-    r3d_shader_uniform_vec4_t uMetrics;
 } r3d_shader_prepare_smaa_edge_detection_t;
 
 typedef struct {
@@ -710,7 +718,6 @@ typedef struct {
     r3d_shader_uniform_sampler_t uEdgesTex;
     r3d_shader_uniform_sampler_t uAreaTex;
     r3d_shader_uniform_sampler_t uSearchTex;
-    r3d_shader_uniform_vec4_t uMetrics;
 } r3d_shader_prepare_smaa_blending_weights_t;
 
 typedef struct {
@@ -1005,8 +1012,6 @@ typedef struct {
     r3d_shader_uniform_sampler_t uSceneTex;
     r3d_shader_uniform_sampler_t uNormalTex;
     r3d_shader_uniform_sampler_t uDepthTex;
-    r3d_shader_uniform_vec2_t uResolution;
-    r3d_shader_uniform_vec2_t uTexelSize;
 } r3d_shader_post_screen_t;
 
 typedef struct {
@@ -1023,14 +1028,12 @@ typedef struct {
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSceneTex;
-    r3d_shader_uniform_vec2_t uSceneTexel;
 } r3d_shader_post_fxaa_t;
 
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSceneTex;
     r3d_shader_uniform_sampler_t uBlendTex;
-    r3d_shader_uniform_vec4_t uMetrics;
 } r3d_shader_post_smaa_t;
 
 typedef struct {

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -29,7 +29,6 @@
 #include "./modules/r3d_render.h"
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_env.h"
-#include "raylib.h"
 
 // ========================================
 // HELPER MACROS

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -29,6 +29,7 @@
 #include "./modules/r3d_render.h"
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_env.h"
+#include "raylib.h"
 
 // ========================================
 // HELPER MACROS
@@ -50,6 +51,7 @@
 
 static void update_view_state(Camera3D camera, double near, double far);
 static void upload_light_array_block_for_mesh(const r3d_render_call_t* call, bool shadow);
+static void upload_frame_block(void);
 static void upload_view_block(void);
 static void upload_env_block(void);
 
@@ -117,6 +119,7 @@ void R3D_End(void)
 
     /* --- Upload and bind uniform buffers --- */
 
+    upload_frame_block();
     upload_view_block();
     upload_env_block();
 
@@ -621,6 +624,20 @@ void upload_light_array_block_for_mesh(const r3d_render_call_t* call, bool shado
     }
 
     r3d_shader_set_uniform_block(R3D_SHADER_BLOCK_LIGHT_ARRAY, &lights);
+}
+
+void upload_frame_block(void)
+{
+    static int frameIndex = 0;
+
+    r3d_shader_block_frame_t frame = {
+        .screenSize = (Vector2) {(float)R3D_TARGET_WIDTH, (float)R3D_TARGET_HEIGHT},
+        .texelSize = (Vector2) {(float)R3D_TARGET_TEXEL_WIDTH, (float)R3D_TARGET_TEXEL_HEIGHT},
+        .time = (float)GetTime(),
+        .index = frameIndex++,
+    };
+
+    r3d_shader_set_uniform_block(R3D_SHADER_BLOCK_FRAME, &frame);
 }
 
 void upload_view_block(void)
@@ -2135,9 +2152,6 @@ r3d_target_t pass_post_screen(r3d_target_t sceneTarget)
         R3D_SHADER_BIND_SAMPLER_CUSTOM(shader, post.screen, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));
         R3D_SHADER_BIND_SAMPLER_CUSTOM(shader, post.screen, uDepthTex, r3d_target_get(R3D_TARGET_DEPTH));
 
-        R3D_SHADER_SET_VEC2_CUSTOM(shader, post.screen, uResolution, (Vector2) {(float)R3D_TARGET_WIDTH, (float)R3D_TARGET_HEIGHT});
-        R3D_SHADER_SET_VEC2_CUSTOM(shader, post.screen, uTexelSize, (Vector2) {(float)R3D_TARGET_TEXEL_WIDTH, (float)R3D_TARGET_TEXEL_HEIGHT});
-
         R3D_RENDER_SCREEN();
     }
 
@@ -2169,8 +2183,6 @@ r3d_target_t pass_post_fxaa(r3d_target_t sceneTarget)
     R3D_SHADER_USE(post.fxaa[R3D.aaPreset]);
 
     R3D_SHADER_BIND_SAMPLER(post.fxaa[R3D.aaPreset], uSceneTex, r3d_target_get(sceneTarget));
-    R3D_SHADER_SET_VEC2(post.fxaa[R3D.aaPreset], uSceneTexel, (Vector2) {(float)R3D_TARGET_TEXEL_WIDTH, (float)R3D_TARGET_TEXEL_HEIGHT});
-
     R3D_RENDER_SCREEN();
 
     return sceneTarget;
@@ -2209,7 +2221,6 @@ r3d_target_t pass_post_smaa(r3d_target_t sceneTarget)
     R3D_SHADER_USE(prepare.smaaEdgeDetection[R3D.aaPreset]);
 
     R3D_SHADER_BIND_SAMPLER(prepare.smaaEdgeDetection[R3D.aaPreset], uSceneTex, r3d_target_get(sceneSource));
-    R3D_SHADER_SET_VEC4(prepare.smaaEdgeDetection[R3D.aaPreset], uMetrics, metrics);
 
     R3D_RENDER_SCREEN();
 
@@ -2224,7 +2235,6 @@ r3d_target_t pass_post_smaa(r3d_target_t sceneTarget)
     R3D_SHADER_BIND_SAMPLER(prepare.smaaBlendingWeights[R3D.aaPreset], uEdgesTex, r3d_target_get(R3D_TARGET_SMAA_EDGES));
     R3D_SHADER_BIND_SAMPLER(prepare.smaaBlendingWeights[R3D.aaPreset], uAreaTex, r3d_texture_get(R3D_TEXTURE_SMAA_AREA));
     R3D_SHADER_BIND_SAMPLER(prepare.smaaBlendingWeights[R3D.aaPreset], uSearchTex, r3d_texture_get(R3D_TEXTURE_SMAA_SEARCH));
-    R3D_SHADER_SET_VEC4(prepare.smaaBlendingWeights[R3D.aaPreset], uMetrics, metrics);
 
     R3D_RENDER_SCREEN();
 
@@ -2237,7 +2247,6 @@ r3d_target_t pass_post_smaa(r3d_target_t sceneTarget)
 
     R3D_SHADER_BIND_SAMPLER(post.smaa[R3D.aaPreset], uSceneTex, r3d_target_get(sceneTarget));
     R3D_SHADER_BIND_SAMPLER(post.smaa[R3D.aaPreset], uBlendTex, r3d_target_get(R3D_TARGET_SMAA_BLEND));
-    R3D_SHADER_SET_VEC4(post.smaa[R3D.aaPreset], uMetrics, metrics);
 
     R3D_RENDER_SCREEN();
 


### PR DESCRIPTION
The goal is to add new built-in variables for custom shaders, such as time, a frame index, access to matrices, and positions within fragment shaders.

---

Here are the built-in values ​​that have been added.

All shaders:
- `int FRAME_INDEX`
- `float TIME`

Surface vertex:
- `mat4 MATRIX_MODEL`
- `mat3 MATRIX_NORMAL`
- `mat4 MATRIX_INV_VIEW`
- `mat4 MATRIX_VIEW_PROJECTION`

Surface fragment:
- `vec3 POSITION`