### PR TITLE
Instance offset

### DIFF
--- a/include/r3d/r3d_draw.h
+++ b/include/r3d/r3d_draw.h
@@ -102,20 +102,37 @@ R3DAPI void R3D_DrawMeshPro(R3D_Mesh mesh, R3D_Material material, Matrix transfo
  *
  * Draws multiple instances using the provided instance buffer.
  * Does nothing if the number of instances is <= 0.
- * 
+ *
  * The command is executed during R3D_End().
  */
 R3DAPI void R3D_DrawMeshInstanced(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int count);
 
 /**
- * @brief Queues an instanced mesh draw command with an additional transform.
+ * @brief Queues an instanced mesh draw command with an instance range.
  *
- * Does nothing if the number of instances is <= 0.
+ * Draws 'count' instances starting at 'offset' in the instance buffer.
+ * Both 'offset' and 'count' are clamped to stay within [0, instances.capacity]:
+ *   - offset is clamped to [0, capacity]
+ *   - count is clamped to [0, capacity - offset]
+ * Does nothing if the resulting count is <= 0.
+ *
+ * The command is executed during R3D_End().
+ */
+R3DAPI void R3D_DrawMeshInstancedEx(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int offset, int count);
+
+/**
+ * @brief Queues an instanced mesh draw command with an instance range and an additional transform.
+ *
+ * Draws 'count' instances starting at 'offset' in the instance buffer.
+ * Both 'offset' and 'count' are clamped to stay within [0, instances.capacity]:
+ *   - offset is clamped to [0, capacity]
+ *   - count is clamped to [0, capacity - offset]
+ * Does nothing if the resulting count is <= 0.
  * The transform is applied to all instances.
  *
  * The command is executed during R3D_End().
  */
-R3DAPI void R3D_DrawMeshInstancedEx(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int count, Matrix transform);
+R3DAPI void R3D_DrawMeshInstancedPro(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int offset, int count, Matrix transform);
 
 /**
  * @brief Queues a model draw command with position and uniform scale.
@@ -143,20 +160,37 @@ R3DAPI void R3D_DrawModelPro(R3D_Model model, Matrix transform);
  *
  * Draws multiple instances using the provided instance buffer.
  * Does nothing if the number of instances is <= 0.
- * 
+ *
  * The command is executed during R3D_End().
  */
 R3DAPI void R3D_DrawModelInstanced(R3D_Model model, R3D_InstanceBuffer instances, int count);
 
 /**
- * @brief Queues an instanced model draw command with an additional transform.
+ * @brief Queues an instanced model draw command with an instance range.
  *
- * Does nothing if the number of instances is <= 0.
+ * Draws 'count' instances starting at 'offset' in the instance buffer.
+ * Both 'offset' and 'count' are clamped to stay within [0, instances.capacity]:
+ *   - offset is clamped to [0, capacity]
+ *   - count is clamped to [0, capacity - offset]
+ * Does nothing if the resulting count is <= 0.
+ *
+ * The command is executed during R3D_End().
+ */
+R3DAPI void R3D_DrawModelInstancedEx(R3D_Model model, R3D_InstanceBuffer instances, int offset, int count);
+
+/**
+ * @brief Queues an instanced model draw command with an instance range and an additional transform.
+ *
+ * Draws 'count' instances starting at 'offset' in the instance buffer.
+ * Both 'offset' and 'count' are clamped to stay within [0, instances.capacity]:
+ *   - offset is clamped to [0, capacity]
+ *   - count is clamped to [0, capacity - offset]
+ * Does nothing if the resulting count is <= 0.
  * The transform is applied to all instances.
  *
  * The command is executed during R3D_End().
  */
-R3DAPI void R3D_DrawModelInstancedEx(R3D_Model model, R3D_InstanceBuffer instances, int count, Matrix transform);
+R3DAPI void R3D_DrawModelInstancedPro(R3D_Model model, R3D_InstanceBuffer instances, int offset, int count, Matrix transform);
 
 /**
  * @brief Queues an animated model draw command.
@@ -188,20 +222,37 @@ R3DAPI void R3D_DrawAnimatedModelPro(R3D_Model model, R3D_AnimationPlayer player
  *
  * Draws multiple animated instances using the provided instance buffer.
  * Does nothing if the number of instances is <= 0.
- * 
+ *
  * The command is executed during R3D_End().
  */
 R3DAPI void R3D_DrawAnimatedModelInstanced(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int count);
 
 /**
- * @brief Queues an instanced animated model draw command with an additional transform.
+ * @brief Queues an instanced animated model draw command with an instance range.
  *
- * Does nothing if the number of instances is <= 0.
+ * Draws 'count' animated instances starting at 'offset' in the instance buffer.
+ * Both 'offset' and 'count' are clamped to stay within [0, instances.capacity]:
+ *   - offset is clamped to [0, capacity]
+ *   - count is clamped to [0, capacity - offset]
+ * Does nothing if the resulting count is <= 0.
+ *
+ * The command is executed during R3D_End().
+ */
+R3DAPI void R3D_DrawAnimatedModelInstancedEx(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int offset, int count);
+
+/**
+ * @brief Queues an instanced animated model draw command with an instance range and an additional transform.
+ *
+ * Draws 'count' animated instances starting at 'offset' in the instance buffer.
+ * Both 'offset' and 'count' are clamped to stay within [0, instances.capacity]:
+ *   - offset is clamped to [0, capacity]
+ *   - count is clamped to [0, capacity - offset]
+ * Does nothing if the resulting count is <= 0.
  * The transform is applied to all instances.
  *
  * The command is executed during R3D_End().
  */
-R3DAPI void R3D_DrawAnimatedModelInstancedEx(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int count, Matrix transform);
+R3DAPI void R3D_DrawAnimatedModelInstancedPro(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int offset, int count, Matrix transform);
 
 /**
  * @brief Queues a decal draw command with position and uniform scale.
@@ -229,20 +280,37 @@ R3DAPI void R3D_DrawDecalPro(R3D_Decal decal, Matrix transform);
  *
  * Draws multiple instances using the provided instance buffer.
  * Does nothing if the number of instances is <= 0.
- * 
+ *
  * The command is executed during R3D_End().
  */
 R3DAPI void R3D_DrawDecalInstanced(R3D_Decal decal, R3D_InstanceBuffer instances, int count);
 
 /**
- * @brief Queues an instanced decal draw command with an additional transform.
+ * @brief Queues an instanced decal draw command with an instance range.
  *
- * Does nothing if the number of instances is <= 0.
- * The transform is applied to all instances.
- * 
+ * Draws 'count' instances starting at 'offset' in the instance buffer.
+ * Both 'offset' and 'count' are clamped to stay within [0, instances.capacity]:
+ *   - offset is clamped to [0, capacity]
+ *   - count is clamped to [0, capacity - offset]
+ * Does nothing if the resulting count is <= 0.
+ *
  * The command is executed during R3D_End().
  */
-R3DAPI void R3D_DrawDecalInstancedEx(R3D_Decal decal, R3D_InstanceBuffer instances, int count, Matrix transform);
+R3DAPI void R3D_DrawDecalInstancedEx(R3D_Decal decal, R3D_InstanceBuffer instances, int offset, int count);
+
+/**
+ * @brief Queues an instanced decal draw command with an instance range and an additional transform.
+ *
+ * Draws 'count' instances starting at 'offset' in the instance buffer.
+ * Both 'offset' and 'count' are clamped to stay within [0, instances.capacity]:
+ *   - offset is clamped to [0, capacity]
+ *   - count is clamped to [0, capacity - offset]
+ * Does nothing if the resulting count is <= 0.
+ * The transform is applied to all instances.
+ *
+ * The command is executed during R3D_End().
+ */
+R3DAPI void R3D_DrawDecalInstancedPro(R3D_Decal decal, R3D_InstanceBuffer instances, int offset, int count, Matrix transform);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -21,6 +21,7 @@
 #include "../common/r3d_frustum.h"
 #include "../common/r3d_math.h"
 #include "../common/r3d_hash.h"
+#include "raylib.h"
 
 // ========================================
 // MODULE STATE
@@ -124,13 +125,13 @@ void load_shape_cube(r3d_render_shape_t* shape)
 // INTERNAL INSTANCES FUNCTIONS
 // ========================================
 
-static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT], R3D_InstanceFlags flags)
+static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT], R3D_InstanceFlags flags, int offset)
 {
     if (BIT_TEST(flags, R3D_INSTANCE_POSITION)) {
         glBindBuffer(GL_ARRAY_BUFFER, buffers[0]);
         glEnableVertexAttribArray(10);
         glVertexAttribDivisor(10, 1);
-        glVertexAttribPointer(10, 3, GL_FLOAT, GL_FALSE, sizeof(Vector3), 0);
+        glVertexAttribPointer(10, 3, GL_FLOAT, GL_FALSE, sizeof(Vector3), (void*)(offset * sizeof(Vector3)));
     }
     else {
         glDisableVertexAttribArray(10);
@@ -140,7 +141,7 @@ static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT],
         glBindBuffer(GL_ARRAY_BUFFER, buffers[1]);
         glEnableVertexAttribArray(11);
         glVertexAttribDivisor(11, 1);
-        glVertexAttribPointer(11, 4, GL_FLOAT, GL_FALSE, sizeof(Quaternion), 0);
+        glVertexAttribPointer(11, 4, GL_FLOAT, GL_FALSE, sizeof(Quaternion), (void*)(offset * sizeof(Quaternion)));
     }
     else {
         glDisableVertexAttribArray(11);
@@ -150,7 +151,7 @@ static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT],
         glBindBuffer(GL_ARRAY_BUFFER, buffers[2]);
         glEnableVertexAttribArray(12);
         glVertexAttribDivisor(12, 1);
