### PR TITLE
Set resolution review

### DIFF
--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -203,7 +203,7 @@ R3DAPI void R3D_GetResolution(int* width, int* height);
  * 
  * @warning This function may be slow due to the destruction and recreation of framebuffers.
  */
-R3DAPI void R3D_UpdateResolution(int width, int height);
+R3DAPI void R3D_SetResolution(int width, int height);
 
 /**
  * @brief Retrieves the current anti-aliasing mode used for rendering.

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -193,15 +193,14 @@ R3DAPI void R3D_Close(void);
 R3DAPI void R3D_GetResolution(int* width, int* height);
 
 /**
- * @brief Updates the internal resolution.
- * 
- * This function changes the internal resolution of the rendering engine. Note that 
- * this process destroys and recreates all framebuffers, which may be a slow operation.
- * 
- * @param width The new width for the internal resolution.
- * @param height The new height for the internal resolution.
- * 
- * @warning This function may be slow due to the destruction and recreation of framebuffers.
+ * @brief Sets the internal rendering resolution.
+ *
+ * Reallocates all internal render targets to the new resolution.
+ * This operation may cause a stall, this is acceptable when called
+ * infrequently (like window resize events), but should never be called per-frame.
+ *
+ * @param width New internal width in pixels.
+ * @param height New internal height in pixels.
  */
 R3DAPI void R3D_SetResolution(int width, int height);
 

--- a/scripts/bin2c.py
+++ b/scripts/bin2c.py
@@ -117,11 +117,11 @@ def write_text_array(f, data, array_name, chunk_size=16000):
         return
 
     text_size = len(data)
-    escaped_text = escape_c_string(text)
 
     f.write(f'static const char {array_name}[] =\n')
-    for i in range(0, len(escaped_text), chunk_size):
-        f.write(f'    "{escaped_text[i:i + chunk_size]}"\n')
+    for i in range(0, len(text), chunk_size):
+        escaped_chunk = escape_c_string(text[i:i + chunk_size])
+        f.write(f'    "{escaped_chunk}"\n')
     f.write(';\n\n')
     f.write(f"#define {array_name}_SIZE {text_size}\n\n")
 

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -260,9 +260,6 @@ void r3d_target_resize(int resW, int resH)
     R3D_MOD_TARGET.txlW = 1.0f / resW;
     R3D_MOD_TARGET.txlH = 1.0f / resH;
 
