### PR TITLE
View projection matrix getter

### DIFF
--- a/include/r3d/r3d_utils.h
+++ b/include/r3d/r3d_utils.h
@@ -125,6 +125,16 @@ R3DAPI Matrix R3D_GetMatrixProjection(void);
  */
 R3DAPI Matrix R3D_GetMatrixInvProjection(void);
 
+/**
+ * @brief Retrieves the view-projection matrix.
+ *
+ * This matrix represents the transformation from world space to clip space.
+ * It is updated at the last call to 'R3D_Begin'.
+ *
+ * @return The current view-projection matrix.
+ */
+R3DAPI Matrix R3D_GetMatrixViewProjection(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -21,7 +21,6 @@
 #include "./modules/r3d_render.h"
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_env.h"
-#include "common/r3d_math.h"
 
 // ========================================
 // SHARED CORE STATE

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -21,6 +21,7 @@
 #include "./modules/r3d_render.h"
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_env.h"
+#include "common/r3d_math.h"
 
 // ========================================
 // SHARED CORE STATE
@@ -45,6 +46,12 @@ bool R3D_Init(int resWidth, int resHeight)
 
     R3D.environment = R3D_ENVIRONMENT_BASE;
     R3D.material = R3D_MATERIAL_BASE;
+
+    R3D.viewState.view = R3D_MATRIX_IDENTITY;
+    R3D.viewState.invView = R3D_MATRIX_IDENTITY;
+    R3D.viewState.proj = R3D_MATRIX_IDENTITY;
+    R3D.viewState.invProj = R3D_MATRIX_IDENTITY;
+    R3D.viewState.viewProj = R3D_MATRIX_IDENTITY;
 
     R3D.aaMode = R3D_ANTI_ALIASING_MODE_NONE;
     R3D.aaPreset = R3D_ANTI_ALIASING_PRESET_MEDIUM;

--- a/src/r3d_utils.c
+++ b/src/r3d_utils.c
@@ -90,3 +90,8 @@ Matrix R3D_GetMatrixInvProjection(void)
 {
     return R3D.viewState.invProj;
 }
+
+Matrix R3D_GetMatrixViewProjection(void)
+{
+    return R3D.viewState.viewProj;
+}


### PR DESCRIPTION
Adds the function `Matrix R3D_GetMatrixViewProjection()` and initializes the obtainable matrices as identities