### PR TITLE
Add `R3D_SetTextureWrap`

### DIFF
--- a/examples/kinematics.c
+++ b/examples/kinematics.c
@@ -20,6 +20,7 @@ int main(void)
 
     R3D_Init(GetScreenWidth(), GetScreenHeight());
     R3D_SetTextureFilter(TEXTURE_FILTER_ANISOTROPIC_8X);
+    R3D_SetTextureWrap(TEXTURE_WRAP_REPEAT);
 
     R3D_Cubemap sky = R3D_GenProceduralSky(1024, R3D_PROCEDURAL_SKY_BASE);
     R3D_AmbientMap ambient = R3D_GenAmbientMap(sky, R3D_AMBIENT_ILLUMINATION | R3D_AMBIENT_REFLECTION);

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -304,6 +304,19 @@ R3DAPI void R3D_SetOutputMode(R3D_OutputMode mode);
 R3DAPI void R3D_SetTextureFilter(TextureFilter filter);
 
 /**
+ * @brief Sets the default texture wrap mode.
+ *
+ * This function only affects textures that are loaded manually for material maps.
+ * Textures loaded automatically during model import will use the wrap mode
+ * defined in the model file itself.
+ *
+ * The default texture wrap mode is `TEXTURE_WRAP_CLAMP`.
+ *
+ * @param wrap The texture wrap mode to apply by default.
+ */
+R3DAPI void R3D_SetTextureWrap(TextureWrap wrap);
+
+/**
  * @brief Set the working color space for user-provided surface colors and color textures.
  *
  * Defines how all *color inputs* should be interpreted:

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -21,7 +21,6 @@
 #include "./modules/r3d_render.h"
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_env.h"
-#include "raylib.h"
 
 // ========================================
 // SHARED CORE STATE

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -21,6 +21,7 @@
 #include "./modules/r3d_render.h"
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_env.h"
+#include "raylib.h"
 
 // ========================================
 // SHARED CORE STATE
@@ -54,6 +55,7 @@ bool R3D_Init(int resWidth, int resHeight)
     R3D.outputMode = R3D_OUTPUT_SCENE;
 
     R3D.textureFilter = TEXTURE_FILTER_TRILINEAR;
+    R3D.textureWrap = TEXTURE_WRAP_CLAMP;
     R3D.colorSpace = R3D_COLORSPACE_SRGB;
     R3D.layers = R3D_LAYER_ALL;
 
@@ -159,6 +161,11 @@ void R3D_SetOutputMode(R3D_OutputMode mode)
 void R3D_SetTextureFilter(TextureFilter filter)
 {
     R3D.textureFilter = filter;
+}
+
+void R3D_SetTextureWrap(TextureWrap wrap)
+{
+    R3D.textureWrap = wrap;
 }
 
 void R3D_SetColorSpace(R3D_ColorSpace space)

--- a/src/r3d_core_state.h
+++ b/src/r3d_core_state.h
@@ -53,6 +53,7 @@ extern struct r3d_core_state {
     R3D_DownscaleMode downscaleMode;    //< Downscaling mode used during the final blit
     R3D_OutputMode outputMode;          //< Defines which buffer we should output in R3D_End()
     TextureFilter textureFilter;        //< Default texture filter for model loading
+    TextureWrap textureWrap;            //< Default texture wrap for material map loading
     R3D_ColorSpace colorSpace;          //< Color space that must be considered for supplied colors or surface colors
     Matrix matCubeViews[6];             //< Pre-computed view matrices for cubemap faces
     R3D_Layer layers;                   //< Active rendering layers

--- a/src/r3d_material.c
+++ b/src/r3d_material.c
@@ -124,7 +124,7 @@ R3D_AlbedoMap R3D_LoadAlbedoMap(const char* fileName, Color color)
 
     bool srgb = (R3D.colorSpace == R3D_COLORSPACE_SRGB);
 
-    map.texture = r3d_image_upload(&image, TEXTURE_WRAP_CLAMP, R3D.textureFilter, srgb);
+    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, srgb);
     map.color = color;
 
     if (map.texture.id != 0) {
@@ -151,7 +151,7 @@ R3D_AlbedoMap R3D_LoadAlbedoMapFromMemory(const char* fileType, const void* file
 
     bool srgb = (R3D.colorSpace == R3D_COLORSPACE_SRGB);
 
-    map.texture = r3d_image_upload(&image, TEXTURE_WRAP_CLAMP, R3D.textureFilter, srgb);
+    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, srgb);
     map.color = color;
 
     if (map.texture.id != 0) {
@@ -187,7 +187,7 @@ R3D_EmissionMap R3D_LoadEmissionMap(const char* fileName, Color color, float ene
 
     bool srgb = (R3D.colorSpace == R3D_COLORSPACE_SRGB);
 
-    map.texture = r3d_image_upload(&image, TEXTURE_WRAP_CLAMP, R3D.textureFilter, srgb);
+    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, srgb);
     map.color = color;
     map.energy = energy;
 
@@ -215,7 +215,7 @@ R3D_EmissionMap R3D_LoadEmissionMapFromMemory(const char* fileType, const void* 
 
     bool srgb = (R3D.colorSpace == R3D_COLORSPACE_SRGB);
 
-    map.texture = r3d_image_upload(&image, TEXTURE_WRAP_CLAMP, R3D.textureFilter, srgb);
+    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, srgb);
     map.color = color;
     map.energy = energy;
 
@@ -250,7 +250,7 @@ R3D_NormalMap R3D_LoadNormalMap(const char* fileName, float scale)
         return map;
     }
 
-    map.texture = r3d_image_upload(&image, TEXTURE_WRAP_CLAMP, R3D.textureFilter, false);
+    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, false);
     map.scale = scale;
 
     if (map.texture.id != 0) {
@@ -275,7 +275,7 @@ R3D_NormalMap R3D_LoadNormalMapFromMemory(const char* fileType, const void* file
         return map;
     }
 
-    map.texture = r3d_image_upload(&image, TEXTURE_WRAP_CLAMP, R3D.textureFilter, false);
+    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, false);
     map.scale = scale;
 
     if (map.texture.id != 0) {
@@ -309,7 +309,7 @@ R3D_OrmMap R3D_LoadOrmMap(const char* fileName, float occlusion, float roughness
         return map;
     }
 
-    map.texture = r3d_image_upload(&image, TEXTURE_WRAP_CLAMP, R3D.textureFilter, false);
+    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, false);
     map.occlusion = occlusion;
     map.roughness = roughness;
     map.metalness = metalness;
@@ -337,7 +337,7 @@ R3D_OrmMap R3D_LoadOrmMapFromMemory(const char* fileType, const void* fileData, 
         return map;
     }
 
-    map.texture = r3d_image_upload(&image, TEXTURE_WRAP_CLAMP, R3D.textureFilter, false);
+    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, false);
     map.occlusion = occlusion;
     map.roughness = roughness;
     map.metalness = metalness;


### PR DESCRIPTION
Added the function `void R3D_SetTextureWrap(TextureWrap wrap)` to allow setting the default texture wrap mode.

Currently, this function only affects textures loaded manually for material maps. Materials loaded from model files through the importer will continue to use the wrap mode provided by Assimp.