### PR TITLE
`R3D_MeshData` Improvements

### DIFF
--- a/include/r3d/r3d_mesh.h
+++ b/include/r3d/r3d_mesh.h
@@ -76,8 +76,10 @@ typedef enum R3D_ShadowCastMode {
  */
 typedef struct R3D_Mesh {
     uint32_t vao, vbo, ebo;                 ///< OpenGL objects handles.
-    int vertexCount, indexCount;            ///< Number of vertices and indices currently in use.
-    int allocVertexCount, allocIndexCount;  ///< Number of vertices and indices allocated in GPU buffers.
+    int vertexCapacity;                     ///< Number of vertices allocated in GPU buffers.
+    int indexCapacity;                      ///< Number of indices allocated in GPU buffers.
+    int vertexCount;                        ///< Number of vertices currently in use.
+    int indexCount;                         ///< Number of indices currently in use.
     R3D_ShadowCastMode shadowCastMode;      ///< Shadow casting mode for the mesh.
     R3D_PrimitiveType primitiveType;        ///< Type of primitive that constitutes the vertices.
     R3D_MeshUsage usage;                    ///< Hint about the usage of the mesh, retained in case of update if there is a reallocation.
@@ -96,7 +98,7 @@ extern "C" {
 /**
  * @brief Creates a 3D mesh from CPU-side mesh data.
  * @param type Primitive type used to interpret vertex data.
- * @param data R3D_MeshData containing vertices and indices (cannot be NULL).
+ * @param data R3D_MeshData containing vertices and indices (can be zero initialized).
  * @param aabb Optional pointer to a bounding box. If NULL, it will be computed automatically.
  * @param usage Hint on how the mesh will be used.
  * @return Created R3D_Mesh.

--- a/include/r3d/r3d_mesh.h
+++ b/include/r3d/r3d_mesh.h
@@ -33,19 +33,6 @@ typedef enum R3D_MeshUsage {
 } R3D_MeshUsage;
 
 /**
- * @brief Defines the geometric primitive type.
- */
-typedef enum R3D_PrimitiveType {
-    R3D_PRIMITIVE_POINTS,           ///< Each vertex represents a single point.
-    R3D_PRIMITIVE_LINES,            ///< Each pair of vertices forms an independent line segment.
-    R3D_PRIMITIVE_LINE_STRIP,       ///< Connected series of line segments sharing vertices.
-    R3D_PRIMITIVE_LINE_LOOP,        ///< Closed loop of connected line segments.
-    R3D_PRIMITIVE_TRIANGLES,        ///< Each set of three vertices forms an independent triangle.
-    R3D_PRIMITIVE_TRIANGLE_STRIP,   ///< Connected strip of triangles sharing vertices.
-    R3D_PRIMITIVE_TRIANGLE_FAN      ///< Fan of triangles sharing the first vertex.
-} R3D_PrimitiveType;
-
-/**
  * @brief Shadow casting modes for objects.
  *
  * Controls how an object interacts with the shadow mapping system.

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -333,21 +333,6 @@ R3DAPI R3D_MeshData R3D_GenMeshDataHeightmap(Image heightmap, Vector3 size);
 R3DAPI R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize);
 
 /**
- * @brief Creates a deep copy of an existing mesh data container.
- * @param meshData Source mesh data to duplicate.
- * @return A new R3D_MeshData containing a copy of the source data.
- */
-R3DAPI R3D_MeshData R3D_CopyMeshData(R3D_MeshData meshData);
-
-/**
- * @brief Merges two mesh data containers into a single one.
- * @param a First mesh data.
- * @param b Second mesh data.
- * @return A new R3D_MeshData containing the merged geometry.
- */
-R3DAPI R3D_MeshData R3D_MergeMeshData(R3D_MeshData a, R3D_MeshData b);
-
-/**
  * @brief Reserves memory for the specified number of vertices and indices.
  * @param meshData Target mesh data container.
  * @param vertexCount Number of vertices to reserve space for.
@@ -366,6 +351,21 @@ R3DAPI void R3D_ShrinkMeshData(R3D_MeshData* meshData);
  * @param meshData Target mesh data container to reset.
  */
 R3DAPI void R3D_ResetMeshData(R3D_MeshData* meshData);
+
+/**
+ * @brief Creates a deep copy of an existing mesh data container.
+ * @param meshData Source mesh data to duplicate.
+ * @return A new R3D_MeshData containing a copy of the source data.
+ */
+R3DAPI R3D_MeshData R3D_CopyMeshData(R3D_MeshData meshData);
+
+/**
+ * @brief Merges two mesh data containers into a single one.
+ * @param a First mesh data.
+ * @param b Second mesh data.
+ * @return A new R3D_MeshData containing the merged geometry.
+ */
+R3DAPI R3D_MeshData R3D_MergeMeshData(R3D_MeshData a, R3D_MeshData b);
 
 /**
  * @brief Appends vertices and indices to the mesh data container.

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -19,6 +19,23 @@
  */
 
 // ========================================
+// ENUMS TYPES
+// ========================================
+
+/**
+ * @brief Defines the geometric primitive type.
+ */
+typedef enum R3D_PrimitiveType {
+    R3D_PRIMITIVE_POINTS,           ///< Each vertex represents a single point.
+    R3D_PRIMITIVE_LINES,            ///< Each pair of vertices forms an independent line segment.
+    R3D_PRIMITIVE_LINE_STRIP,       ///< Connected series of line segments sharing vertices.
+    R3D_PRIMITIVE_LINE_LOOP,        ///< Closed loop of connected line segments.
+    R3D_PRIMITIVE_TRIANGLES,        ///< Each set of three vertices forms an independent triangle.
+    R3D_PRIMITIVE_TRIANGLE_STRIP,   ///< Connected strip of triangles sharing vertices.
+    R3D_PRIMITIVE_TRIANGLE_FAN      ///< Fan of triangles sharing the first vertex.
+} R3D_PrimitiveType;
+
+// ========================================
 // STRUCTS TYPES
 // ========================================
 
@@ -406,14 +423,18 @@ R3DAPI void R3D_GenMeshDataUVsCylindrical(R3D_MeshData* meshData);
 /**
  * @brief Computes vertex normals from triangle geometry.
  * @param meshData Mesh data to modify.
+ * @param type Primitive type of the mesh. Points and line primitives are not
+ *             supported and will default to a front-facing normal (0, 0, 1).
  */
-R3DAPI void R3D_GenMeshDataNormals(R3D_MeshData* meshData);
+R3DAPI void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType type);
 
 /**
  * @brief Computes vertex tangents based on existing normals and UVs.
  * @param meshData Mesh data to modify.
+ * @param type Primitive type of the mesh. Points and line primitives are not
+ *             supported and will default to a front-facing tangent (1, 0, 0, 1).
  */
-R3DAPI void R3D_GenMeshDataTangents(R3D_MeshData* meshData);
+R3DAPI void R3D_GenMeshDataTangents(R3D_MeshData* meshData, R3D_PrimitiveType type);
 
 /**
  * @brief Calculates the axis-aligned bounding box of the mesh.

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -47,6 +47,8 @@ typedef struct R3D_Vertex {
 typedef struct R3D_MeshData {
     R3D_Vertex* vertices;       ///< Pointer to vertex data in CPU memory.
     uint32_t* indices;          ///< Pointer to index data in CPU memory.
+    int vertexCapacity;         ///< Capacity of vertices.
+    int indexCapacity;          ///< Capacity of indices.
     int vertexCount;            ///< Number of vertices.
     int indexCount;             ///< Number of indices.
 } R3D_MeshData;
@@ -327,6 +329,38 @@ R3DAPI R3D_MeshData R3D_CopyMeshData(R3D_MeshData meshData);
  * @return A new R3D_MeshData containing the merged geometry.
  */
 R3DAPI R3D_MeshData R3D_MergeMeshData(R3D_MeshData a, R3D_MeshData b);
+
+/**
+ * @brief Reserves memory for the specified number of vertices and indices.
+ * @param meshData Target mesh data container.
+ * @param vertexCount Number of vertices to reserve space for.
+ * @param indexCount Number of indices to reserve space for.
+ */
+R3DAPI void R3D_ReserveMeshData(R3D_MeshData* meshData, int vertexCount, int indexCount);
+
+/**
+ * @brief Clears all vertices and indices without releasing allocated memory.
+ * @param meshData Target mesh data container to reset.
+ */
+R3DAPI void R3D_ResetMeshData(R3D_MeshData* meshData);
+
+/**
+ * @brief Appends vertices and indices to the mesh data container.
+ * @param meshData Target mesh data container.
+ * @param vertices Array of vertices to append.
+ * @param vertexCount Number of vertices to append.
+ * @param indices Array of indices to append.
+ * @param indexCount Number of indices to append.
+ */
+R3DAPI void R3D_PushMeshData(R3D_MeshData* meshData, R3D_Vertex* vertices, int vertexCount, uint32_t* indices, int indexCount);
+
+/**
+ * @brief Removes the specified number of vertices and indices from the end.
+ * @param meshData Target mesh data container.
+ * @param vertexCount Number of vertices to remove.
+ * @param indexCount Number of indices to remove.
+ */
+R3DAPI void R3D_PopMeshData(R3D_MeshData* meshData, int vertexCount, int indexCount);
 
 /**
  * @brief Translates all vertices by a given offset.

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -71,7 +71,7 @@ extern "C" {
  *
  * @return A new R3D_MeshData instance with allocated memory.
  */
-R3DAPI R3D_MeshData R3D_CreateMeshData(int vertexCount, int indexCount);
+R3DAPI R3D_MeshData R3D_LoadMeshData(int vertexCount, int indexCount);
 
 /**
  * @brief Releases memory used by a mesh data container.
@@ -318,7 +318,7 @@ R3DAPI R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize);
  * @param meshData Source mesh data to duplicate.
  * @return A new R3D_MeshData containing a copy of the source data.
  */
-R3DAPI R3D_MeshData R3D_DuplicateMeshData(R3D_MeshData meshData);
+R3DAPI R3D_MeshData R3D_CopyMeshData(R3D_MeshData meshData);
 
 /**
  * @brief Merges two mesh data containers into a single one.

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -356,6 +356,12 @@ R3DAPI R3D_MeshData R3D_MergeMeshData(R3D_MeshData a, R3D_MeshData b);
 R3DAPI void R3D_ReserveMeshData(R3D_MeshData* meshData, int vertexCount, int indexCount);
 
 /**
+ * @brief Shrinks allocated memory to fit the current vertex and index counts.
+ * @param meshData Target mesh data container to shrink.
+ */
+R3DAPI void R3D_ShrinkMeshData(R3D_MeshData* meshData);
+
+/**
  * @brief Clears all vertices and indices without releasing allocated memory.
  * @param meshData Target mesh data container to reset.
  */
@@ -369,15 +375,14 @@ R3DAPI void R3D_ResetMeshData(R3D_MeshData* meshData);
  * @param indices Array of indices to append.
  * @param indexCount Number of indices to append.
  */
-R3DAPI void R3D_PushMeshData(R3D_MeshData* meshData, R3D_Vertex* vertices, int vertexCount, uint32_t* indices, int indexCount);
+R3DAPI void R3D_AppendMeshData(R3D_MeshData* meshData, R3D_Vertex* vertices, int vertexCount, uint32_t* indices, int indexCount);
 
 /**
- * @brief Removes the specified number of vertices and indices from the end.
+ * @brief Applies a transformation matrix to all vertices in the mesh data.
  * @param meshData Target mesh data container.
- * @param vertexCount Number of vertices to remove.
- * @param indexCount Number of indices to remove.
+ * @param transform Transformation matrix to apply.
  */
-R3DAPI void R3D_PopMeshData(R3D_MeshData* meshData, int vertexCount, int indexCount);
+R3DAPI void R3D_TransformMeshData(R3D_MeshData* meshData, Matrix transform);
 
 /**
  * @brief Translates all vertices by a given offset.

--- a/src/importer/r3d_importer_mesh.c
+++ b/src/importer/r3d_importer_mesh.c
@@ -271,7 +271,7 @@ static bool load_mesh_internal(
     int vertexCount = aiMesh->mNumVertices;
     int indexCount = 3 * aiMesh->mNumFaces;
 
-    R3D_MeshData data = R3D_CreateMeshData(vertexCount, indexCount);
+    R3D_MeshData data = R3D_LoadMeshData(vertexCount, indexCount);
     if (!data.vertices || !data.indices) {
         R3D_TRACELOG(LOG_ERROR, "Failed to load mesh; Unable to allocate mesh data");
         return false;

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -892,14 +892,31 @@ void r3d_render_create_vertex_array(
     glGenVertexArrays(1, vao);
     glBindVertexArray(*vao);
 
-    glGenBuffers(1, vbo);
-    glBindBuffer(GL_ARRAY_BUFFER, *vbo);
-    glBufferData(
-        GL_ARRAY_BUFFER,
-        vertexCount * sizeof(R3D_Vertex),
-        vertices,
-        usage
-    );
+    GLuint buffers[2] = {0};
+    glGenBuffers(2, buffers);
+    glBindBuffer(GL_ARRAY_BUFFER, buffers[0]);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buffers[1]);
+
+    *vbo = buffers[0];
+    *ebo = buffers[1];
+
+    if (vertexCount > 0) {
+        glBufferData(
+            GL_ARRAY_BUFFER,
+            vertexCount * sizeof(R3D_Vertex),
+            vertices,
+            usage
+        );
+    }
+
+    if (indexCount > 0) {
+        glBufferData(
+            GL_ELEMENT_ARRAY_BUFFER,
+            indexCount * indexStride,
+            indices,
+            usage
+        );
+    }
 
     // position (vec3)
     glEnableVertexAttribArray(0);
@@ -936,19 +953,6 @@ void r3d_render_create_vertex_array(
     glVertexAttrib4f(13, 1.0f, 1.0f, 1.0f, 1.0f);
     glVertexAttrib4f(14, 0.0f, 0.0f, 0.0f, 0.0f);
 
-    if (indexCount > 0) {
-        glGenBuffers(1, ebo);
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, *ebo);
-        glBufferData(
-            GL_ELEMENT_ARRAY_BUFFER,
-            indexCount * indexStride,
-            indices,
-            usage
-        );
-    }
-    else {
-        *ebo = 0;
-    }
-
+    // VAO setup completed!
     glBindVertexArray(0);
 }

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -369,7 +369,7 @@ void R3D_DrawModelPro(R3D_Model model, Matrix transform)
     {
         const R3D_Mesh* mesh = &model.meshes[i];
         if (!IS_MESH_DRAWABLE(*mesh, R3D.layers)) {
-            return;
+            continue;
         }
 
         r3d_render_call_t drawCall = {0};
@@ -408,7 +408,7 @@ void R3D_DrawModelInstancedPro(R3D_Model model, R3D_InstanceBuffer instances, in
     {
         const R3D_Mesh* mesh = &model.meshes[i];
         if (!IS_MESH_DRAWABLE(*mesh, R3D.layers)) {
-            return;
+            continue;
         }
 
         r3d_render_call_t drawCall = {0};
@@ -447,7 +447,7 @@ void R3D_DrawAnimatedModelPro(R3D_Model model, R3D_AnimationPlayer player, Matri
     {
         const R3D_Mesh* mesh = &model.meshes[i];
         if (!IS_MESH_DRAWABLE(*mesh, R3D.layers)) {
-            return;
+            continue;
         }
 
         r3d_render_call_t drawCall = {0};
@@ -488,7 +488,7 @@ void R3D_DrawAnimatedModelInstancedPro(R3D_Model model, R3D_AnimationPlayer play
     {
         const R3D_Mesh* mesh = &model.meshes[i];
         if (!IS_MESH_DRAWABLE(*mesh, R3D.layers)) {
-            return;
+            continue;
         }
 
         r3d_render_call_t drawCall = {0};

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -34,14 +34,20 @@
 // HELPER MACROS
 // ========================================
 
-#define R3D_SHADOW_CAST_ONLY_MASK ( \
-    (1 << R3D_SHADOW_CAST_ONLY_AUTO) | \
-    (1 << R3D_SHADOW_CAST_ONLY_DOUBLE_SIDED) | \
-    (1 << R3D_SHADOW_CAST_ONLY_FRONT_SIDE) | \
-    (1 << R3D_SHADOW_CAST_ONLY_BACK_SIDE) \
+#define IS_MESH_VALID(mesh)                     \
+    (((mesh).vao != 0) && ((mesh).vertexCount > 0))
+
+#define IS_MESH_DRAWABLE(mesh, cullMask)        \
+    (IS_MESH_VALID(mesh) && BIT_TEST_ANY((cullMask), (mesh).layerMask))
+
+#define SHADOW_CAST_ONLY_MASK (                 \
+    (1 << R3D_SHADOW_CAST_ONLY_AUTO) |          \
+    (1 << R3D_SHADOW_CAST_ONLY_DOUBLE_SIDED) |  \
+    (1 << R3D_SHADOW_CAST_ONLY_FRONT_SIDE) |    \
+    (1 << R3D_SHADOW_CAST_ONLY_BACK_SIDE)       \
 )
 
-#define R3D_IS_SHADOW_CAST_ONLY(mode) \
+#define IS_SHADOW_CAST_ONLY(mode)               \
     ((R3D_SHADOW_CAST_ONLY_MASK & (1 << (mode))) != 0)
 
 // ========================================
@@ -286,7 +292,7 @@ void R3D_DrawMeshEx(R3D_Mesh mesh, R3D_Material material, Vector3 position, Quat
 
 void R3D_DrawMeshPro(R3D_Mesh mesh, R3D_Material material, Matrix transform)
 {
-    if (!BIT_TEST_ANY(R3D.layers, mesh.layerMask)) {
+    if (!IS_MESH_DRAWABLE(mesh, R3D.layers)) {
         return;
     }
 
@@ -318,7 +324,7 @@ void R3D_DrawMeshInstancedPro(R3D_Mesh mesh, R3D_Material material, R3D_Instance
 {
     if (count <= 0) return;
 
-    if (!BIT_TEST_ANY(R3D.layers, mesh.layerMask)) {
+    if (!IS_MESH_DRAWABLE(mesh, R3D.layers)) {
         return;
     }
 
@@ -362,9 +368,8 @@ void R3D_DrawModelPro(R3D_Model model, Matrix transform)
     for (int i = 0; i < model.meshCount; i++)
     {
         const R3D_Mesh* mesh = &model.meshes[i];
-
-        if (!BIT_TEST_ANY(R3D.layers, mesh->layerMask)) {
-            continue;
+        if (!IS_MESH_DRAWABLE(*mesh, R3D.layers)) {
+            return;
         }
 
         r3d_render_call_t drawCall = {0};
@@ -402,9 +407,8 @@ void R3D_DrawModelInstancedPro(R3D_Model model, R3D_InstanceBuffer instances, in
     for (int i = 0; i < model.meshCount; i++)
     {
         const R3D_Mesh* mesh = &model.meshes[i];
-
-        if (!BIT_TEST_ANY(R3D.layers, mesh->layerMask)) {
-            continue;
+        if (!IS_MESH_DRAWABLE(*mesh, R3D.layers)) {
+            return;
         }
 
         r3d_render_call_t drawCall = {0};
@@ -442,9 +446,8 @@ void R3D_DrawAnimatedModelPro(R3D_Model model, R3D_AnimationPlayer player, Matri
     for (int i = 0; i < model.meshCount; i++)
     {
         const R3D_Mesh* mesh = &model.meshes[i];
-
-        if (!BIT_TEST_ANY(R3D.layers, mesh->layerMask)) {
-            continue;
+        if (!IS_MESH_DRAWABLE(*mesh, R3D.layers)) {
+            return;
         }
 
         r3d_render_call_t drawCall = {0};
@@ -484,9 +487,8 @@ void R3D_DrawAnimatedModelInstancedPro(R3D_Model model, R3D_AnimationPlayer play
     for (int i = 0; i < model.meshCount; i++)
     {
         const R3D_Mesh* mesh = &model.meshes[i];
-
-        if (!BIT_TEST_ANY(R3D.layers, mesh->layerMask)) {
-            continue;
+        if (!IS_MESH_DRAWABLE(*mesh, R3D.layers)) {
+            return;
         }
 
         r3d_render_call_t drawCall = {0};

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -1738,6 +1738,58 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
     return meshData;
 }
 
+void R3D_ReserveMeshData(R3D_MeshData* meshData, int vertexCount, int indexCount)
+{
+    if (vertexCount > meshData->vertexCapacity) {
+        void* vertices = RL_REALLOC(meshData->vertices, vertexCount * sizeof(*meshData->vertices));
+        if (vertices == NULL) {
+            R3D_TRACELOG(LOG_WARNING, "Failed to reserve vertices memory");
+            return;
+        }
+        meshData->vertexCapacity = vertexCount;
+        meshData->vertices = vertices;
+    }
+
+    if (indexCount > meshData->indexCapacity) {
+        void* indices = RL_REALLOC(meshData->indices, indexCount * sizeof(*meshData->indices));
+        if (indices == NULL) {
+            R3D_TRACELOG(LOG_WARNING, "Failed to reserve indices memory");
+            return;
+        }
+        meshData->indexCapacity = indexCount;
+        meshData->indices = indices;
+    }
+}
+
+void R3D_ShrinkMeshData(R3D_MeshData* meshData)
+{
+    if (meshData->vertexCount > 0 && meshData->vertexCount != meshData->vertexCapacity) {
+        void* vertices = RL_REALLOC(meshData->vertices, meshData->vertexCount * sizeof(*meshData->vertices));
+        if (vertices == NULL) {
+            R3D_TRACELOG(LOG_WARNING, "Failed to shrink vertices memory");
+            return;
+        }
+        meshData->vertexCapacity = meshData->vertexCount;
+        meshData->vertices = vertices;
+    }
+
+    if (meshData->indexCount > 0 && meshData->indexCount != meshData->indexCapacity) {
+        void* indices = RL_REALLOC(meshData->indices, meshData->indexCount * sizeof(*meshData->indices));
+        if (indices == NULL) {
+            R3D_TRACELOG(LOG_WARNING, "Failed to shrink indices memory");
+            return;
+        }
+        meshData->indexCapacity = meshData->indexCount;
+        meshData->indices = indices;
+    }
+}
+
+void R3D_ResetMeshData(R3D_MeshData* meshData)
+{
+    meshData->vertexCount = 0;
+    meshData->indexCount = 0;
+}
+
 R3D_MeshData R3D_CopyMeshData(R3D_MeshData meshData)
 {
     R3D_MeshData duplicate = {0};
@@ -1793,58 +1845,6 @@ R3D_MeshData R3D_MergeMeshData(R3D_MeshData a, R3D_MeshData b)
     }
 
     return merged;
-}
-
-void R3D_ReserveMeshData(R3D_MeshData* meshData, int vertexCount, int indexCount)
-{
-    if (vertexCount > meshData->vertexCapacity) {
-        void* vertices = RL_REALLOC(meshData->vertices, vertexCount * sizeof(*meshData->vertices));
-        if (vertices == NULL) {
-            R3D_TRACELOG(LOG_WARNING, "Failed to reserve vertices memory");
-            return;
-        }
-        meshData->vertexCapacity = vertexCount;
-        meshData->vertices = vertices;
-    }
-
-    if (indexCount > meshData->indexCapacity) {
-        void* indices = RL_REALLOC(meshData->indices, indexCount * sizeof(*meshData->indices));
-        if (indices == NULL) {
-            R3D_TRACELOG(LOG_WARNING, "Failed to reserve indices memory");
-            return;
-        }
-        meshData->indexCapacity = indexCount;
-        meshData->indices = indices;
-    }
-}
-
-void R3D_ShrinkMeshData(R3D_MeshData* meshData)
-{
-    if (meshData->vertexCount > 0 && meshData->vertexCount != meshData->vertexCapacity) {
-        void* vertices = RL_REALLOC(meshData->vertices, meshData->vertexCount * sizeof(*meshData->vertices));
-        if (vertices == NULL) {
-            R3D_TRACELOG(LOG_WARNING, "Failed to shrink vertices memory");
-            return;
-        }
-        meshData->vertexCapacity = meshData->vertexCount;
-        meshData->vertices = vertices;
-    }
-
-    if (meshData->indexCount > 0 && meshData->indexCount != meshData->indexCapacity) {
-        void* indices = RL_REALLOC(meshData->indices, meshData->indexCount * sizeof(*meshData->indices));
-        if (indices == NULL) {
-            R3D_TRACELOG(LOG_WARNING, "Failed to shrink indices memory");
-            return;
-        }
-        meshData->indexCapacity = meshData->indexCount;
-        meshData->indices = indices;
-    }
-}
-
-void R3D_ResetMeshData(R3D_MeshData* meshData)
-{
-    meshData->vertexCount = 0;
-    meshData->indexCount = 0;
 }
 
 void R3D_AppendMeshData(R3D_MeshData* meshData, R3D_Vertex* vertices, int vertexCount, uint32_t* indices, int indexCount)

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -1739,7 +1739,7 @@ void R3D_ReserveMeshData(R3D_MeshData* meshData, int vertexCount, int indexCount
     if (vertexCount > meshData->vertexCapacity) {
         void* vertices = RL_REALLOC(meshData->vertices, vertexCount * sizeof(*meshData->vertices));
         if (vertices == NULL) {
-            R3D_TRACELOG(LOG_WARNING, "");
+            R3D_TRACELOG(LOG_WARNING, "Failed to reserve vertices memory");
             return;
         }
         meshData->vertexCapacity = vertexCount;
@@ -1749,7 +1749,7 @@ void R3D_ReserveMeshData(R3D_MeshData* meshData, int vertexCount, int indexCount
     if (indexCount > meshData->indexCapacity) {
         void* indices = RL_REALLOC(meshData->indices, indexCount * sizeof(*meshData->indices));
         if (indices == NULL) {
-            R3D_TRACELOG(LOG_WARNING, "");
+            R3D_TRACELOG(LOG_WARNING, "Failed to reserve indices memory");
             return;
         }
         meshData->indexCapacity = indexCount;

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -38,7 +38,7 @@ static void gen_cube_face(
 // PUBLIC API
 // ========================================
 
-R3D_MeshData R3D_CreateMeshData(int vertexCount, int indexCount)
+R3D_MeshData R3D_LoadMeshData(int vertexCount, int indexCount)
 {
     R3D_MeshData meshData = {0};
 
@@ -1675,7 +1675,7 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
     return meshData;
 }
 
-R3D_MeshData R3D_DuplicateMeshData(R3D_MeshData meshData)
+R3D_MeshData R3D_CopyMeshData(R3D_MeshData meshData)
 {
     R3D_MeshData duplicate = {0};
 
@@ -1684,7 +1684,7 @@ R3D_MeshData R3D_DuplicateMeshData(R3D_MeshData meshData)
         return duplicate;
     }
 
-    duplicate = R3D_CreateMeshData(meshData.vertexCount, meshData.indexCount);
+    duplicate = R3D_LoadMeshData(meshData.vertexCount, meshData.indexCount);
     if (duplicate.vertices == NULL) {
         return duplicate;
     }
@@ -1710,7 +1710,7 @@ R3D_MeshData R3D_MergeMeshData(R3D_MeshData a, R3D_MeshData b)
     int totalVertices = a.vertexCount + b.vertexCount;
     int totalIndices = a.indexCount + b.indexCount;
 
-    merged = R3D_CreateMeshData(totalVertices, totalIndices);
+    merged = R3D_LoadMeshData(totalVertices, totalIndices);
 
     if (merged.vertices == NULL) {
         return merged;

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -15,7 +15,6 @@
 
 #include "./common/r3d_helper.h"
 #include "common/r3d_math.h"
-#include "raylib.h"
 
 // ========================================
 // INTERNAL FUNCTIONS


### PR DESCRIPTION
This PR revises a few things to make working with custom / dynamic meshes a bit more pleasant.

---

### Breaking Changes

**Function renames** (better naming consistency):
- `R3D_CreateMeshData()` -> `R3D_LoadMeshData()`
- `R3D_DuplicateMeshData()` -> `R3D_CopyMeshData()`

**`R3D_MeshData`** gets two new members: `int vertexCapacity` and `int indexCapacity`, which track the amount of allocated storage. `vertexCount` and `indexCount` now strictly represent the data to be considered when uploading to a `R3D_Mesh` or when used by `r3d_kinematics` functions.

**`R3D_Mesh`**: `allocVertexCount` and `allocIndexCount` renamed to `vertexCapacity` and `indexCapacity` for consistency with the above.

**`R3D_GenMeshDataNormals()` and `R3D_GenMeshDataTangents()`** now take a `R3D_PrimitiveType` parameter to handle the topology correctly.

---

### New API

A few functions to manage `R3D_MeshData` as a dynamic container _(+ a transform function)_:

```c
R3DAPI void R3D_ReserveMeshData(R3D_MeshData* meshData, int vertexCount, int indexCount);
R3DAPI void R3D_ShrinkMeshData(R3D_MeshData* meshData);
R3DAPI void R3D_ResetMeshData(R3D_MeshData* meshData);
R3DAPI void R3D_AppendMeshData(R3D_MeshData* meshData, R3D_Vertex* vertices, int vertexCount, uint32_t* indices, int indexCount);
R3DAPI void R3D_TransformMeshData(R3D_MeshData* meshData, Matrix transform);
```

---

### Behavior changes

`R3D_LoadMesh()` now accepts empty (zero-initialized) mesh data. In that case it only generates the OpenGL objects, without any allocation or upload. You can then call `R3D_UpdateMesh()` whenever you have data ready and everything will be handled automatically.

Meshes with no VBO or no vertex count are now silently ignored during draw calls.

Note: it is still the user's responsibility to keep indexed and non-indexed operations consistent. The worst that can realistically happen is that part of the mesh won't be rendered.