### PR TITLE
Light toggle shadow check

### DIFF
--- a/src/r3d_lighting.c
+++ b/src/r3d_lighting.c
@@ -64,7 +64,7 @@ void R3D_ToggleLight(R3D_Light id)
     GET_LIGHT_OR_RETURN(light, id);
     light->enabled = !light->enabled;
 
-    if (light->enabled && light->enabled) {
+    if (light->enabled && light->shadowLayer >= 0) {
         light->state.shadowShouldBeUpdated = true;
     }
 }


### PR DESCRIPTION
`R3D_ToggleLight` had a redundant check for if the light was enabled instead of checking if it was using shadows when determining if the light's shadow should be flagged for update.