-    // TODO: Avoid reallocating targets if the new dimensions
-    //       are smaller than the allocated dimensions?
-
     alloc_depth_stencil_renderbuffer(resW, resH);
 
     for (int i = 0; i < R3D_TARGET_COUNT; i++) {

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -87,40 +87,39 @@ typedef enum {
 // HELPER MACROS
 // ========================================
 
-#define R3D_TARGET_WIDTH        R3D_MOD_TARGET.resW
-#define R3D_TARGET_HEIGHT       R3D_MOD_TARGET.resH
+#define R3D_TARGET_SIZE_W   R3D_MOD_TARGET.resW
+#define R3D_TARGET_SIZE_H   R3D_MOD_TARGET.resH
+#define R3D_TARGET_TEXEL_W  R3D_MOD_TARGET.txlW
+#define R3D_TARGET_TEXEL_H  R3D_MOD_TARGET.txlH
 
-#define R3D_TARGET_TEXEL_WIDTH  R3D_MOD_TARGET.txlW
-#define R3D_TARGET_TEXEL_HEIGHT R3D_MOD_TARGET.txlH
-
-#define R3D_TARGET_LEVEL_LIST(...) (int[]){ __VA_ARGS__ }
+#define R3D_TARGET_LEVEL_LIST(...) (int[]) {__VA_ARGS__}
 
 #define R3D_TARGET_CLEAR(depth, ...)                                    \
     r3d_target_clear(                                                   \
-        (r3d_target_t[]){ __VA_ARGS__ },                                \
-        sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t), \
+        (r3d_target_t[]) {__VA_ARGS__},                                 \
+        sizeof((r3d_target_t[]) {__VA_ARGS__}) / sizeof(r3d_target_t),  \
         0, (depth)                                                      \
     )
 
 #define R3D_TARGET_BIND(depth, ...)                                     \
     r3d_target_bind(                                                    \
         (r3d_target_t[]){ __VA_ARGS__ },                                \
-        sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t), \
+        sizeof((r3d_target_t[]) {__VA_ARGS__}) / sizeof(r3d_target_t),  \
         0, (depth)                                                      \
     )
 
 #define R3D_TARGET_BIND_LEVEL(level, ...)                               \
     r3d_target_bind(                                                    \
-        (r3d_target_t[]){ __VA_ARGS__ },                                \
-        sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t), \
+        (r3d_target_t[]) {__VA_ARGS__},                                 \
+        sizeof((r3d_target_t[]) {__VA_ARGS__}) / sizeof(r3d_target_t),  \
         (level), false                                                  \
     )
 
 #define R3D_TARGET_BIND_LEVELS(levelsArr, ...)                          \
     r3d_target_bind_levels(                                             \
-        (r3d_target_t[]){ __VA_ARGS__ },                                \
+        (r3d_target_t[]) {__VA_ARGS__},                                 \
         (levelsArr),                                                    \
-        sizeof((r3d_target_t[]){ __VA_ARGS__ }) / sizeof(r3d_target_t)  \
+        sizeof((r3d_target_t[]) {__VA_ARGS__}) / sizeof(r3d_target_t)   \
     )
 
 /*

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -87,10 +87,10 @@ void R3D_GetResolution(int* width, int* height)
     r3d_target_get_resolution(width, height, R3D_TARGET_SCENE_0, 0);
 }
 
-void R3D_UpdateResolution(int width, int height)
+void R3D_SetResolution(int width, int height)
 {
     if (width <= 0 || height <= 0) {
-        R3D_TRACELOG(LOG_ERROR, "Invalid resolution given to 'R3D_UpdateResolution'");
+        R3D_TRACELOG(LOG_ERROR, "Invalid resolution given to 'R3D_SetResolution'");
         return;
     }
 

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -84,7 +84,8 @@ void R3D_Close(void)
 
 void R3D_GetResolution(int* width, int* height)
 {
-    r3d_target_get_resolution(width, height, R3D_TARGET_SCENE_0, 0);
+    if (width) *width = R3D_TARGET_WIDTH;
+    if (height) *height = R3D_TARGET_HEIGHT;
 }
 
 void R3D_SetResolution(int width, int height)

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -84,8 +84,8 @@ void R3D_Close(void)
 
 void R3D_GetResolution(int* width, int* height)
 {
-    if (width) *width = R3D_TARGET_WIDTH;
-    if (height) *height = R3D_TARGET_HEIGHT;
+    if (width) *width = R3D_TARGET_SIZE_W;
+    if (height) *height = R3D_TARGET_SIZE_H;
 }
 
 void R3D_SetResolution(int width, int height)

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -650,7 +650,7 @@ void upload_frame_block(void)
 
     r3d_shader_block_frame_t frame = {
         .screenSize = (Vector2) {(float)R3D_TARGET_SIZE_W, (float)R3D_TARGET_SIZE_H},
-        .texelSize = (Vector2) {(float)R3D_TARGET_TEXEL_W, (float)R3D_TARGET_TEXEL_H},
+        .texelSize = (Vector2) {R3D_TARGET_TEXEL_W, R3D_TARGET_TEXEL_H},
         .time = (float)GetTime(),
         .index = frameIndex++,
     };
@@ -2327,13 +2327,6 @@ r3d_target_t pass_post_smaa(r3d_target_t sceneTarget)
 {
     r3d_target_t sceneSource = r3d_target_swap_scene(sceneTarget);
 
-    Vector4 metrics = {
-        R3D_TARGET_TEXEL_W,
-        R3D_TARGET_TEXEL_H,
-        R3D_TARGET_SIZE_W,
-        R3D_TARGET_SIZE_H
-    };
-
     /* --- Clear previous content --- */
 
     // Bind and clear the stencil buffer. Since AA is the last post-processing
