### PR TITLE
Super Sampling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,8 @@ embed_shaders(${PROJECT_NAME}
     # Blit
     "${R3D_ROOT_PATH}/shaders/blit/up_bicubic.frag"
     "${R3D_ROOT_PATH}/shaders/blit/up_lanczos.frag"
+    "${R3D_ROOT_PATH}/shaders/blit/down_rgss.frag"
+    "${R3D_ROOT_PATH}/shaders/blit/down_pdss.frag"
 )
 
 embed_assets(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,8 +304,6 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/generic/cubemap.vert"
     # Prepare
     "${R3D_ROOT_PATH}/shaders/prepare/atrous_wavelet.frag"
-    "${R3D_ROOT_PATH}/shaders/prepare/bicubic_up.frag"
-    "${R3D_ROOT_PATH}/shaders/prepare/lanczos_up.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/smaa_blending_weigths.vert"
     "${R3D_ROOT_PATH}/shaders/prepare/smaa_blending_weigths.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/smaa_edge_detection.vert"
@@ -356,6 +354,9 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/post/smaa.vert"
     "${R3D_ROOT_PATH}/shaders/post/smaa.frag"
     "${R3D_ROOT_PATH}/shaders/post/visualizer.frag"
+    # Blit
+    "${R3D_ROOT_PATH}/shaders/blit/up_bicubic.frag"
+    "${R3D_ROOT_PATH}/shaders/blit/up_lanczos.frag"
 )
 
 embed_assets(${PROJECT_NAME}

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -100,7 +100,7 @@ typedef enum R3D_AspectMode {
 typedef enum R3D_UpscaleMode {
     R3D_UPSCALE_NEAREST,    ///< Nearest-neighbor upscaling: very fast, but produces blocky pixels.
     R3D_UPSCALE_LINEAR,     ///< Bilinear upscaling: very fast, smoother than nearest, but can appear blurry.
-    R3D_UPSCALE_BICUBIC,    ///< Bicubic (Catmull-Rom) upscaling: slower, smoother, and less blurry than linear.
+    R3D_UPSCALE_BICUBIC,    ///< Bicubic upscaling: slower, smoother, and less blurry than linear.
     R3D_UPSCALE_LANCZOS     ///< Lanczos-2 upscaling: preserves more fine details, but is the most expensive.
 } R3D_UpscaleMode;
 
@@ -111,8 +111,9 @@ typedef enum R3D_UpscaleMode {
  */
 typedef enum R3D_DownscaleMode {
     R3D_DOWNSCALE_NEAREST,  ///< Nearest-neighbor downscaling: very fast, but produces aliasing.
-    R3D_DOWNSCALE_LINEAR,   ///< Bilinear downscaling: very fast, can serve as a basic form of anti-aliasing (SSAA).
-    R3D_DOWNSCALE_BOX       ///< Box-blur downscaling: uses a simple but effective box blur, slightly more expensive than linear, smooths moiré better.
+    R3D_DOWNSCALE_LINEAR,   ///< Bilinear filtering. Fast, may show moire on high-frequency content.
+    R3D_DOWNSCALE_RGSS,     ///< 4-sample supersampling. Reduces aliasing and moire, low cost. Recommended default.
+    R3D_DOWNSCALE_PDSS      ///< 16-sample supersampling. Better color accuracy than RGSS, higher cost.
 } R3D_DownscaleMode;
 
 /**

--- a/shaders/blit/down_pdss.frag
+++ b/shaders/blit/down_pdss.frag
@@ -1,0 +1,63 @@
+/* down_pdss.frag -- Poisson Disk Super Sampling fragment shader
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+/* === Varyings === */
+
+noperspective in vec2 vTexCoord;
+
+/* === Uniforms === */
+
+uniform sampler2D uSourceTex;
+uniform vec2 uDestTexel;
+
+/* === Fragments === */
+
+out vec4 FragColor;
+
+/* === Main program === */
+
+void main()
+{
+    const vec2 o00 = vec2( 0.176777,  0.000000) * 0.5;
+    const vec2 o01 = vec2(-0.225772,  0.206826) * 0.5;
+    const vec2 o02 = vec2( 0.034558, -0.393771) * 0.5;
+    const vec2 o03 = vec2( 0.284571,  0.371173) * 0.5;
+    const vec2 o04 = vec2(-0.522223, -0.092374) * 0.5;
+    const vec2 o05 = vec2( 0.494695, -0.314685) * 0.5;
+    const vec2 o06 = vec2(-0.165466,  0.615525) * 0.5;
+    const vec2 o07 = vec2(-0.315561, -0.607594) * 0.5;
+    const vec2 o08 = vec2( 0.684642,  0.250030) * 0.5;
+    const vec2 o09 = vec2(-0.712256,  0.294009) * 0.5;
+    const vec2 o10 = vec2( 0.343354, -0.733729) * 0.5;
+    const vec2 o11 = vec2( 0.253730,  0.808932) * 0.5;
+    const vec2 o12 = vec2(-0.764746, -0.443186) * 0.5;
+    const vec2 o13 = vec2( 0.897134, -0.197232) * 0.5;
+    const vec2 o14 = vec2(-0.547507,  0.778772) * 0.5;
+    const vec2 o15 = vec2(-0.126487, -0.976090) * 0.5;
+
+    vec4 c  = texture(uSourceTex, vTexCoord + o00 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o01 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o02 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o03 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o04 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o05 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o06 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o07 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o08 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o09 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o10 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o11 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o12 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o13 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o14 * uDestTexel);
+         c += texture(uSourceTex, vTexCoord + o15 * uDestTexel);
+
+    FragColor = c * (1.0 / 16.0);
+}

--- a/shaders/blit/down_rgss.frag
+++ b/shaders/blit/down_rgss.frag
@@ -1,0 +1,41 @@
+/* down_rgss.frag -- Rotated Grid Super Sampling fragment shader
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+/* === Varyings === */
+
+noperspective in vec2 vTexCoord;
+
+/* === Uniforms === */
+
+uniform sampler2D uSourceTex;
+uniform vec2 uDestTexel;
+
+/* === Fragments === */
+
+out vec4 FragColor;
+
+/* === Main program === */
+
+void main()
+{
+    // Rotated grid at ~26.6°, rhombus covering [-3/8, 3/8] on X and Y
+
+    const vec2 o0 = vec2(-3.0,  1.0) / 8.0;
+    const vec2 o1 = vec2( 1.0,  3.0) / 8.0;
+    const vec2 o2 = vec2( 3.0, -1.0) / 8.0;
+    const vec2 o3 = vec2(-1.0, -3.0) / 8.0;
+
+    vec4 c0 = texture(uSourceTex, vTexCoord + o0 * uDestTexel);
+    vec4 c1 = texture(uSourceTex, vTexCoord + o1 * uDestTexel);
+    vec4 c2 = texture(uSourceTex, vTexCoord + o2 * uDestTexel);
+    vec4 c3 = texture(uSourceTex, vTexCoord + o3 * uDestTexel);
+
+    FragColor = (c0 + c1 + c2 + c3) * 0.25;
+}

--- a/shaders/blit/up_bicubic.frag
+++ b/shaders/blit/up_bicubic.frag
@@ -1,4 +1,4 @@
-/* bicubic_up.frag -- Catmull-Rom bicubic upscaling fragment shader
+/* up_bicubic.frag -- Catmull-Rom bicubic upscaling fragment shader
  *
  * Copyright (c) 2025-2026 Le Juez Victor
  *

--- a/shaders/blit/up_lanczos.frag
+++ b/shaders/blit/up_lanczos.frag
@@ -1,4 +1,4 @@
-/* lanczos_up.frag -- Lanczos-2 upscaling fragment shader
+/* up_lanczos.frag -- Lanczos-2 upscaling fragment shader
  *
  * Copyright (c) 2025-2026 Le Juez Victor
  *

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -73,6 +73,8 @@
 #include <shaders/visualizer.frag.h>
 #include <shaders/up_bicubic.frag.h>
 #include <shaders/up_lanczos.frag.h>
+#include <shaders/down_rgss.frag.h>
+#include <shaders/down_pdss.frag.h>
 
 // ========================================
 // MODULE STATE
@@ -1518,6 +1520,32 @@ bool r3d_shader_load_blit_up_lanczos(r3d_shader_custom_t* custom)
     return true;
 }
 
+bool r3d_shader_load_blit_down_rgss(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_blit_down_rgss_t, blit, downRgss);
+    LOAD_SHADER(downRgss, SCREEN_VERT, DOWN_RGSS_FRAG);
+
+    GET_LOCATION(downRgss, uDestTexel);
+
+    USE_SHADER(downRgss);
+    SET_SAMPLER(downRgss, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+
+    return true;
+}
+
+bool r3d_shader_load_blit_down_pdss(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_blit_down_pdss_t, blit, downPdss);
+    LOAD_SHADER(downPdss, SCREEN_VERT, DOWN_PDSS_FRAG);
+
+    GET_LOCATION(downPdss, uDestTexel);
+
+    USE_SHADER(downPdss);
+    SET_SAMPLER(downPdss, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+
+    return true;
+}
+
 // ========================================
 // MODULE FUNCTIONS
 // ========================================
@@ -1598,6 +1626,8 @@ void r3d_shader_quit()
 
     UNLOAD_SHADER(blit.upBicubic);
     UNLOAD_SHADER(blit.upLanczos);
+    UNLOAD_SHADER(blit.downRgss);
+    UNLOAD_SHADER(blit.downPdss);
 }
 
 void r3d_shader_bind_sampler(r3d_shader_sampler_t sampler, GLuint texture)

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -24,8 +24,6 @@
 #include <shaders/screen.vert.h>
 #include <shaders/cubemap.vert.h>
 #include <shaders/atrous_wavelet.frag.h>
-#include <shaders/bicubic_up.frag.h>
-#include <shaders/lanczos_up.frag.h>
 #include <shaders/blur_down.frag.h>
 #include <shaders/blur_up.frag.h>
 #include <shaders/depth_pyramid.frag.h>
@@ -73,6 +71,8 @@
 #include <shaders/smaa.vert.h>
 #include <shaders/smaa.frag.h>
 #include <shaders/visualizer.frag.h>
+#include <shaders/up_bicubic.frag.h>
+#include <shaders/up_lanczos.frag.h>
 
 // ========================================
 // MODULE STATE
@@ -266,32 +266,6 @@ bool r3d_shader_load_prepare_atrous_wavelet(r3d_shader_custom_t* custom)
     SET_SAMPLER(atrousWavelet, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
     SET_SAMPLER(atrousWavelet, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
     SET_SAMPLER(atrousWavelet, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
-
-    return true;
-}
-
-bool r3d_shader_load_prepare_bicubic_up(r3d_shader_custom_t* custom)
-{
-    DECL_SHADER(r3d_shader_prepare_bicubic_up_t, prepare, bicubicUp);
-    LOAD_SHADER(bicubicUp, SCREEN_VERT, BICUBIC_UP_FRAG);
-
-    GET_LOCATION(bicubicUp, uSourceTexel);
-
-    USE_SHADER(bicubicUp);
-    SET_SAMPLER(bicubicUp, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
-
-    return true;
-}
-
-bool r3d_shader_load_prepare_lanczos_up(r3d_shader_custom_t* custom)
-{
-    DECL_SHADER(r3d_shader_prepare_lanczos_up_t, prepare, lanczosUp);
-    LOAD_SHADER(lanczosUp, SCREEN_VERT, LANCZOS_UP_FRAG);
-
-    GET_LOCATION(lanczosUp, uSourceTexel);
-
-    USE_SHADER(lanczosUp);
-    SET_SAMPLER(lanczosUp, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
 
     return true;
 }
@@ -1518,6 +1492,32 @@ bool r3d_shader_load_post_visualizer(r3d_shader_custom_t* custom)
     return true;
 }
 
+bool r3d_shader_load_blit_up_bicubic(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_blit_up_bicubic_t, blit, upBicubic);
+    LOAD_SHADER(upBicubic, SCREEN_VERT, UP_BICUBIC_FRAG);
+
+    GET_LOCATION(upBicubic, uSourceTexel);
+
+    USE_SHADER(upBicubic);
+    SET_SAMPLER(upBicubic, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+
+    return true;
+}
+
+bool r3d_shader_load_blit_up_lanczos(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_blit_up_lanczos_t, blit, upLanczos);
+    LOAD_SHADER(upLanczos, SCREEN_VERT, UP_LANCZOS_FRAG);
+
+    GET_LOCATION(upLanczos, uSourceTexel);
+
+    USE_SHADER(upLanczos);
+    SET_SAMPLER(upLanczos, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+
+    return true;
+}
+
 // ========================================
 // MODULE FUNCTIONS
 // ========================================
@@ -1549,8 +1549,6 @@ void r3d_shader_quit()
     glDeleteBuffers(R3D_SHADER_BLOCK_COUNT, R3D_MOD_SHADER.uniformBuffers);
 
     UNLOAD_SHADER(prepare.atrousWavelet);
-    UNLOAD_SHADER(prepare.bicubicUp);
-    UNLOAD_SHADER(prepare.lanczosUp);
     UNLOAD_SHADER(prepare.blurDown);
     UNLOAD_SHADER(prepare.blurUp);
     UNLOAD_SHADER(prepare.depthPyramid);
@@ -1597,6 +1595,9 @@ void r3d_shader_quit()
     UNLOAD_SHADERS(post.fxaa);
     UNLOAD_SHADERS(post.smaa);
     UNLOAD_SHADER(post.visualizer);
+
+    UNLOAD_SHADER(blit.upBicubic);
+    UNLOAD_SHADER(blit.upLanczos);
 }
 
 void r3d_shader_bind_sampler(r3d_shader_sampler_t sampler, GLuint texture)

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -1094,6 +1094,18 @@ typedef struct {
     r3d_shader_uniform_vec2_t uSourceTexel;
 } r3d_shader_blit_up_lanczos_t;
 
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uSourceTex;
+    r3d_shader_uniform_vec2_t uDestTexel;
+} r3d_shader_blit_down_rgss_t;
+
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uSourceTex;
+    r3d_shader_uniform_vec2_t uDestTexel;
+} r3d_shader_blit_down_pdss_t;
+
 // ========================================
 // CUSTOM SHADERS STRUCTURES
 // ========================================
@@ -1207,6 +1219,8 @@ extern struct r3d_mod_shader {
     struct {
         r3d_shader_blit_up_bicubic_t upBicubic;
         r3d_shader_blit_up_lanczos_t upLanczos;
+        r3d_shader_blit_down_rgss_t downRgss;
+        r3d_shader_blit_down_pdss_t downPdss;
     } blit;
 
 } R3D_MOD_SHADER;
@@ -1277,6 +1291,8 @@ bool r3d_shader_load_post_smaa_ultra(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_visualizer(r3d_shader_custom_t* custom);
 bool r3d_shader_load_blit_up_bicubic(r3d_shader_custom_t* custom);
 bool r3d_shader_load_blit_up_lanczos(r3d_shader_custom_t* custom);
+bool r3d_shader_load_blit_down_rgss(r3d_shader_custom_t* custom);
+bool r3d_shader_load_blit_down_pdss(r3d_shader_custom_t* custom);
 
 static const struct r3d_shader_loader {
 
@@ -1346,6 +1362,8 @@ static const struct r3d_shader_loader {
     struct {
         r3d_shader_loader_func upBicubic;
         r3d_shader_loader_func upLanczos;
+        r3d_shader_loader_func downRgss;
+        r3d_shader_loader_func downPdss;
     } blit;
 
 } R3D_MOD_SHADER_LOADER = {
@@ -1423,6 +1441,8 @@ static const struct r3d_shader_loader {
     .blit = {
         .upBicubic = r3d_shader_load_blit_up_bicubic,
         .upLanczos = r3d_shader_load_blit_up_lanczos,
+        .downRgss = r3d_shader_load_blit_down_rgss,
+        .downPdss = r3d_shader_load_blit_down_pdss,
     },
 
 };

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -595,18 +595,6 @@ typedef struct {
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSourceTex;
-    r3d_shader_uniform_vec2_t uSourceTexel;
-} r3d_shader_prepare_bicubic_up_t;
-
-typedef struct {
-    GLuint id;
-    r3d_shader_uniform_sampler_t uSourceTex;
-    r3d_shader_uniform_vec2_t uSourceTexel;
-} r3d_shader_prepare_lanczos_up_t;
-
-typedef struct {
-    GLuint id;
-    r3d_shader_uniform_sampler_t uSourceTex;
     r3d_shader_uniform_int_t uSourceLod;
 } r3d_shader_prepare_blur_down_t;
 
@@ -1094,6 +1082,18 @@ typedef struct {
     r3d_shader_uniform_int_t uOutputMode;
 } r3d_shader_post_visualizer_t;
 
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uSourceTex;
+    r3d_shader_uniform_vec2_t uSourceTexel;
+} r3d_shader_blit_up_bicubic_t;
+
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uSourceTex;
+    r3d_shader_uniform_vec2_t uSourceTexel;
+} r3d_shader_blit_up_lanczos_t;
+
 // ========================================
 // CUSTOM SHADERS STRUCTURES
 // ========================================
@@ -1146,8 +1146,6 @@ extern struct r3d_mod_shader {
     // Prepare shaders
     struct {
         r3d_shader_prepare_atrous_wavelet_t atrousWavelet;
-        r3d_shader_prepare_bicubic_up_t bicubicUp;
-        r3d_shader_prepare_lanczos_up_t lanczosUp;
         r3d_shader_prepare_blur_down_t blurDown;
         r3d_shader_prepare_blur_up_t blurUp;
         r3d_shader_prepare_depth_pyramid_t depthPyramid;
@@ -1205,6 +1203,12 @@ extern struct r3d_mod_shader {
         r3d_shader_post_visualizer_t visualizer;
     } post;
 
+    // Blit shaders
+    struct {
+        r3d_shader_blit_up_bicubic_t upBicubic;
+        r3d_shader_blit_up_lanczos_t upLanczos;
+    } blit;
+
 } R3D_MOD_SHADER;
 
 // ========================================
@@ -1214,8 +1218,6 @@ extern struct r3d_mod_shader {
 typedef bool (*r3d_shader_loader_func)(r3d_shader_custom_t* custom);
 
 bool r3d_shader_load_prepare_atrous_wavelet(r3d_shader_custom_t* custom);
-bool r3d_shader_load_prepare_bicubic_up(r3d_shader_custom_t* custom);
-bool r3d_shader_load_prepare_lanczos_up(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_blur_down(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_blur_up(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_depth_pyramid(r3d_shader_custom_t* custom);
@@ -1273,14 +1275,14 @@ bool r3d_shader_load_post_smaa_medium(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_smaa_high(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_smaa_ultra(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_visualizer(r3d_shader_custom_t* custom);
+bool r3d_shader_load_blit_up_bicubic(r3d_shader_custom_t* custom);
+bool r3d_shader_load_blit_up_lanczos(r3d_shader_custom_t* custom);
 
 static const struct r3d_shader_loader {
 
     // Prepare shaders
     struct {
         r3d_shader_loader_func atrousWavelet;
-        r3d_shader_loader_func bicubicUp;
-        r3d_shader_loader_func lanczosUp;
         r3d_shader_loader_func blurDown;
         r3d_shader_loader_func blurUp;
         r3d_shader_loader_func depthPyramid;
@@ -1340,12 +1342,16 @@ static const struct r3d_shader_loader {
         r3d_shader_loader_func visualizer;
     } post;
 
+    // Blit shaders
+    struct {
+        r3d_shader_loader_func upBicubic;
+        r3d_shader_loader_func upLanczos;
+    } blit;
+
 } R3D_MOD_SHADER_LOADER = {
 
     .prepare = {
         .atrousWavelet = r3d_shader_load_prepare_atrous_wavelet,
-        .bicubicUp = r3d_shader_load_prepare_bicubic_up,
-        .lanczosUp = r3d_shader_load_prepare_lanczos_up,
         .blurDown = r3d_shader_load_prepare_blur_down,
         .blurUp = r3d_shader_load_prepare_blur_up,
         .depthPyramid = r3d_shader_load_prepare_depth_pyramid,
@@ -1412,6 +1418,11 @@ static const struct r3d_shader_loader {
         .smaa[2] = r3d_shader_load_post_smaa_high,
         .smaa[3] = r3d_shader_load_post_smaa_ultra,
         .visualizer = r3d_shader_load_post_visualizer,
+    },
+
+    .blit = {
+        .upBicubic = r3d_shader_load_blit_up_bicubic,
+        .upLanczos = r3d_shader_load_blit_up_lanczos,
     },
 
 };

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -477,13 +477,21 @@ GLuint r3d_target_get_or_null(r3d_target_t target)
 
 void r3d_target_blit(r3d_target_t target, bool depth, GLuint dstFbo, int dstX, int dstY, int dstW, int dstH, bool linear)
 {
-    int fboIndex = get_or_create_fbo(&target, 1, depth);
+    assert(target > R3D_TARGET_INVALID || depth);
 
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, dstFbo);
+    int fboIndex = -1;
+    if (target > R3D_TARGET_INVALID) {
+        fboIndex = get_or_create_fbo(&target, 1, depth);
+    }
+    else {
+        fboIndex = get_or_create_fbo(NULL, 0, true);
+    }
+
     glBindFramebuffer(GL_READ_FRAMEBUFFER, R3D_MOD_TARGET.fbo[fboIndex].id);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, dstFbo);
 
     if (linear) {
-        if (target > 0) {
+        if (target > R3D_TARGET_INVALID) {
             glBlitFramebuffer(
                 0, 0, R3D_MOD_TARGET.resW, R3D_MOD_TARGET.resH,
                 dstX, dstY, dstX + dstW, dstY + dstH, GL_COLOR_BUFFER_BIT,
@@ -500,7 +508,7 @@ void r3d_target_blit(r3d_target_t target, bool depth, GLuint dstFbo, int dstX, i
     }
     else {
         GLbitfield mask = GL_NONE;
-        if (target > 0) mask |= GL_COLOR_BUFFER_BIT;
+        if (target > R3D_TARGET_INVALID) mask |= GL_COLOR_BUFFER_BIT;
         if (depth) mask |= GL_DEPTH_BUFFER_BIT;
         glBlitFramebuffer(
             0, 0, R3D_MOD_TARGET.resW, R3D_MOD_TARGET.resH,

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -2432,44 +2432,46 @@ void blit_to_screen(r3d_target_t source)
     }
 
     if (greater) {
-        float txlW, txlH;
-        r3d_target_get_texel_size(&txlW, &txlH, source, 0);
-
         glBindFramebuffer(GL_FRAMEBUFFER, dstId);
         glViewport(dstX, dstY, dstW, dstH);
-
         switch (R3D.upscaleMode) {
         case R3D_UPSCALE_BICUBIC:
             R3D_SHADER_USE(blit.upBicubic);
-            R3D_SHADER_SET_VEC2(blit.upBicubic, uSourceTexel, (Vector2) {txlW, txlH});
+            R3D_SHADER_SET_VEC2(blit.upBicubic, uSourceTexel, (Vector2) {(float)R3D_TARGET_TEXEL_WIDTH, (float)R3D_TARGET_TEXEL_HEIGHT});
             R3D_SHADER_BIND_SAMPLER(blit.upBicubic, uSourceTex, r3d_target_get(source));
             break;
         case R3D_UPSCALE_LANCZOS:
             R3D_SHADER_USE(blit.upLanczos);
-            R3D_SHADER_SET_VEC2(blit.upLanczos, uSourceTexel, (Vector2) {txlW, txlH});
+            R3D_SHADER_SET_VEC2(blit.upLanczos, uSourceTexel, (Vector2) {(float)R3D_TARGET_TEXEL_WIDTH, (float)R3D_TARGET_TEXEL_HEIGHT});
             R3D_SHADER_BIND_SAMPLER(blit.upLanczos, uSourceTex, r3d_target_get(source));
             break;
         default:
             break;
         }
-
         R3D_RENDER_SCREEN();
-
-        r3d_target_blit(0, true, dstId, dstX, dstY, dstW, dstH, false);
+        r3d_target_blit(-1, true, dstId, dstX, dstY, dstW, dstH, false);
         return;
     }
 
-    if (smaller && R3D.downscaleMode == R3D_DOWNSCALE_BOX) {
+    if (smaller) {
         glBindFramebuffer(GL_FRAMEBUFFER, dstId);
         glViewport(dstX, dstY, dstW, dstH);
-
-        R3D_SHADER_USE(prepare.blurDown);
-        R3D_SHADER_SET_INT(prepare.blurDown, uSourceLod, 0);
-        R3D_SHADER_BIND_SAMPLER(prepare.blurDown, uSourceTex, r3d_target_get(source));
-
+        switch (R3D.downscaleMode) {
+        case R3D_DOWNSCALE_RGSS:
+            R3D_SHADER_USE(blit.downRgss);
+            R3D_SHADER_SET_VEC2(blit.downRgss, uDestTexel, (Vector2) {1.0f/dstW, 1.0f/dstH});
+            R3D_SHADER_BIND_SAMPLER(blit.downRgss, uSourceTex, r3d_target_get(source));
+            break;
+        case R3D_DOWNSCALE_PDSS:
+            R3D_SHADER_USE(blit.downPdss);
+            R3D_SHADER_SET_VEC2(blit.downPdss, uDestTexel, (Vector2) {1.0f/dstW, 1.0f/dstH});
+            R3D_SHADER_BIND_SAMPLER(blit.downPdss, uSourceTex, r3d_target_get(source));
+            break;
+        default:
+            break;
+        }
         R3D_RENDER_SCREEN();
-
-        r3d_target_blit(0, true, dstId, dstX, dstY, dstW, dstH, false);
+        r3d_target_blit(-1, true, dstId, dstX, dstY, dstW, dstH, false);
         return;
     }
 }
@@ -2509,7 +2511,7 @@ void visualize_to_screen(r3d_target_t source)
 
     R3D_RENDER_SCREEN();
 
-    r3d_target_blit(0, true, dstId, dstX, dstY, dstW, dstH, false);
+    r3d_target_blit(-1, true, dstId, dstX, dstY, dstW, dstH, false);
 }
 
 void cleanup_after_render(void)

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -2440,14 +2440,14 @@ void blit_to_screen(r3d_target_t source)
 
         switch (R3D.upscaleMode) {
         case R3D_UPSCALE_BICUBIC:
-            R3D_SHADER_USE(prepare.bicubicUp);
-            R3D_SHADER_SET_VEC2(prepare.bicubicUp, uSourceTexel, (Vector2) {txlW, txlH});
-            R3D_SHADER_BIND_SAMPLER(prepare.bicubicUp, uSourceTex, r3d_target_get(source));
+            R3D_SHADER_USE(blit.upBicubic);
+            R3D_SHADER_SET_VEC2(blit.upBicubic, uSourceTexel, (Vector2) {txlW, txlH});
+            R3D_SHADER_BIND_SAMPLER(blit.upBicubic, uSourceTex, r3d_target_get(source));
             break;
         case R3D_UPSCALE_LANCZOS:
-            R3D_SHADER_USE(prepare.lanczosUp);
-            R3D_SHADER_SET_VEC2(prepare.lanczosUp, uSourceTexel, (Vector2) {txlW, txlH});
-            R3D_SHADER_BIND_SAMPLER(prepare.lanczosUp, uSourceTex, r3d_target_get(source));
+            R3D_SHADER_USE(blit.upLanczos);
+            R3D_SHADER_SET_VEC2(blit.upLanczos, uSourceTexel, (Vector2) {txlW, txlH});
+            R3D_SHADER_BIND_SAMPLER(blit.upLanczos, uSourceTex, r3d_target_get(source));
             break;
         default:
             break;


### PR DESCRIPTION
Replaces the previous "box" downscale mode, which was repurposing a poorly suited downsampling shader, with two new dedicated modes:
- `R3D_DOWNSCALE_RGSS`: Rotated grid 2x2
- `R3D_DOWNSCALE_PDSS`: Poisson disk 16 samples

Also reorganized the shaders internally, upscale and downscale shaders are now grouped under a dedicated "blit" category. Not the better name, but it gets the point across.