### PR TITLE
DoF before bloom in post processing

### DIFF
--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -210,12 +210,12 @@ void R3D_End(void)
         sceneTarget = pass_post_fog(sceneTarget);
     }
 
-    if (R3D.environment.bloom.mode != R3D_BLOOM_DISABLED) {
-        sceneTarget = pass_post_bloom(sceneTarget);
-    }
-
     if (R3D.environment.dof.mode != R3D_DOF_DISABLED) {
         sceneTarget = pass_post_dof(sceneTarget);
+    }
+
+    if (R3D.environment.bloom.mode != R3D_BLOOM_DISABLED) {
+        sceneTarget = pass_post_bloom(sceneTarget);
     }
 
     sceneTarget = pass_post_screen(sceneTarget);


### PR DESCRIPTION
This simply moves depth of field ahead of bloom in post processing.

Bloom after DoF seems incorrect since bloom is meant to represent bleeding of received light and having it occur before DoF would not correctly represent the focal point of our "lens". More generally, having bloom before DoF can look odd since the bloomed areas do not directly match with the out of focus areas.

This would also seem to be inline with general practice. One of the more straightforward references is Unity's pipeline.
https://docs.unity3d.com/Packages/com.unity.render-pipelines.high-definition@17.5/manual/rendering-execution-order.html