@@ -2400,7 +2393,7 @@ void blit_to_screen(r3d_target_t source)
 
     int dstX = 0, dstY = 0;
     if (R3D.aspectMode == R3D_ASPECT_KEEP) {
-        float srcRatio = (float)R3D_MOD_TARGET.resW / R3D_MOD_TARGET.resH;
+        float srcRatio = (float)R3D_TARGET_SIZE_W / R3D_TARGET_SIZE_H;
         float dstRatio = (float)dstW / dstH;
         if (srcRatio > dstRatio) {
             int newH = (int)(dstW / srcRatio + 0.5f);
@@ -2437,12 +2430,12 @@ void blit_to_screen(r3d_target_t source)
         switch (R3D.upscaleMode) {
         case R3D_UPSCALE_BICUBIC:
             R3D_SHADER_USE(blit.upBicubic);
-            R3D_SHADER_SET_VEC2(blit.upBicubic, uSourceTexel, (Vector2) {(float)R3D_TARGET_TEXEL_W, (float)R3D_TARGET_TEXEL_H});
+            R3D_SHADER_SET_VEC2(blit.upBicubic, uSourceTexel, (Vector2) {R3D_TARGET_TEXEL_W, R3D_TARGET_TEXEL_H});
             R3D_SHADER_BIND_SAMPLER(blit.upBicubic, uSourceTex, r3d_target_get(source));
             break;
         case R3D_UPSCALE_LANCZOS:
             R3D_SHADER_USE(blit.upLanczos);
-            R3D_SHADER_SET_VEC2(blit.upLanczos, uSourceTexel, (Vector2) {(float)R3D_TARGET_TEXEL_W, (float)R3D_TARGET_TEXEL_H});
+            R3D_SHADER_SET_VEC2(blit.upLanczos, uSourceTexel, (Vector2) {R3D_TARGET_TEXEL_W, R3D_TARGET_TEXEL_H});
             R3D_SHADER_BIND_SAMPLER(blit.upLanczos, uSourceTex, r3d_target_get(source));
             break;
         default:
@@ -2488,7 +2481,7 @@ void visualize_to_screen(r3d_target_t source)
 
     int dstX = 0, dstY = 0;
     if (R3D.aspectMode == R3D_ASPECT_KEEP) {
-        float srcRatio = (float)R3D_MOD_TARGET.resW / R3D_MOD_TARGET.resH;
+        float srcRatio = (float)R3D_TARGET_SIZE_W / R3D_TARGET_SIZE_H;
         float dstRatio = (float)dstW / dstH;
         if (srcRatio > dstRatio) {
             int newH = (int)(dstW / srcRatio + 0.5f);

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -649,8 +649,8 @@ void upload_frame_block(void)
     static int frameIndex = 0;
 
     r3d_shader_block_frame_t frame = {
-        .screenSize = (Vector2) {(float)R3D_TARGET_WIDTH, (float)R3D_TARGET_HEIGHT},
-        .texelSize = (Vector2) {(float)R3D_TARGET_TEXEL_WIDTH, (float)R3D_TARGET_TEXEL_HEIGHT},
+        .screenSize = (Vector2) {(float)R3D_TARGET_SIZE_W, (float)R3D_TARGET_SIZE_H},
+        .texelSize = (Vector2) {(float)R3D_TARGET_TEXEL_W, (float)R3D_TARGET_TEXEL_H},
         .time = (float)GetTime(),
         .index = frameIndex++,
     };
@@ -1919,7 +1919,7 @@ void pass_deferred_lights(void)
     R3D_LIGHT_FOR_EACH_VISIBLE(light)
     {
         // Set scissors rect
-        r3d_rect_t dst = {0, 0, R3D_TARGET_WIDTH, R3D_TARGET_HEIGHT};
+        r3d_rect_t dst = {0, 0, R3D_TARGET_SIZE_W, R3D_TARGET_SIZE_H};
         if (light->type != R3D_LIGHT_DIR) {
             dst = r3d_light_get_screen_rect(light, &R3D.viewState.viewProj, dst.w, dst.h);
             if (memcmp(&dst, &(r3d_rect_t){0}, sizeof(r3d_rect_t)) == 0) continue;
@@ -2328,10 +2328,10 @@ r3d_target_t pass_post_smaa(r3d_target_t sceneTarget)
     r3d_target_t sceneSource = r3d_target_swap_scene(sceneTarget);
 
     Vector4 metrics = {
-        R3D_TARGET_TEXEL_WIDTH,
-        R3D_TARGET_TEXEL_HEIGHT,
-        R3D_TARGET_WIDTH,
-        R3D_TARGET_HEIGHT
+        R3D_TARGET_TEXEL_W,
+        R3D_TARGET_TEXEL_H,
+        R3D_TARGET_SIZE_W,
+        R3D_TARGET_SIZE_H
     };
 
     /* --- Clear previous content --- */
@@ -2437,12 +2437,12 @@ void blit_to_screen(r3d_target_t source)
         switch (R3D.upscaleMode) {
         case R3D_UPSCALE_BICUBIC:
             R3D_SHADER_USE(blit.upBicubic);
-            R3D_SHADER_SET_VEC2(blit.upBicubic, uSourceTexel, (Vector2) {(float)R3D_TARGET_TEXEL_WIDTH, (float)R3D_TARGET_TEXEL_HEIGHT});
+            R3D_SHADER_SET_VEC2(blit.upBicubic, uSourceTexel, (Vector2) {(float)R3D_TARGET_TEXEL_W, (float)R3D_TARGET_TEXEL_H});
             R3D_SHADER_BIND_SAMPLER(blit.upBicubic, uSourceTex, r3d_target_get(source));
             break;
         case R3D_UPSCALE_LANCZOS:
             R3D_SHADER_USE(blit.upLanczos);
-            R3D_SHADER_SET_VEC2(blit.upLanczos, uSourceTexel, (Vector2) {(float)R3D_TARGET_TEXEL_WIDTH, (float)R3D_TARGET_TEXEL_HEIGHT});
+            R3D_SHADER_SET_VEC2(blit.upLanczos, uSourceTexel, (Vector2) {(float)R3D_TARGET_TEXEL_W, (float)R3D_TARGET_TEXEL_H});
             R3D_SHADER_BIND_SAMPLER(blit.upLanczos, uSourceTex, r3d_target_get(source));
             break;
         default:

--- a/src/r3d_utils.c
+++ b/src/r3d_utils.c
@@ -53,8 +53,8 @@ Texture2D R3D_GetBufferNormal(void)
 {
     Texture2D texture = { 0 };
     texture.id = r3d_target_get(R3D_TARGET_NORMAL);
-    texture.width = R3D_TARGET_WIDTH;
-    texture.height = R3D_TARGET_HEIGHT;
+    texture.width = R3D_TARGET_SIZE_W;
+    texture.height = R3D_TARGET_SIZE_H;
     texture.mipmaps = 1;
     texture.format = PIXELFORMAT_UNCOMPRESSED_R32;
     return texture;
@@ -64,8 +64,8 @@ Texture2D R3D_GetBufferDepth(void)
 {
     Texture2D texture = { 0 };
     texture.id = r3d_target_get(R3D_TARGET_DEPTH);
-    texture.width = R3D_TARGET_WIDTH;
-    texture.height = R3D_TARGET_HEIGHT;
+    texture.width = R3D_TARGET_SIZE_W;
+    texture.height = R3D_TARGET_SIZE_H;
     texture.mipmaps = 1;
     texture.format = PIXELFORMAT_UNCOMPRESSED_R16;
     return texture;


### PR DESCRIPTION
This PR simply renames `R3D_UpdateResolution` to `R3D_SetResolution`, which is more consistent.

Some internal cleanup was done along the way.

---

I originally started this while trying to run a comparison test between not reallocating when the new requested size is smaller (and "simply" changing the viewport) and unconditionally calling `glTexImage2D` on every window resize.

So I performed a stress test comparing both methods with window dimensions changing every frame, but I observed absolutely no measurable difference between the two approaches. This is likely because my stress test introduced more noise elsewhere. In the end, considering the rather crazy complexity introduced by managing physical vs logical resolution, I decided that, until proven otherwise, calling `glTexImage2D` on every resize is clearly acceptable.

Hopefully modern drivers are smart enough to keep previously allocated memory around for a while when the size decreases.