### PR TITLE
Review skybox generation + sky shaders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ add_library(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/src/r3d_lighting.c"
     "${R3D_ROOT_PATH}/src/r3d_surface_shader.c"
     "${R3D_ROOT_PATH}/src/r3d_screen_shader.c"
+    "${R3D_ROOT_PATH}/src/r3d_sky_shader.c"
     "${R3D_ROOT_PATH}/src/r3d_material.c"
     "${R3D_ROOT_PATH}/src/r3d_mesh.c"
     "${R3D_ROOT_PATH}/src/r3d_mesh_data.c"
@@ -318,7 +319,8 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/prepare/cubemap_from_equirectangular.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/cubemap_irradiance.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/cubemap_prefilter.frag"
-    "${R3D_ROOT_PATH}/shaders/prepare/cubemap_skybox.frag"
+    "${R3D_ROOT_PATH}/shaders/prepare/cubemap_procedural_sky.frag"
+    "${R3D_ROOT_PATH}/shaders/prepare/cubemap_custom_sky.frag"
     # Scene
     "${R3D_ROOT_PATH}/shaders/scene/scene.vert"
     "${R3D_ROOT_PATH}/shaders/scene/geometry.frag"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,7 @@ add_library(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/src/r3d_model.c"
     "${R3D_ROOT_PATH}/src/r3d_probe.c"
     "${R3D_ROOT_PATH}/src/r3d_skeleton.c"
+    "${R3D_ROOT_PATH}/src/r3d_sky.c"
     "${R3D_ROOT_PATH}/src/r3d_utils.c"
     "${R3D_ROOT_PATH}/src/r3d_visibility.c"
     # External

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,11 +25,9 @@
 * [ ] **Review skybox generation**
   Improve parameter structure and naming, add an optional debanding setting, and support shaders for skyboxes.
 
-* [ ] **Consider `R3D_Camera` type (maybe)**
-  Think about introducing a dedicated camera type that handles `cullMask` per camera (instead of using global state) and manages `near/far` parameters directly, removing the last dependency on `rlgl`.
-
 ## **Ideas (Not Planned Yet)**
 
+* [ ] Think about introducing a dedicated `R3D_Camera` that handles `cullMask` per camera (instead of using global state) and manages `near/far` parameters directly, removing the last dependency on `rlgl`.
 * [ ] Investigate the integration of a velocity buffer and frame history, mainly for TAA and motion blur. The current begin/end rendering model makes this non-trivial.
 * [ ] Improve support for shadow/transparency interaction (e.g., colored shadows).
 * [ ] Implement Cascaded Shadow Maps (or alternative) for directional lights.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@
   Similar to existing skeleton and animation loading utilities, it would be useful to provide
   helper functions to import materials from files when needed.
 
-* [ ] **Review skybox generation**
+* [x] **Review skybox generation**
   Improve parameter structure and naming, add an optional debanding setting, and support shaders for skyboxes.
 
 ## **Ideas (Not Planned Yet)**

--- a/docs/shaders/sky_shader.md
+++ b/docs/shaders/sky_shader.md
@@ -1,0 +1,270 @@
+# Sky Shaders
+
+Sky shaders are used to procedurally generate skybox cubemaps. Unlike screen shaders, they do not process a rendered frame, they render each face of a cubemap from scratch.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Entry Point](#entry-point)
+- [Built-in Variables](#built-in-variables)
+- [Helper Functions](#helper-functions)
+- [Uniforms](#uniforms)
+- [Usage](#usage)
+- [Best Practices](#best-practices)
+- [Quick Reference](#quick-reference)
+
+---
+
+## Overview
+
+A sky shader runs once per texel of a cubemap to compute the sky color seen from that direction. R3D renders all six faces of the cubemap using an internal unit cube, calling your `fragment()` function for each pixel.
+
+Sky shaders are not used during the normal frame rendering process, they are invoked explicitly to generate or update a `R3D_Cubemap`.
+
+### Basic Example
+
+```glsl
+void fragment() {
+    // Simple gradient sky: blue at horizon, dark at zenith
+    float t = max(EYEDIR.y, 0.0);
+    COLOR = mix(vec3(0.5, 0.7, 1.0), vec3(0.1, 0.2, 0.5), t);
+}
+```
+
+### Loading a Shader
+
+```c
+// From file
+R3D_SkyShader* shader = R3D_LoadSkyShader("sky.glsl");
+
+// From memory
+const char* code = "void fragment() { COLOR = vec3(0.2, 0.4, 0.8); }";
+R3D_SkyShader* shader = R3D_LoadSkyShaderFromMemory(code);
+
+// Don't forget to unload when done
+R3D_UnloadSkyShader(shader);
+```
+
+---
+
+## Entry Point
+
+Sky shaders have only **one required entry point**: `fragment()`. There is no vertex stage, and consequently, no varyings.
+
+### Fragment Stage
+
+Runs once per cubemap texel to compute the sky color for that direction.
+
+```glsl
+void fragment() {
+    // Use EYEDIR to determine sky color based on view direction
+    vec3 sunDir = normalize(vec3(0.5, 0.8, 0.3));
+    float sun = pow(max(dot(EYEDIR, sunDir), 0.0), 64.0);
+    COLOR = mix(vec3(0.1, 0.3, 0.8), vec3(1.0, 0.9, 0.6), sun);
+}
+```
+
+---
+
+## Built-in Variables
+
+Sky shaders provide built-in variables describing the current cubemap texel:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `POSITION` | `vec3` | Interpolated local position on the unit cube |
+| `TEXCOORD` | `vec2` | 2D texture coordinates on the current cube face (0.0 to 1.0) |
+| `EYEDIR` | `vec3` | Normalized direction vector into the cubemap |
+| `FRAME_INDEX` | `int` | Index incremented at each frame |
+| `TIME` | `float` | Time provided by raylib's `GetTime()` |
+| `COLOR` | `vec3` | Output color (write to this) |
+
+### Key Variable: `EYEDIR`
+
+`EYEDIR` is the most commonly useful variable. It is the normalized version of `POSITION` and represents the 3D direction from the origin toward the current texel in the cubemap. Use it to:
+
+- Determine sky color based on elevation (`EYEDIR.y`)
+- Compute sun/moon angle via `dot(EYEDIR, lightDir)`
+- Sample an equirectangular texture using the provided helper
+
+```glsl
+void fragment() {
+    // Sky gradient based on elevation
+    float horizon = smoothstep(-0.05, 0.1, EYEDIR.y);
+    COLOR = mix(vec3(0.8, 0.6, 0.4), vec3(0.2, 0.4, 0.9), horizon);
+}
+```
+
+### `TEXCOORD` vs `EYEDIR`
+
+- Use `EYEDIR` for 3D directional effects (gradients, sun, stars, procedural atmosphere).
+- Use `TEXCOORD` when you need 2D face-local coordinates, for example when sampling a per-face texture or applying a per-face pattern.
+
+### `TIME` and `FRAME_INDEX`
+
+These work identically to their equivalents in surface and screen shaders. `TIME` is useful for animating sky conditions (moving clouds, day/night cycle), and `FRAME_INDEX` can drive frame-dependent noise effects when updating the cubemap each frame.
+
+---
+
+## Helper Functions
+
+Sky shaders include a built-in helper to convert a direction vector to equirectangular (spherical) UV coordinates:
+
+```glsl
+vec2 GetSphericalCoord(vec3 direction);
+```
+
+Returns UV coordinates suitable for sampling an equirectangular (panoramic) texture from a direction vector.
+
+**Example:**
+
+```glsl
+uniform sampler2D u_panorama;
+
+void fragment() {
+    vec2 uv = GetSphericalCoord(EYEDIR);
+    COLOR = texture(u_panorama, uv).rgb;
+}
+```
+
+---
+
+## Uniforms
+
+Sky shaders support the same uniform system as surface and screen shaders, with identical limits and behavior.
+
+### Supported Types
+
+**Values:** `bool`, `int`, `float`, `vec2`, `vec3`, `vec4`, `mat2`, `mat3`, `mat4`
+
+**Samplers:** `sampler1D`, `sampler2D`, `sampler3D`, `samplerCube`
+
+### Limits
+
+- **Maximum uniform values:** 16 by default (configurable via `R3D_MAX_SHADER_UNIFORMS`)
+- **Maximum samplers:** 4 by default (configurable via `R3D_MAX_SHADER_SAMPLERS`)
+
+### Setting Uniforms from C
+
+```c
+float time = GetTime();
+R3D_SetSkyShaderUniform(shader, "u_time", &time);
+
+Texture2D panorama = LoadTexture("sky.hdr");
+R3D_SetSkyShaderSampler(shader, "u_panorama", panorama);
+```
+
+---
+
+## Usage
+
+Sky shaders are used exclusively through two functions:
+
+```c
+R3D_Cubemap R3D_GenCustomSky(int size, R3D_SkyShader* shader);
+void R3D_UpdateCustomSky(R3D_Cubemap* cubemap, R3D_SkyShader* shader);
+```
+
+- **`R3D_GenCustomSky`** allocates a new cubemap and renders all six faces using the provided shader.
+- **`R3D_UpdateCustomSky`** re-renders an existing cubemap in place.
+
+### Example
+
+```c
+R3D_SkyShader* shader = R3D_LoadSkyShader("sky.glsl");
+
+// Generate once at startup and set it to the environment
+R3D_Cubemap sky = R3D_GenCustomSky(512, shader);
+R3D_GetEnvironment()->background.sky = sky;
+
+float time = 0.0f;
+
+while (!WindowShouldClose()) {
+    // Update sky every frame for animated effects
+    time += GetFrameTime();
+    R3D_SetSkyShaderUniform(shader, "u_time", &time);
+    R3D_UpdateCustomSky(&sky, shader);
+
+    R3D_Begin();
+    // ... draw scene with sky cubemap ...
+    R3D_End();
+}
+
+R3D_UnloadSkyShader(shader);
+```
+
+> **Note:** Updating a cubemap every frame can be expensive for large sizes. Consider updating at a lower frequency, or using a smaller size (e.g. 64–128) when details are not critical.
+
+---
+
+## Best Practices
+
+### Performance
+
+1. **Choose an appropriate cubemap size:** 64 is enough for smooth gradients and distant lighting; 256–512 is needed for sharp sun discs or detailed clouds.
+2. **Update selectively:** Only call `R3D_UpdateCustomSky` when the sky actually changes (new time of day, weather, etc.).
+3. **Avoid heavy loops:** Keep procedural noise and atmospheric scattering computations minimal or pre-baked into textures.
+4. **Cache expensive values:** Pre-compute quantities like `dot(EYEDIR, sunDir)` once and reuse them.
+
+### Quality
+
+1. **Normalize directions before use:** `EYEDIR` is already normalized, but any derived direction (reflected rays, sun direction) should be explicitly normalized.
+2. **Guard against negative `EYEDIR.y`:** When computing atmospheric effects based on elevation, clamp or check `EYEDIR.y` to avoid artifacts below the horizon.
+3. **Use `GetSphericalCoord` for panoramas:** Manually computing spherical coordinates is error-prone; prefer the built-in helper.
+
+### Organization
+
+1. **One shader per sky type:** Separate procedural sky, starfield, and panoramic sky into distinct shaders.
+2. **Document parameter ranges:** Comment expected ranges for uniforms like sun elevation or cloud density.
+
+---
+
+## Quick Reference
+
+### Loading/Unloading
+```c
+R3D_SkyShader* R3D_LoadSkyShader(const char* filePath);
+R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code);
+void R3D_UnloadSkyShader(R3D_SkyShader* shader);
+```
+
+### Setting Uniforms
+```c
+void R3D_SetSkyShaderUniform(R3D_SkyShader* shader, const char* name, const void* value);
+void R3D_SetSkyShaderSampler(R3D_SkyShader* shader, const char* name, Texture texture);
+```
+
+### Generating/Updating Cubemaps
+```c
+R3D_Cubemap R3D_GenCustomSky(int size, R3D_SkyShader* shader);
+void R3D_UpdateCustomSky(R3D_Cubemap* cubemap, R3D_SkyShader* shader);
+```
+
+### Shader Structure
+```glsl
+uniform <type> <name>;      // Optional: uniforms
+
+void fragment() {           // Required: fragment stage
+    // Read: POSITION, TEXCOORD, EYEDIR, TIME, FRAME_INDEX
+    // Helper: GetSphericalCoord(vec3 direction) -> vec2
+    // Write: COLOR
+}
+```
+
+### Built-in Variables
+```glsl
+// Input (read-only)
+vec3 POSITION;      // Local position on the unit cube
+vec2 TEXCOORD;      // UV coordinates on the current cube face [0..1]
+vec3 EYEDIR;        // Normalized direction into the cubemap
+int FRAME_INDEX;    // Frame counter
+float TIME;         // Elapsed time
+
+// Output (write)
+vec3 COLOR;         // Output sky color for this texel
+```
+
+### Helper Functions
+```glsl
+vec2 GetSphericalCoord(vec3 direction); // Direction → equirectangular UV
+```

--- a/examples/kinematics.c
+++ b/examples/kinematics.c
@@ -21,7 +21,7 @@ int main(void)
     R3D_Init(GetScreenWidth(), GetScreenHeight());
     R3D_SetTextureFilter(TEXTURE_FILTER_ANISOTROPIC_8X);
 
-    R3D_Cubemap sky = R3D_GenCubemapSky(4096, R3D_CUBEMAP_SKY_BASE);
+    R3D_Cubemap sky = R3D_GenProceduralSky(1024, R3D_PROCEDURAL_SKY_BASE);
     R3D_AmbientMap ambient = R3D_GenAmbientMap(sky, R3D_AMBIENT_ILLUMINATION | R3D_AMBIENT_REFLECTION);
     R3D_ENVIRONMENT_SET(background.sky, sky);
     R3D_ENVIRONMENT_SET(ambient.map, ambient);

--- a/examples/resources/shaders/sky.glsl
+++ b/examples/resources/shaders/sky.glsl
@@ -1,0 +1,23 @@
+uniform vec3 u_color;
+uniform ivec2 u_cells;
+uniform float u_line_px;
+
+void fragment()
+{
+    vec2 uv = TEXCOORD;
+
+    vec2 cells = max(vec2(u_cells), vec2(1.0));
+    vec2 g = uv * cells;
+    vec2 cell_uv = fract(g);
+    vec2 dist_to_edge = min(cell_uv, 1.0 - cell_uv);
+
+    vec2 px = fwidth(cell_uv);
+    vec2 half_thick = 0.5 * u_line_px * px;
+
+    float line_x = 1.0 - smoothstep(half_thick.x, half_thick.x + px.x, dist_to_edge.x);
+    float line_y = 1.0 - smoothstep(half_thick.y, half_thick.y + px.y, dist_to_edge.y);
+
+    float grid = max(line_x, line_y);
+
+    COLOR = u_color * grid;
+}

--- a/examples/skybox.c
+++ b/examples/skybox.c
@@ -23,13 +23,39 @@ int main(void)
     skyParams.skyEnergy = 2.0f;
     skyParams.sunEnergy = 2.0f;
 
+    // Load a custom sky shader
+    R3D_SkyShader* shader = R3D_LoadSkyShader(RESOURCES_PATH "shaders/sky.glsl");
+    R3D_SetSkyShaderUniform(shader, "u_color", &(Vector3){0.0f, 0.5f, 0.0f});
+    R3D_SetSkyShaderUniform(shader, "u_cells", (int[2]){10, 10});
+    R3D_SetSkyShaderUniform(shader, "u_line_px", (float[1]){1.0f});
+
     // Load and generate skyboxes
-    R3D_Cubemap skyProcedural = R3D_GenProceduralSky(1024, skyParams);
     R3D_Cubemap skyPanorama = R3D_LoadCubemap(RESOURCES_PATH "panorama/sky.hdr", R3D_CUBEMAP_LAYOUT_AUTO_DETECT);
+    R3D_Cubemap skyProcedural = R3D_GenProceduralSky(1024, skyParams);
+    R3D_Cubemap skyCustom = R3D_GenCustomSKy(512, shader);
 
     // Generate ambient maps
-    R3D_AmbientMap ambientProcedural = R3D_GenAmbientMap(skyProcedural, R3D_AMBIENT_ILLUMINATION | R3D_AMBIENT_REFLECTION);
     R3D_AmbientMap ambientPanorama = R3D_GenAmbientMap(skyPanorama, R3D_AMBIENT_ILLUMINATION | R3D_AMBIENT_REFLECTION);
+    R3D_AmbientMap ambientProcedural = R3D_GenAmbientMap(skyProcedural, R3D_AMBIENT_ILLUMINATION | R3D_AMBIENT_REFLECTION);
+    R3D_AmbientMap ambientCustom = R3D_GenAmbientMap(skyCustom, R3D_AMBIENT_ILLUMINATION | R3D_AMBIENT_REFLECTION);
+
+    // Store skies/ambients
+    R3D_EnvBackground backgrounds[3] = {0};
+    R3D_EnvAmbient ambients[3] = {0};
+    int currentSky = 0;
+
+    for (int i = 0; i < 3; i++) {
+        backgrounds[i].energy = 1.0f;
+        ambients[i].energy = 1.0f;
+    }
+
+    backgrounds[0].sky = skyPanorama;
+    backgrounds[1].sky = skyProcedural;
+    backgrounds[2].sky = skyCustom;
+
+    ambients[0].map = ambientPanorama;
+    ambients[1].map = ambientProcedural;
+    ambients[2].map = ambientCustom;
 
     // Set default sky/ambient maps
     R3D_ENVIRONMENT_SET(background.sky, skyPanorama);
@@ -57,16 +83,11 @@ int main(void)
         BeginDrawing();
         ClearBackground(RAYWHITE);
 
-        if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
-            if (R3D_ENVIRONMENT_GET(background.sky.texture) == skyPanorama.texture) {
-                R3D_ENVIRONMENT_SET(background.sky, skyProcedural);
-                R3D_ENVIRONMENT_SET(ambient.map, ambientProcedural);
-            }
-            else {
-                R3D_ENVIRONMENT_SET(background.sky, skyPanorama);
-                R3D_ENVIRONMENT_SET(ambient.map, ambientPanorama);
-            }
-        }
+        currentSky += IsMouseButtonPressed(MOUSE_RIGHT_BUTTON) - IsMouseButtonPressed(MOUSE_LEFT_BUTTON);
+        currentSky = (currentSky + 3) % 3;
+
+        R3D_ENVIRONMENT_SET(background, backgrounds[currentSky]);
+        R3D_ENVIRONMENT_SET(ambient, ambients[currentSky]);
 
         // Draw sphere grid
         R3D_Begin(camera);

--- a/examples/skybox.c
+++ b/examples/skybox.c
@@ -32,7 +32,7 @@ int main(void)
     // Load and generate skyboxes
     R3D_Cubemap skyPanorama = R3D_LoadCubemap(RESOURCES_PATH "panorama/sky.hdr", R3D_CUBEMAP_LAYOUT_AUTO_DETECT);
     R3D_Cubemap skyProcedural = R3D_GenProceduralSky(1024, skyParams);
-    R3D_Cubemap skyCustom = R3D_GenCustomSKy(512, shader);
+    R3D_Cubemap skyCustom = R3D_GenCustomSky(512, shader);
 
     // Generate ambient maps
     R3D_AmbientMap ambientPanorama = R3D_GenAmbientMap(skyPanorama, R3D_AMBIENT_ILLUMINATION | R3D_AMBIENT_REFLECTION);

--- a/examples/skybox.c
+++ b/examples/skybox.c
@@ -18,13 +18,13 @@ int main(void)
     R3D_Mesh sphere = R3D_GenMeshSphere(0.5f, 32, 64);
 
     // Define procedural skybox parameters
-    R3D_CubemapSky skyParams = R3D_CUBEMAP_SKY_BASE;
+    R3D_ProceduralSky skyParams = R3D_PROCEDURAL_SKY_BASE;
     skyParams.groundEnergy = 2.0f;
     skyParams.skyEnergy = 2.0f;
     skyParams.sunEnergy = 2.0f;
 
     // Load and generate skyboxes
-    R3D_Cubemap skyProcedural = R3D_GenCubemapSky(512, skyParams);
+    R3D_Cubemap skyProcedural = R3D_GenProceduralSky(1024, skyParams);
     R3D_Cubemap skyPanorama = R3D_LoadCubemap(RESOURCES_PATH "panorama/sky.hdr", R3D_CUBEMAP_LAYOUT_AUTO_DETECT);
 
     // Generate ambient maps

--- a/examples/sun.c
+++ b/examples/sun.c
@@ -36,7 +36,7 @@ int main(void)
     R3D_UnmapInstances(instances, R3D_INSTANCE_POSITION);
 
     // Setup environment
-    R3D_Cubemap skybox = R3D_GenCubemapSky(1024, R3D_CUBEMAP_SKY_BASE);
+    R3D_Cubemap skybox = R3D_GenProceduralSky(1024, R3D_PROCEDURAL_SKY_BASE);
     R3D_ENVIRONMENT_SET(background.sky, skybox);
 
     R3D_AmbientMap ambientMap = R3D_GenAmbientMap(skybox, R3D_AMBIENT_ILLUMINATION | R3D_AMBIENT_REFLECTION);

--- a/include/r3d/r3d.h
+++ b/include/r3d/r3d.h
@@ -38,6 +38,7 @@
 #include "r3d_probe.h"
 #include "r3d_screen_shader.h"
 #include "r3d_skeleton.h"
+#include "r3d_sky.h"
 #include "r3d_surface_shader.h"
 #include "r3d_utils.h"
 #include "r3d_visibility.h"

--- a/include/r3d/r3d_cubemap.h
+++ b/include/r3d/r3d_cubemap.h
@@ -19,27 +19,6 @@
  */
 
 // ========================================
-// CONSTANTS
-// ========================================
-
-#define R3D_CUBEMAP_SKY_BASE                                    \
-    R3D_LITERAL(R3D_CubemapSky) {                               \
-        .skyTopColor = (Color) {98, 116, 140, 255},             \
-        .skyHorizonColor = (Color) {165, 167, 171, 255},        \
-        .skyHorizonCurve = 0.15f,                               \
-        .skyEnergy = 1.0f,                                      \
-        .groundBottomColor = (Color) {51, 43, 34, 255},         \
-        .groundHorizonColor = (Color) {165, 167, 171, 255},     \
-        .groundHorizonCurve = 0.02f,                            \
-        .groundEnergy = 1.0f,                                   \
-        .sunDirection = (Vector3) {-1.0f, -1.0f, -1.0f},        \
-        .sunColor = (Color) {255, 255, 255, 255},               \
-        .sunSize = 1.5f * DEG2RAD,                              \
-        .sunCurve = 0.15,                                       \
-        .sunEnergy = 1.0f,                                      \
-    }
-
-// ========================================
 // ENUM TYPES
 // ========================================
 
@@ -73,31 +52,6 @@ typedef struct R3D_Cubemap {
     int size;
 } R3D_Cubemap;
 
-/**
- * @brief Parameters for procedural sky generation.
- *
- * Curves control gradient falloff (lower = sharper transition at horizon).
- */
-typedef struct R3D_CubemapSky {
-
-    Color skyTopColor;          // Sky color at zenith
-    Color skyHorizonColor;      // Sky color at horizon
-    float skyHorizonCurve;      // Gradient curve exponent (0.01 - 1.0, typical: 0.15)
-    float skyEnergy;            // Sky brightness multiplier
-
-    Color groundBottomColor;    // Ground color at nadir
-    Color groundHorizonColor;   // Ground color at horizon
-    float groundHorizonCurve;   // Gradient curve exponent (typical: 0.02)
-    float groundEnergy;         // Ground brightness multiplier
-
-    Vector3 sunDirection;       // Direction from which light comes (can take not normalized)
-    Color sunColor;             // Sun disk color
-    float sunSize;              // Sun angular size in radians (real sun: ~0.0087 rad = 0.5°)
-    float sunCurve;             // Sun edge softness exponent (typical: 0.15)
-    float sunEnergy;            // Sun brightness multiplier
-
-} R3D_CubemapSky;
-
 // ========================================
 // PUBLIC API
 // ========================================
@@ -121,25 +75,9 @@ R3DAPI R3D_Cubemap R3D_LoadCubemap(const char* fileName, R3D_CubemapLayout layou
 R3DAPI R3D_Cubemap R3D_LoadCubemapFromImage(Image image, R3D_CubemapLayout layout);
 
 /**
- * @brief Generates a procedural sky cubemap.
- *
- * Creates a GPU cubemap with procedural gradient sky and sun rendering.
- * The cubemap is ready for use as environment map or IBL source.
- */
-R3DAPI R3D_Cubemap R3D_GenCubemapSky(int size, R3D_CubemapSky params);
-
-/**
  * @brief Releases GPU resources associated with a cubemap.
  */
 R3DAPI void R3D_UnloadCubemap(R3D_Cubemap cubemap);
-
-/**
- * @brief Updates an existing procedural sky cubemap.
- *
- * Re-renders the cubemap with new parameters. Faster than unload + generate
- * when animating sky conditions (time of day, weather, etc.).
- */
-R3DAPI void R3D_UpdateCubemapSky(R3D_Cubemap* cubemap, R3D_CubemapSky params);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/r3d/r3d_sky.h
+++ b/include/r3d/r3d_sky.h
@@ -1,0 +1,102 @@
+/* r3d_sky.h -- R3D Sky Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#ifndef R3D_SKY_H
+#define R3D_SKY_H
+
+#include "./r3d_platform.h"
+#include "./r3d_cubemap.h"
+#include <raylib.h>
+#include <stdint.h>
+
+/**
+ * @defgroup Sky
+ * @{
+ */
+
+// ========================================
+// CONSTANTS
+// ========================================
+
+#define R3D_PROCEDURAL_SKY_BASE                                 \
+    R3D_LITERAL(R3D_ProceduralSky) {                            \
+        .skyTopColor = (Color) {98, 116, 140, 255},             \
+        .skyHorizonColor = (Color) {165, 167, 171, 255},        \
+        .skyHorizonCurve = 0.15f,                               \
+        .skyEnergy = 1.0f,                                      \
+        .groundBottomColor = (Color) {51, 43, 34, 255},         \
+        .groundHorizonColor = (Color) {165, 167, 171, 255},     \
+        .groundHorizonCurve = 0.02f,                            \
+        .groundEnergy = 1.0f,                                   \
+        .sunDirection = (Vector3) {-1.0f, -1.0f, -1.0f},        \
+        .sunColor = (Color) {255, 255, 255, 255},               \
+        .sunSize = 1.5f * DEG2RAD,                              \
+        .sunCurve = 0.15f,                                      \
+        .sunEnergy = 1.0f,                                      \
+    }
+
+// ========================================
+// STRUCT TYPES
+// ========================================
+
+/**
+ * @brief Parameters for procedural sky generation.
+ *
+ * Curves control gradient falloff (lower = sharper transition at horizon).
+ */
+typedef struct R3D_ProceduralSky {
+
+    Color skyTopColor;          // Sky color at zenith
+    Color skyHorizonColor;      // Sky color at horizon
+    float skyHorizonCurve;      // Gradient curve exponent (0.01 - 1.0, typical: 0.15)
+    float skyEnergy;            // Sky brightness multiplier
+
+    Color groundBottomColor;    // Ground color at nadir
+    Color groundHorizonColor;   // Ground color at horizon
+    float groundHorizonCurve;   // Gradient curve exponent (typical: 0.02)
+    float groundEnergy;         // Ground brightness multiplier
+
+    Vector3 sunDirection;       // Direction from which light comes (can take not normalized)
+    Color sunColor;             // Sun disk color
+    float sunSize;              // Sun angular size in radians (real sun: ~0.0087 rad = 0.5°)
+    float sunCurve;             // Sun edge softness exponent (typical: 0.15)
+    float sunEnergy;            // Sun brightness multiplier
+
+} R3D_ProceduralSky;
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Generates a procedural sky cubemap.
+ *
+ * Creates a GPU cubemap with procedural gradient sky and sun rendering.
+ * The cubemap is ready for use as environment map or IBL source.
+ */
+R3DAPI R3D_Cubemap R3D_GenProceduralSky(int size, R3D_ProceduralSky params);
+
+/**
+ * @brief Updates an existing procedural sky cubemap.
+ *
+ * Re-renders the cubemap with new parameters. Faster than unload + generate
+ * when animating sky conditions (time of day, weather, etc.).
+ */
+R3DAPI void R3D_UpdateProceduralSky(R3D_Cubemap* cubemap, R3D_ProceduralSky params);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+/** @} */ // end of Sky
+
+#endif // R3D_SKY_H

--- a/include/r3d/r3d_sky.h
+++ b/include/r3d/r3d_sky.h
@@ -9,6 +9,7 @@
 #ifndef R3D_SKY_H
 #define R3D_SKY_H
 
+#include "./r3d_sky_shader.h"
 #include "./r3d_platform.h"
 #include "./r3d_cubemap.h"
 #include <raylib.h>
@@ -86,12 +87,28 @@ extern "C" {
 R3DAPI R3D_Cubemap R3D_GenProceduralSky(int size, R3D_ProceduralSky params);
 
 /**
+ * @brief Generates a custom sky cubemap.
+ *
+ * Creates a GPU cubemap rendered using the provided sky shader.
+ * The cubemap is ready for use as environment map or IBL source.
+ */
+R3DAPI R3D_Cubemap R3D_GenCustomSky(int size, R3D_SkyShader* shader);
+
+/**
  * @brief Updates an existing procedural sky cubemap.
  *
  * Re-renders the cubemap with new parameters. Faster than unload + generate
  * when animating sky conditions (time of day, weather, etc.).
  */
 R3DAPI void R3D_UpdateProceduralSky(R3D_Cubemap* cubemap, R3D_ProceduralSky params);
+
+/**
+ * @brief Updates an existing custom sky cubemap.
+ *
+ * Re-renders the cubemap using the provided sky shader. Faster than unload + generate
+ * when animating sky conditions or updating shader uniforms (time, clouds, stars, etc.).
+ */
+R3DAPI void R3D_UpdateCustomSky(R3D_Cubemap* cubemap, R3D_SkyShader* shader);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/r3d/r3d_sky.h
+++ b/include/r3d/r3d_sky.h
@@ -36,7 +36,7 @@
         .groundEnergy = 1.0f,                                   \
         .sunDirection = (Vector3) {-1.0f, -1.0f, -1.0f},        \
         .sunColor = (Color) {255, 255, 255, 255},               \
-        .sunSize = 1.5f * DEG2RAD,                              \
+        .sunSize = 1.0f * DEG2RAD,                              \
         .sunCurve = 0.15f,                                      \
         .sunEnergy = 1.0f,                                      \
     }

--- a/include/r3d/r3d_sky_shader.h
+++ b/include/r3d/r3d_sky_shader.h
@@ -63,11 +63,7 @@ R3DAPI R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code);
 R3DAPI void R3D_UnloadSkyShader(R3D_SkyShader* shader);
 
 /**
- * @brief Sets a uniform value for the current frame.
- *
- * Once a uniform is set, it remains valid for the all frames.
- * If an uniform is set multiple times during the same frame,
- * the last value defined before R3D_End() is used.
+ * @brief Sets a uniform value for all subsequent sky generations.
  *
  * Supported types:
  * bool, int, float,
@@ -86,11 +82,7 @@ R3DAPI void R3D_UnloadSkyShader(R3D_SkyShader* shader);
 R3DAPI void R3D_SetSkyShaderUniform(R3D_SkyShader* shader, const char* name, const void* value);
 
 /**
- * @brief Sets a texture sampler for the current frame.
- *
- * Once a sampler is set, it remains valid for all frames.
- * If a sampler is set multiple times during the same frame,
- * the last value defined before R3D_End() is used.
+ * @brief Sets a uniform value for all subsequent sky generations.
  *
  * Supported samplers:
  * sampler1D, sampler2D, sampler3D, samplerCube

--- a/include/r3d/r3d_sky_shader.h
+++ b/include/r3d/r3d_sky_shader.h
@@ -1,0 +1,112 @@
+/* r3d_sky_shader.h -- R3D Sky Shader Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#ifndef R3D_SKY_SHADER_H
+#define R3D_SKY_SHADER_H
+
+#include "./r3d_platform.h"
+#include <raylib.h>
+
+/**
+ * @defgroup SkyShader
+ * @{
+ */
+
+// ========================================
+// OPAQUE TYPES
+// ========================================
+
+typedef struct R3D_SkyShader R3D_SkyShader;
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Loads a sky shader from a file.
+ *
+ * The shader must define a single entry point:
+ * `void fragment()`. Any other entry point, such as `vertex()`,
+ * or any varyings will be ignored.
+ *
+ * @param filePath Path to the shader source file.
+ * @return Pointer to the loaded sky shader, or NULL on failure.
+ */
+R3DAPI R3D_SkyShader* R3D_LoadSkyShader(const char* filePath);
+
+/**
+ * @brief Loads a sky shader from a source code string in memory.
+ *
+ * The shader must define a single entry point:
+ * `void fragment()`. Any other entry point, such as `vertex()`,
+ * or any varyings will be ignored.
+ *
+ * @param code Null-terminated shader source code.
+ * @return Pointer to the loaded sky shader, or NULL on failure.
+ */
+R3DAPI R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code);
+
+/**
+ * @brief Unloads and destroys a sky shader.
+ *
+ * @param shader Sky shader to unload.
+ */
+R3DAPI void R3D_UnloadSkyShader(R3D_SkyShader* shader);
+
+/**
+ * @brief Sets a uniform value for the current frame.
+ *
+ * Once a uniform is set, it remains valid for the all frames.
+ * If an uniform is set multiple times during the same frame,
+ * the last value defined before R3D_End() is used.
+ *
+ * Supported types:
+ * bool, int, float,
+ * ivec2, ivec3, ivec4,
+ * vec2, vec3, vec4,
+ * mat2, mat3, mat4
+ *
+ * @warning Boolean values are read as 4 bytes.
+ *
+ * @param shader Target sky shader.
+ *               May be NULL. In that case, the call is ignored
+ *               and a warning is logged.
+ * @param name   Name of the uniform. Must not be NULL.
+ * @param value  Pointer to the uniform value. Must not be NULL.
+ */
+R3DAPI void R3D_SetSkyShaderUniform(R3D_SkyShader* shader, const char* name, const void* value);
+
+/**
+ * @brief Sets a texture sampler for the current frame.
+ *
+ * Once a sampler is set, it remains valid for all frames.
+ * If a sampler is set multiple times during the same frame,
+ * the last value defined before R3D_End() is used.
+ *
+ * Supported samplers:
+ * sampler1D, sampler2D, sampler3D, samplerCube
+ *
+ * @param shader  Target sky shader.
+ *                May be NULL. In that case, the call is ignored
+ *                and a warning is logged.
+ * @param name    Name of the sampler uniform. Must not be NULL.
+ * @param texture Texture to bind to the sampler.
+ */
+R3DAPI void R3D_SetSkyShaderSampler(R3D_SkyShader* shader, const char* name, Texture texture);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+/** @} */ // end of SkyShader
+
+#endif // R3D_SKY_SHADER_H

--- a/shaders/prepare/cubemap_custom_sky.frag
+++ b/shaders/prepare/cubemap_custom_sky.frag
@@ -1,0 +1,62 @@
+/* screen.frag -- Base of custom screen fragment shader
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+/* === Includes === */
+
+#include "../include/blocks/frame.glsl"
+#include "../include/blocks/view.glsl"
+
+/* === Varyings === */
+
+in vec3 vPosition;
+in vec2 vTexCoord;
+
+/* === Fragments === */
+
+out vec4 FragColor;
+
+/* === Built-In Input Variables === */
+
+vec3 POSITION = vec3(0.0);
+vec2 TEXCOORD = vec2(0.0);
+vec3 EYEDIR = vec3(0.0);
+int FRAME_INDEX = 0;
+float TIME = 0.0;
+
+/* === Built-In Output Variables === */
+
+vec3 COLOR = vec3(0.0);
+
+/* === Main function === */
+
+vec2 GetSphericalCoord(vec3 v)
+{
+    vec2 uv = vec2(atan(v.z, v.x), asin(v.y));
+    uv *= vec2(0.1591, -0.3183); // negative Y, to flip axis
+    uv += 0.5;
+    return uv;
+}
+
+/* === Main function === */
+
+#define fragment()
+
+void main()
+{
+    POSITION = vPosition;
+    TEXCOORD = vTexCoord;
+    EYEDIR = normalize(vPosition);
+    FRAME_INDEX = uFrame.index;
+    TIME = uFrame.time;
+
+    fragment();
+
+    FragColor = vec4(COLOR, 1.0);
+}

--- a/shaders/prepare/cubemap_custom_sky.frag
+++ b/shaders/prepare/cubemap_custom_sky.frag
@@ -1,4 +1,4 @@
-/* screen.frag -- Base of custom screen fragment shader
+/* cubemap_custom_sky.frag -- Base of custom custom skybox fragment shader
  *
  * Copyright (c) 2025-2026 Le Juez Victor
  *

--- a/shaders/prepare/cubemap_procedural_sky.frag
+++ b/shaders/prepare/cubemap_procedural_sky.frag
@@ -1,4 +1,4 @@
-/* cubemap_skybox.frag -- Skybox generation fragment shader
+/* cubemap_procedural_sky.frag -- Procedural sky generation fragment shader
  *
  * Copyright (c) 2025-2026 Le Juez Victor
  *

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -761,7 +761,13 @@ typedef struct {
     r3d_shader_uniform_float_t uSunSize;
     r3d_shader_uniform_float_t uSunCurve;
     r3d_shader_uniform_float_t uSunEnergy;
-} r3d_shader_prepare_cubemap_skybox_t;
+} r3d_shader_prepare_cubemap_procedural_sky_t;
+
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_mat4_t uMatProj;
+    r3d_shader_uniform_mat4_t uMatView;
+} r3d_shader_prepare_cubemap_custom_sky_t;
 
 typedef struct {
     GLuint id;
@@ -1048,6 +1054,11 @@ typedef struct {
 
 typedef struct {
     union {
+        // Must follow the same naming pattern as `r3d_shader_loader`
+        struct {
+            r3d_shader_prepare_cubemap_custom_sky_t cubemapCustomSky;
+        } prepare;
+
         // Must follow the same naming pattern as `r3d_mod_shader`
         struct {
             r3d_shader_scene_geometry_t geometry;
@@ -1111,7 +1122,7 @@ extern struct r3d_mod_shader {
         r3d_shader_prepare_cubemap_from_equirectangular_t cubemapFromEquirectangular;
         r3d_shader_prepare_cubemap_irradiance_t cubemapIrradiance;
         r3d_shader_prepare_cubemap_prefilter_t cubemapPrefilter;
-        r3d_shader_prepare_cubemap_skybox_t cubemapSkybox;
+        r3d_shader_prepare_cubemap_procedural_sky_t cubemapProceduralSky;
     } prepare;
 
     // Scene shaders
@@ -1183,7 +1194,8 @@ bool r3d_shader_load_prepare_smaa_blending_weights_ultra(r3d_shader_custom_t* cu
 bool r3d_shader_load_prepare_cubemap_from_equirectangular(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_cubemap_irradiance(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_cubemap_prefilter(r3d_shader_custom_t* custom);
-bool r3d_shader_load_prepare_cubemap_skybox(r3d_shader_custom_t* custom);
+bool r3d_shader_load_prepare_cubemap_procedural_sky(r3d_shader_custom_t* custom);
+bool r3d_shader_load_prepare_cubemap_custom_sky(r3d_shader_custom_t* custom);
 bool r3d_shader_load_scene_geometry(r3d_shader_custom_t* custom);
 bool r3d_shader_load_scene_forward(r3d_shader_custom_t* custom);
 bool r3d_shader_load_scene_unlit(r3d_shader_custom_t* custom);
@@ -1239,7 +1251,8 @@ static const struct r3d_shader_loader {
         r3d_shader_loader_func cubemapFromEquirectangular;
         r3d_shader_loader_func cubemapIrradiance;
         r3d_shader_loader_func cubemapPrefilter;
-        r3d_shader_loader_func cubemapSkybox;
+        r3d_shader_loader_func cubemapProceduralSky;
+        r3d_shader_loader_func cubemapCustomSky;
     } prepare;
 
     // Scene shaders
@@ -1307,7 +1320,8 @@ static const struct r3d_shader_loader {
         .cubemapFromEquirectangular = r3d_shader_load_prepare_cubemap_from_equirectangular,
         .cubemapIrradiance = r3d_shader_load_prepare_cubemap_irradiance,
         .cubemapPrefilter = r3d_shader_load_prepare_cubemap_prefilter,
-        .cubemapSkybox = r3d_shader_load_prepare_cubemap_skybox,
+        .cubemapProceduralSky = r3d_shader_load_prepare_cubemap_procedural_sky,
+        .cubemapCustomSky = r3d_shader_load_prepare_cubemap_custom_sky,
     },
 
     .scene = {

--- a/src/r3d_sky.c
+++ b/src/r3d_sky.c
@@ -37,7 +37,7 @@ R3D_Cubemap R3D_GenProceduralSky(int size, R3D_ProceduralSky params)
     return cubemap;
 }
 
-R3D_Cubemap R3D_GenCustomSKy(int size, R3D_SkyShader* shader)
+R3D_Cubemap R3D_GenCustomSky(int size, R3D_SkyShader* shader)
 {
     R3D_Cubemap cubemap = r3d_cubemap_allocate(size);
     R3D_UpdateCustomSky(&cubemap, shader);

--- a/src/r3d_sky.c
+++ b/src/r3d_sky.c
@@ -1,0 +1,80 @@
+/* r3d_cubemap.c -- R3D Cubemap Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#include <r3d/r3d_cubemap.h>
+#include <r3d/r3d_sky.h>
+#include <raymath.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <rlgl.h>
+#include <glad.h>
+
+#include "./modules/r3d_driver.h"
+#include "./modules/r3d_shader.h"
+#include "./modules/r3d_render.h"
+#include "./r3d_core_state.h"
+
+// ========================================
+// EXTERNAL FUNCTIONS
+// ========================================
+
+R3D_Cubemap r3d_cubemap_allocate(int size);
+void r3d_cubemap_gen_mipmap(const R3D_Cubemap* cubemap);
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+R3D_Cubemap R3D_GenProceduralSky(int size, R3D_ProceduralSky params)
+{
+    R3D_Cubemap cubemap = r3d_cubemap_allocate(size);
+    R3D_UpdateProceduralSky(&cubemap, params);
+    return cubemap;
+}
+
+void R3D_UpdateProceduralSky(R3D_Cubemap* cubemap, R3D_ProceduralSky params)
+{
+    r3d_driver_invalidate_cache();
+
+    Matrix matProj = MatrixPerspective(90.0 * DEG2RAD, 1.0, 0.1, 10.0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, cubemap->fbo);
+    glViewport(0, 0, cubemap->size, cubemap->size);
+
+    R3D_SHADER_USE(prepare.cubemapSkybox);
+    r3d_driver_disable(GL_CULL_FACE);
+
+    R3D_SHADER_SET_MAT4(prepare.cubemapSkybox, uMatProj, matProj);
+    R3D_SHADER_SET_COL3(prepare.cubemapSkybox, uSkyTopColor, R3D.colorSpace, params.skyTopColor);
+    R3D_SHADER_SET_COL3(prepare.cubemapSkybox, uSkyHorizonColor, R3D.colorSpace, params.skyHorizonColor);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uSkyHorizonCurve, params.skyHorizonCurve);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uSkyEnergy, params.skyEnergy);
+    R3D_SHADER_SET_COL3(prepare.cubemapSkybox, uGroundBottomColor, R3D.colorSpace, params.groundBottomColor);
+    R3D_SHADER_SET_COL3(prepare.cubemapSkybox, uGroundHorizonColor, R3D.colorSpace, params.groundHorizonColor);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uGroundHorizonCurve, params.groundHorizonCurve);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uGroundEnergy, params.groundEnergy);
+    R3D_SHADER_SET_VEC3(prepare.cubemapSkybox, uSunDirection, Vector3Normalize(Vector3Negate(params.sunDirection)));
+    R3D_SHADER_SET_COL3(prepare.cubemapSkybox, uSunColor, R3D.colorSpace, params.sunColor);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uSunSize, params.sunSize);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uSunCurve, params.sunCurve);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uSunEnergy, params.sunEnergy);
+
+    for (int i = 0; i < 6; i++) {
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, cubemap->texture, 0);
+        glClear(GL_DEPTH_BUFFER_BIT);
+
+        R3D_SHADER_SET_MAT4(prepare.cubemapSkybox, uMatView, R3D.matCubeViews[i]);
+        R3D_RENDER_CUBE();
+    }
+
+    r3d_cubemap_gen_mipmap(cubemap);
+
+    glViewport(0, 0, rlGetFramebufferWidth(), rlGetFramebufferHeight());
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    r3d_driver_enable(GL_CULL_FACE);
+}

--- a/src/r3d_sky.c
+++ b/src/r3d_sky.c
@@ -37,6 +37,13 @@ R3D_Cubemap R3D_GenProceduralSky(int size, R3D_ProceduralSky params)
     return cubemap;
 }
 
+R3D_Cubemap R3D_GenCustomSKy(int size, R3D_SkyShader* shader)
+{
+    R3D_Cubemap cubemap = r3d_cubemap_allocate(size);
+    R3D_UpdateCustomSky(&cubemap, shader);
+    return cubemap;
+}
+
 void R3D_UpdateProceduralSky(R3D_Cubemap* cubemap, R3D_ProceduralSky params)
 {
     r3d_driver_invalidate_cache();
@@ -46,29 +53,63 @@ void R3D_UpdateProceduralSky(R3D_Cubemap* cubemap, R3D_ProceduralSky params)
     glBindFramebuffer(GL_FRAMEBUFFER, cubemap->fbo);
     glViewport(0, 0, cubemap->size, cubemap->size);
 
-    R3D_SHADER_USE(prepare.cubemapSkybox);
+    R3D_SHADER_USE(prepare.cubemapProceduralSky);
     r3d_driver_disable(GL_CULL_FACE);
 
-    R3D_SHADER_SET_MAT4(prepare.cubemapSkybox, uMatProj, matProj);
-    R3D_SHADER_SET_COL3(prepare.cubemapSkybox, uSkyTopColor, R3D.colorSpace, params.skyTopColor);
-    R3D_SHADER_SET_COL3(prepare.cubemapSkybox, uSkyHorizonColor, R3D.colorSpace, params.skyHorizonColor);
-    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uSkyHorizonCurve, params.skyHorizonCurve);
-    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uSkyEnergy, params.skyEnergy);
-    R3D_SHADER_SET_COL3(prepare.cubemapSkybox, uGroundBottomColor, R3D.colorSpace, params.groundBottomColor);
-    R3D_SHADER_SET_COL3(prepare.cubemapSkybox, uGroundHorizonColor, R3D.colorSpace, params.groundHorizonColor);
-    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uGroundHorizonCurve, params.groundHorizonCurve);
-    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uGroundEnergy, params.groundEnergy);
-    R3D_SHADER_SET_VEC3(prepare.cubemapSkybox, uSunDirection, Vector3Normalize(Vector3Negate(params.sunDirection)));
-    R3D_SHADER_SET_COL3(prepare.cubemapSkybox, uSunColor, R3D.colorSpace, params.sunColor);
-    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uSunSize, params.sunSize);
-    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uSunCurve, params.sunCurve);
-    R3D_SHADER_SET_FLOAT(prepare.cubemapSkybox, uSunEnergy, params.sunEnergy);
+    R3D_SHADER_SET_MAT4(prepare.cubemapProceduralSky, uMatProj, matProj);
+    R3D_SHADER_SET_COL3(prepare.cubemapProceduralSky, uSkyTopColor, R3D.colorSpace, params.skyTopColor);
+    R3D_SHADER_SET_COL3(prepare.cubemapProceduralSky, uSkyHorizonColor, R3D.colorSpace, params.skyHorizonColor);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapProceduralSky, uSkyHorizonCurve, params.skyHorizonCurve);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapProceduralSky, uSkyEnergy, params.skyEnergy);
+    R3D_SHADER_SET_COL3(prepare.cubemapProceduralSky, uGroundBottomColor, R3D.colorSpace, params.groundBottomColor);
+    R3D_SHADER_SET_COL3(prepare.cubemapProceduralSky, uGroundHorizonColor, R3D.colorSpace, params.groundHorizonColor);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapProceduralSky, uGroundHorizonCurve, params.groundHorizonCurve);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapProceduralSky, uGroundEnergy, params.groundEnergy);
+    R3D_SHADER_SET_VEC3(prepare.cubemapProceduralSky, uSunDirection, Vector3Normalize(Vector3Negate(params.sunDirection)));
+    R3D_SHADER_SET_COL3(prepare.cubemapProceduralSky, uSunColor, R3D.colorSpace, params.sunColor);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapProceduralSky, uSunSize, params.sunSize);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapProceduralSky, uSunCurve, params.sunCurve);
+    R3D_SHADER_SET_FLOAT(prepare.cubemapProceduralSky, uSunEnergy, params.sunEnergy);
 
     for (int i = 0; i < 6; i++) {
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, cubemap->texture, 0);
         glClear(GL_DEPTH_BUFFER_BIT);
 
-        R3D_SHADER_SET_MAT4(prepare.cubemapSkybox, uMatView, R3D.matCubeViews[i]);
+        R3D_SHADER_SET_MAT4(prepare.cubemapProceduralSky, uMatView, R3D.matCubeViews[i]);
+        R3D_RENDER_CUBE();
+    }
+
+    r3d_cubemap_gen_mipmap(cubemap);
+
+    glViewport(0, 0, rlGetFramebufferWidth(), rlGetFramebufferHeight());
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    r3d_driver_enable(GL_CULL_FACE);
+}
+
+void R3D_UpdateCustomSky(R3D_Cubemap* cubemap, R3D_SkyShader* shader)
+{
+    if (shader == NULL) {
+        R3D_TRACELOG(LOG_WARNING, "Failed to generate custom sky; The sky shader is NULL");
+        return;
+    }
+
+    r3d_driver_invalidate_cache();
+
+    Matrix matProj = MatrixPerspective(90.0 * DEG2RAD, 1.0, 0.1, 10.0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, cubemap->fbo);
+    glViewport(0, 0, cubemap->size, cubemap->size);
+
+    R3D_SHADER_USE_CUSTOM(shader, prepare.cubemapCustomSky);
+    r3d_driver_disable(GL_CULL_FACE);
+
+    R3D_SHADER_SET_MAT4_CUSTOM(shader, prepare.cubemapCustomSky, uMatProj, matProj);
+
+    for (int i = 0; i < 6; i++) {
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, cubemap->texture, 0);
+        glClear(GL_DEPTH_BUFFER_BIT);
+
+        R3D_SHADER_SET_MAT4_CUSTOM(shader, prepare.cubemapCustomSky, uMatView, R3D.matCubeViews[i]);
         R3D_RENDER_CUBE();
     }
 

--- a/src/r3d_sky_shader.c
+++ b/src/r3d_sky_shader.c
@@ -1,0 +1,219 @@
+/* r3d_sky_shader.c -- R3D Sky Shader Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#include <r3d/r3d_sky_shader.h>
+#include <r3d_config.h>
+#include <raylib.h>
+#include <string.h>
+#include <stdlib.h>
+#include <glad.h>
+
+#include "./modules/r3d_shader.h"
+#include "./common/r3d_rshade.h"
+
+// ========================================
+// OPAQUE STRUCTS
+// ========================================
+
+struct R3D_SkyShader {
+    r3d_shader_custom_t program;
+    char userCode[R3D_MAX_SHADER_CODE_LENGTH];
+};
+
+// ========================================
+// INTERNAL FUNCTIONS
+// ========================================
+
+static bool compile_shader(R3D_SkyShader* shader);
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+R3D_SkyShader* R3D_LoadSkyShader(const char* filePath)
+{
+    char* code = LoadFileText(filePath);
+    if (code == NULL) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to load sky shader; Unable to load shader file");
+        return NULL;
+    }
+
+    R3D_SkyShader* shader = R3D_LoadSkyShaderFromMemory(code);
+    UnloadFileText(code);
+
+    return shader;
+}
+
+R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code)
+{
+    size_t userCodeLen = strlen(code);
+    if (userCodeLen > R3D_MAX_SHADER_CODE_LENGTH) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to load sky shader; User code too long");
+        return NULL;
+    }
+
+    if (!strstr(code, "void fragment()")) {
+        R3D_TRACELOG(LOG_WARNING, "Failed to load sky shader; Missing fragment() entry point");
+        return NULL;
+    }
+
+    R3D_SkyShader* shader = RL_CALLOC(1, sizeof(R3D_SkyShader));
+    if (!shader) {
+        R3D_TRACELOG(LOG_ERROR, "Bad alloc during sky shader loading");
+        return NULL;
+    }
+
+    char* output = RL_MALLOC(userCodeLen * 3);
+    if (!output) {
+        R3D_TRACELOG(LOG_ERROR, "Bad alloc during sky shader loading");
+        RL_FREE(shader);
+        return NULL;
+    }
+
+    char* outPtr = output;
+    const char* ptr = code;
+
+    int uniformCount = 0;
+    int samplerCount = 0;
+    int currentOffset = 0;
+
+    r3d_rshade_parsed_function_t fragmentFunc = {0};
+
+    /* --- PHASE 1: Parse user code and collect metadata --- */
+
+    while (*ptr)
+    {
+        r3d_rshade_skip_whitespace_and_comments(&ptr);
+        if (!*ptr) break;
+
+        // Parse uniform declarations
+        if (r3d_rshade_match_keyword(ptr, "uniform", 7)) {
+            ptr += 7;
+            r3d_rshade_parse_uniform(&ptr,
+                shader->program.samplers,
+                &shader->program.uniforms,
+                &samplerCount,
+                &uniformCount,
+                &currentOffset,
+                R3D_MAX_SHADER_SAMPLERS,
+                R3D_MAX_SHADER_UNIFORMS
+            );
+            continue;
+        }
+
+        // Parse fragment() function
+        r3d_rshade_parsed_function_t* func = r3d_rshade_check_shader_entry(ptr, NULL, &fragmentFunc);
+        if (func) {
+            r3d_rshade_skip_to_brace(&ptr);
+            if (*ptr == '{') {
+                func->bodyStart = ptr;
+                r3d_rshade_skip_to_matching_brace(&ptr);
+                func->bodyEnd = ptr;
+            }
+            continue;
+        }
+
+        ptr++;
+    }
+
+    /* --- PHASE 2: Generate transformed shader code --- */
+
+    // Write uniform block and samplers
+    outPtr = r3d_rshade_write_uniform_block(outPtr, shader->program.uniforms.entries, uniformCount);
+    outPtr = r3d_rshade_write_samplers(outPtr, shader->program.samplers, samplerCount);
+
+    // Copy global code (excluding comments, uniforms, fragment()) then write fragment stage section
+    outPtr = r3d_rshade_copy_global_code(outPtr, code, false, NULL, &fragmentFunc);
+    outPtr = r3d_rshade_write_shader_function(outPtr, "fragment", &fragmentFunc);
+
+    *outPtr = '\0';
+
+    // Copy transformed code to shader structure
+    size_t finalLen = strlen(output);
+    if (finalLen > R3D_MAX_SHADER_CODE_LENGTH) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to load sky shader; Transformed code too long");
+        RL_FREE(output);
+        RL_FREE(shader);
+        return NULL;
+    }
+
+    memcpy(shader->userCode, output, finalLen + 1);
+    RL_FREE(output);
+
+    /* --- PHASE 3: Compile shader --- */
+
+    if (!compile_shader(shader)) {
+        R3D_UnloadSkyShader(shader);
+        return NULL;
+    }
+
+    /* --- PHASE 4: Initialize uniform buffer --- */
+
+    r3d_rshade_init_ubo(&shader->program.uniforms, currentOffset);
+
+    R3D_TRACELOG(LOG_INFO, "Sky shader loaded successfully");
+    R3D_TRACELOG(LOG_INFO, "    > Sampler count: %i", samplerCount);
+    R3D_TRACELOG(LOG_INFO, "    > Uniform count: %i", uniformCount);
+
+    return shader;
+}
+
+void R3D_UnloadSkyShader(R3D_SkyShader* shader)
+{
+    if (!shader) return;
+
+    if (shader->program.uniforms.bufferId != 0) {
+        glDeleteBuffers(1, &shader->program.uniforms.bufferId);
+    }
+
+    if (shader->program.prepare.cubemapCustomSky.id != 0) {
+        glDeleteProgram(shader->program.prepare.cubemapCustomSky.id);
+    }
+
+    RL_FREE(shader);
+}
+
+void R3D_SetSkyShaderUniform(R3D_SkyShader* shader, const char* name, const void* value)
+{
+    if (!shader) {
+        R3D_TRACELOG(LOG_WARNING, "Cannot set uniform '%s' on NULL sky shader", name);
+        return;
+    }
+
+    if (!r3d_shader_set_custom_uniform(&shader->program, name, value)) {
+        R3D_TRACELOG(LOG_WARNING, "Failed to set custom uniform '%s'", name);
+    }
+}
+
+void R3D_SetSkyShaderSampler(R3D_SkyShader* shader, const char* name, Texture texture)
+{
+    if (!shader) {
+        R3D_TRACELOG(LOG_WARNING, "Cannot set sampler '%s' on NULL sky shader", name);
+        return;
+    }
+
+    if (!r3d_shader_set_custom_sampler(&shader->program, name, texture)) {
+        R3D_TRACELOG(LOG_WARNING, "Failed to set custom sampler '%s'", name);
+    }
+}
+
+// ========================================
+// INTERNAL FUNCTIONS
+// ========================================
+
+bool compile_shader(R3D_SkyShader* shader)
+{
+    // Store reference to the user code in custom shader struct
+    shader->program.userCode = shader->userCode;
+
+    bool ok = R3D_MOD_SHADER_LOADER.prepare.cubemapCustomSky(&shader->program);
+    if (!ok) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to compile sky shader");
+    }
+    return ok;
+}


### PR DESCRIPTION
This PR refactors the sky generation API and introduces support for custom sky shaders.

### API changes

- `R3D_CubemapSky` has been moved from `r3d_cubemap.h` to a new dedicated header `r3d_sky.h`.
- `R3D_CubemapSky` has been renamed to `R3D_ProceduralSky`.
- `R3D_CUBEMAP_SKY_BASE` has been renamed to `R3D_PROCEDURAL_SKY_BASE`.

Sky generation is now fully handled in `r3d_sky.h`, while `r3d_cubemap.h` is limited to cubemap loading and resource management.

### Custom sky shaders

Also, this PR adds `R3D_SkyShader`, allowing users to generate cubemaps using custom shaders.

New functions:

- `R3D_GenCustomSky`
- `R3D_UpdateCustomSky`

Sky shaders are not part of the frame rendering pipeline. They are executed explicitly to render cubemap faces when generating or updating a `R3D_Cubemap`.