-        glVertexAttribPointer(12, 3, GL_FLOAT, GL_FALSE, sizeof(Vector3), 0);
+        glVertexAttribPointer(12, 3, GL_FLOAT, GL_FALSE, sizeof(Vector3), (void*)(offset * sizeof(Vector3)));
     }
     else {
         glDisableVertexAttribArray(12);
@@ -160,7 +161,7 @@ static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT],
         glBindBuffer(GL_ARRAY_BUFFER, buffers[3]);
         glEnableVertexAttribArray(13);
         glVertexAttribDivisor(13, 1);
-        glVertexAttribPointer(13, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(Color), 0);
+        glVertexAttribPointer(13, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(Color), (void*)(offset * sizeof(Color)));
     }
     else {
         glDisableVertexAttribArray(13);
@@ -170,7 +171,7 @@ static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT],
         glBindBuffer(GL_ARRAY_BUFFER, buffers[4]);
         glEnableVertexAttribArray(14);
         glVertexAttribDivisor(14, 1);
-        glVertexAttribPointer(14, 4, GL_FLOAT, GL_FALSE, sizeof(Vector4), 0);
+        glVertexAttribPointer(14, 4, GL_FLOAT, GL_FALSE, sizeof(Vector4), (void*)(offset * sizeof(Vector4)));
     }
     else {
         glDisableVertexAttribArray(14);
@@ -853,7 +854,7 @@ void r3d_render_draw_instanced(const r3d_render_call_t* call)
     const r3d_render_group_t* group = r3d_render_get_call_group(call);
     const R3D_InstanceBuffer* instances = &group->instances;
 
-    enable_instances(group->instances.buffers, group->instances.flags);
+    enable_instances(group->instances.buffers, group->instances.flags, group->instanceOffset);
 
     if (elemCount == 0) {
         glDrawArraysInstanced(primitive, 0, vertCount, group->instanceCount);

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -21,7 +21,6 @@
 #include "../common/r3d_frustum.h"
 #include "../common/r3d_math.h"
 #include "../common/r3d_hash.h"
-#include "raylib.h"
 
 // ========================================
 // MODULE STATE

--- a/src/modules/r3d_render.h
+++ b/src/modules/r3d_render.h
@@ -199,6 +199,7 @@ typedef struct {
     r3d_oriented_box_t obb;         //< Oriented bounding box of all drawables contained in the group
     GLuint skinTexture;             //< Texture that contains the bone matrices (can be 0 for non-skinned)
     R3D_InstanceBuffer instances;   //< Instance buffer to use
+    int instanceOffset;             //< Offset to the first instance
     int instanceCount;              //< Number of instances
 } r3d_render_group_t;
 

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -300,10 +300,15 @@ void R3D_DrawMeshPro(R3D_Mesh mesh, R3D_Material material, Matrix transform)
 
 void R3D_DrawMeshInstanced(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int count)
 {
-    R3D_DrawMeshInstancedEx(mesh, material, instances, count, R3D_MATRIX_IDENTITY);
+    R3D_DrawMeshInstancedPro(mesh, material, instances, 0, count, R3D_MATRIX_IDENTITY);
 }
 
-void R3D_DrawMeshInstancedEx(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int count, Matrix transform)
+void R3D_DrawMeshInstancedEx(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int offset, int count)
+{
+    R3D_DrawMeshInstancedPro(mesh, material, instances, offset, count, R3D_MATRIX_IDENTITY);
+}
+
+void R3D_DrawMeshInstancedPro(R3D_Mesh mesh, R3D_Material material, R3D_InstanceBuffer instances, int offset, int count, Matrix transform)
 {
     if (count <= 0) return;
 
@@ -314,7 +319,8 @@ void R3D_DrawMeshInstancedEx(R3D_Mesh mesh, R3D_Material material, R3D_InstanceB
     r3d_render_group_t drawGroup = {0};
     drawGroup.transform = transform;
     drawGroup.instances = instances;
-    drawGroup.instanceCount = CLAMP(count, 0, instances.capacity);
+    drawGroup.instanceOffset = CLAMP(offset, 0, instances.capacity);
+    drawGroup.instanceCount = CLAMP(count, 0, instances.capacity - offset);
 
     r3d_render_group_push(&drawGroup);
 
@@ -366,10 +372,15 @@ void R3D_DrawModelPro(R3D_Model model, Matrix transform)
 
 void R3D_DrawModelInstanced(R3D_Model model, R3D_InstanceBuffer instances, int count)
 {
-    R3D_DrawModelInstancedEx(model, instances, count, R3D_MATRIX_IDENTITY);
+    R3D_DrawModelInstancedPro(model, instances, 0, count, R3D_MATRIX_IDENTITY);
 }
 
-void R3D_DrawModelInstancedEx(R3D_Model model, R3D_InstanceBuffer instances, int count, Matrix transform)
+void R3D_DrawModelInstancedEx(R3D_Model model, R3D_InstanceBuffer instances, int offset, int count)
+{
+    R3D_DrawModelInstancedPro(model, instances, offset, count, R3D_MATRIX_IDENTITY);
+}
+
+void R3D_DrawModelInstancedPro(R3D_Model model, R3D_InstanceBuffer instances, int offset, int count, Matrix transform)
 {
     if (count <= 0) return;
 
@@ -377,7 +388,8 @@ void R3D_DrawModelInstancedEx(R3D_Model model, R3D_InstanceBuffer instances, int
     drawGroup.transform = transform;
     drawGroup.skinTexture = model.skeleton.skinTexture;
     drawGroup.instances = instances;
-    drawGroup.instanceCount = CLAMP(count, 0, instances.capacity);
+    drawGroup.instanceOffset = CLAMP(offset, 0, instances.capacity);
+    drawGroup.instanceCount = CLAMP(count, 0, instances.capacity - offset);
 
     r3d_render_group_push(&drawGroup);
 
@@ -440,17 +452,23 @@ void R3D_DrawAnimatedModelPro(R3D_Model model, R3D_AnimationPlayer player, Matri
 
 void R3D_DrawAnimatedModelInstanced(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int count)
 {
-    R3D_DrawAnimatedModelInstancedEx(model, player, instances, count, R3D_MATRIX_IDENTITY);
+    R3D_DrawAnimatedModelInstancedPro(model, player, instances, 0, count, R3D_MATRIX_IDENTITY);
 }
 
-void R3D_DrawAnimatedModelInstancedEx(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int count, Matrix transform)
+void R3D_DrawAnimatedModelInstancedEx(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int offset, int count)
+{
+    R3D_DrawAnimatedModelInstancedPro(model, player, instances, offset, count, R3D_MATRIX_IDENTITY);
+}
+
+void R3D_DrawAnimatedModelInstancedPro(R3D_Model model, R3D_AnimationPlayer player, R3D_InstanceBuffer instances, int offset, int count, Matrix transform)
 {
     if (count <= 0) return;
 
     r3d_render_group_t drawGroup = {0};
     drawGroup.transform = transform;
     drawGroup.instances = instances;
-    drawGroup.instanceCount = CLAMP(count, 0, instances.capacity);
+    drawGroup.instanceOffset = CLAMP(offset, 0, instances.capacity);
+    drawGroup.instanceCount = CLAMP(count, 0, instances.capacity - offset);
 
     drawGroup.skinTexture = (player.skinTexture > 0)
         ? player.skinTexture : model.skeleton.skinTexture;
@@ -506,10 +524,15 @@ void R3D_DrawDecalPro(R3D_Decal decal, Matrix transform)
 
 void R3D_DrawDecalInstanced(R3D_Decal decal, R3D_InstanceBuffer instances, int count)
 {
-    R3D_DrawDecalInstancedEx(decal, instances, count, R3D_MATRIX_IDENTITY);
+    R3D_DrawDecalInstancedPro(decal, instances, 0, count, R3D_MATRIX_IDENTITY);
 }
 
-void R3D_DrawDecalInstancedEx(R3D_Decal decal, R3D_InstanceBuffer instances, int count, Matrix transform)
+void R3D_DrawDecalInstancedEx(R3D_Decal decal, R3D_InstanceBuffer instances, int offset, int count)
+{
+    R3D_DrawDecalInstancedPro(decal, instances, offset, count, R3D_MATRIX_IDENTITY);
+}
+
+void R3D_DrawDecalInstancedPro(R3D_Decal decal, R3D_InstanceBuffer instances, int offset, int count, Matrix transform)
 {
     if (count <= 0) return;
 
@@ -519,7 +542,8 @@ void R3D_DrawDecalInstancedEx(R3D_Decal decal, R3D_InstanceBuffer instances, int
     r3d_render_group_t drawGroup = {0};
     drawGroup.transform = transform;
     drawGroup.instances = instances;
-    drawGroup.instanceCount = CLAMP(count, 0, instances.capacity);
+    drawGroup.instanceOffset = CLAMP(offset, 0, instances.capacity);
+    drawGroup.instanceCount = CLAMP(count, 0, instances.capacity - offset);
 
     r3d_render_group_push(&drawGroup);
 


### PR DESCRIPTION
Introduces an `offset` parameter to all instanced draw functions, allowing drawing to start at an arbitrary position within an instance buffer. This is useful when multiple mesh types share the same instance buffer.

**Breaking change:** the `Ex` variants no longer accept a `Matrix` parameter, they now take `int offset, int count` instead. A new `Pro` variant has been added for cases where a global transform are needed.