### PR TITLE
Add texture loading helpers and color space utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,7 @@ add_library(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/src/r3d_screen_shader.c"
     "${R3D_ROOT_PATH}/src/r3d_sky_shader.c"
     "${R3D_ROOT_PATH}/src/r3d_material.c"
+    "${R3D_ROOT_PATH}/src/r3d_texture.c"
     "${R3D_ROOT_PATH}/src/r3d_mesh.c"
     "${R3D_ROOT_PATH}/src/r3d_mesh_data.c"
     "${R3D_ROOT_PATH}/src/r3d_model.c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ add_library(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/src/r3d_animation_player.c"
     "${R3D_ROOT_PATH}/src/r3d_animation_tree.c"
     "${R3D_ROOT_PATH}/src/r3d_animation.c"
+    "${R3D_ROOT_PATH}/src/r3d_color.c"
     "${R3D_ROOT_PATH}/src/r3d_core.c"
     "${R3D_ROOT_PATH}/src/r3d_cubemap.c"
     "${R3D_ROOT_PATH}/src/r3d_draw.c"

--- a/include/r3d/r3d_color.h
+++ b/include/r3d/r3d_color.h
@@ -1,0 +1,74 @@
+/* r3d_color.h -- R3D Color Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#ifndef R3D_COLOR_H
+#define R3D_COLOR_H
+
+#include "./r3d_platform.h"
+#include <raylib.h>
+
+/**
+ * @defgroup Color
+ * @{
+ */
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Converts an sRGB color to linear space.
+ *
+ * @param color The sRGB color to convert.
+ * @return The converted linear color as a Vector4.
+ */
+R3DAPI Vector4 R3D_ColorSrgbToLinear(Color color);
+
+/**
+ * @brief Converts an sRGB color to linear space.
+ *
+ * @param color The sRGB color to convert.
+ * @return The converted linear color as a Vector3.
+ */
+R3DAPI Vector3 R3D_ColorSrgbToLinearVector3(Color color);
+
+/**
+ * @brief Converts a linear color to sRGB space.
+ *
+ * @param color The linear color to convert.
+ * @return The converted sRGB color.
+ */
+R3DAPI Color R3D_ColorLinearToSrgb(Vector4 color);
+
+/**
+ * @brief Converts a color from the current color space to linear space.
+ *
+ * @param color The color to convert.
+ * @return The converted linear color as a Vector4.
+ */
+R3DAPI Vector4 R3D_ColorFromCurrentSpace(Color color);
+
+/**
+ * @brief Converts a color from the current color space to linear space.
+ *
+ * @param color The color to convert.
+ * @return The converted linear color as a Vector3.
+ */
+R3DAPI Vector3 R3D_ColorFromCurrentSpaceVector3(Color color);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+/** @} */ // end of Color
+
+#endif // R3D_COLOR_H

--- a/include/r3d/r3d_texture.h
+++ b/include/r3d/r3d_texture.h
@@ -1,0 +1,122 @@
+/* r3d_texture.h -- R3D Texture Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#ifndef R3D_TEXTURE_H
+#define R3D_TEXTURE_H
+
+#include "./r3d_platform.h"
+#include <raylib.h>
+
+/**
+ * @defgroup Texture
+ * @{
+ */
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Loads a texture from the specified file path.
+ *
+ * If 'isColor' is true, the texture is loaded using the currently defined color space (sRGB by default).
+ * The wrap and filter modes are taken from the current global default state.
+ *
+ * @param fileName The path to the texture file.
+ * @param isColor Whether the texture should be treated as color data.
+ * @return The loaded texture.
+ */
+R3DAPI Texture2D R3D_LoadTexture(const char* fileName, bool isColor);
+
+/**
+ * @brief Loads a texture from the specified file path.
+ *
+ * If 'isColor' is true, the texture is loaded using the currently defined color space (sRGB by default).
+ *
+ * @param fileName The path to the texture file.
+ * @param wrap The texture wrap mode.
+ * @param filter The texture filter mode.
+ * @param isColor Whether the texture should be treated as color data.
+ * @return The loaded texture.
+ */
+R3DAPI Texture2D R3D_LoadTextureEx(const char* fileName, TextureWrap wrap, TextureFilter filter, bool isColor);
+
+/**
+ * @brief Loads a texture from the specified image.
+ *
+ * If 'isColor' is true, the texture is loaded using the currently defined color space (sRGB by default).
+ * The wrap and filter modes are taken from the current global default state.
+ *
+ * @param image The source image.
+ * @param isColor Whether the texture should be treated as color data.
+ * @return The loaded texture.
+ */
+R3DAPI Texture2D R3D_LoadTextureFromImage(Image image, bool isColor);
+
+/**
+ * @brief Loads a texture from the specified image.
+ *
+ * If 'isColor' is true, the texture is loaded using the currently defined color space (sRGB by default).
+ *
+ * @param image The source image.
+ * @param wrap The texture wrap mode.
+ * @param filter The texture filter mode.
+ * @param isColor Whether the texture should be treated as color data.
+ * @return The loaded texture.
+ */
+R3DAPI Texture2D R3D_LoadTextureFromImageEx(Image image, TextureWrap wrap, TextureFilter filter, bool isColor);
+
+/**
+ * @brief Loads a texture directly from memory.
+ *
+ * If 'isColor' is true, the texture is loaded using the currently defined color space (sRGB by default).
+ * The wrap and filter modes are taken from the current global default state.
+ *
+ * @param fileType The file type/extension used to interpret the data.
+ * @param fileData A pointer to the file data in memory.
+ * @param dataSize The size of the file data in bytes.
+ * @param isColor Whether the texture should be treated as color data.
+ * @return The loaded texture.
+ */
+R3DAPI Texture2D R3D_LoadTextureFromMemory(const char* fileType, const void* fileData, int dataSize, bool isColor);
+
+/**
+ * @brief Loads a texture directly from memory.
+ *
+ * If 'isColor' is true, the texture is loaded using the currently defined color space (sRGB by default).
+ *
+ * @param fileType The file type/extension used to interpret the data.
+ * @param fileData A pointer to the file data in memory.
+ * @param dataSize The size of the file data in bytes.
+ * @param wrap The texture wrap mode.
+ * @param filter The texture filter mode.
+ * @param isColor Whether the texture should be treated as color data.
+ * @return The loaded texture.
+ */
+R3DAPI Texture2D R3D_LoadTextureFromMemoryEx(const char* fileType, const void* fileData, int dataSize, TextureWrap wrap, TextureFilter filter, bool isColor);
+
+/**
+ * @brief Unloads a texture.
+ *
+ * This function is equivalent to raylib's `UnloadTexture` and is provided for consistency.
+ *
+ * @param texture The texture to unload.
+ */
+R3DAPI void R3D_UnloadTexture(Texture2D texture);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+/** @} */ // end of Texture
+
+#endif // R3D_TEXTURE_H

--- a/include/r3d/r3d_texture.h
+++ b/include/r3d/r3d_texture.h
@@ -107,7 +107,8 @@ R3DAPI Texture2D R3D_LoadTextureFromMemoryEx(const char* fileType, const void* f
 /**
  * @brief Unloads a texture.
  *
- * This function is equivalent to raylib's `UnloadTexture` and is provided for consistency.
+ * This function calls raylib's `UnloadTexture` internally, while ensuring that
+ * the provided texture is not an internal r3d texture.
  *
  * @param texture The texture to unload.
  */

--- a/src/r3d_color.c
+++ b/src/r3d_color.c
@@ -1,0 +1,41 @@
+/* r3d_color.c -- R3D Color Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#include <r3d/r3d_color.h>
+
+#include "./common/r3d_math.h"
+#include "./r3d_core_state.h"
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+Vector4 R3D_ColorSrgbToLinear(Color color)
+{
+    return r3d_color_srgb_to_linear_vec4(color);
+}
+
+Vector3 R3D_ColorSrgbToLinearVector3(Color color)
+{
+    return r3d_color_srgb_to_linear_vec3(color);
+}
+
+Color R3D_ColorLinearToSrgb(Vector4 color)
+{
+    return r3d_color_linear_to_srgb_vec4(color);
+}
+
+Vector4 R3D_ColorFromCurrentSpace(Color color)
+{
+    return r3d_color_to_linear_vec4(color, R3D.colorSpace);
+}
+
+Vector3 R3D_ColorFromCurrentSpaceVector3(Color color)
+{
+    return r3d_color_to_linear_vec3(color, R3D.colorSpace);
+}

--- a/src/r3d_material.c
+++ b/src/r3d_material.c
@@ -7,6 +7,7 @@
  */
 
 #include <r3d/r3d_material.h>
+#include <r3d/r3d_texture.h>
 #include <r3d/r3d_utils.h>
 #include <r3d_config.h>
 
@@ -14,8 +15,6 @@
 #   include "./importer/r3d_importer_internal.h"
 #endif
 
-#include "./modules/r3d_texture.h"
-#include "./common/r3d_image.h"
 #include "./r3d_core_state.h"
 
 // ========================================
@@ -118,214 +117,75 @@ void R3D_UnloadMaterial(R3D_Material material)
 R3D_AlbedoMap R3D_LoadAlbedoMap(const char* fileName, Color color)
 {
     R3D_AlbedoMap map = {0};
-
-    Image image = LoadImage(fileName);
-    if (!IsImageValid(image)) {
-        R3D_TRACELOG(LOG_WARNING, "Failed to load albedo image: '%s'", fileName);
-        return map;
-    }
-
-    bool srgb = (R3D.colorSpace == R3D_COLORSPACE_SRGB);
-
-    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, srgb);
+    map.texture = R3D_LoadTexture(fileName, true);
     map.color = color;
-
-    if (map.texture.id != 0) {
-        R3D_TRACELOG(LOG_INFO, "Albedo map loaded successfully: '%s'", fileName);
-    }
-    else {
-        R3D_TRACELOG(LOG_WARNING, "Failed to upload albedo texture: '%s'", fileName);
-    }
-
-    UnloadImage(image);
-
     return map;
 }
 
 R3D_AlbedoMap R3D_LoadAlbedoMapFromMemory(const char* fileType, const void* fileData, int dataSize, Color color)
 {
     R3D_AlbedoMap map = {0};
-
-    Image image = LoadImageFromMemory(fileType, fileData, dataSize);
-    if (!IsImageValid(image)) {
-        R3D_TRACELOG(LOG_WARNING, "Failed to load albedo image from memory (type: '%s')", fileType);
-        return map;
-    }
-
-    bool srgb = (R3D.colorSpace == R3D_COLORSPACE_SRGB);
-
-    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, srgb);
+    map.texture = R3D_LoadTextureFromMemory(fileType, fileData, dataSize, true);
     map.color = color;
-
-    if (map.texture.id != 0) {
-        R3D_TRACELOG(LOG_INFO, "Albedo map loaded successfully from memory (type: '%s')", fileType);
-    }
-    else {
-        R3D_TRACELOG(LOG_WARNING, "Failed to upload albedo texture from memory (type: '%s')", fileType);
-    }
-
-    UnloadImage(image);
-
     return map;
 }
 
 void R3D_UnloadAlbedoMap(R3D_AlbedoMap map)
 {
-    if (map.texture.id == 0 || r3d_texture_is_default(map.texture.id)) {
-        return;
-    }
-
-    UnloadTexture(map.texture);
+    R3D_UnloadTexture(map.texture);
 }
 
 R3D_EmissionMap R3D_LoadEmissionMap(const char* fileName, Color color, float energy)
 {
     R3D_EmissionMap map = {0};
-
-    Image image = LoadImage(fileName);
-    if (!IsImageValid(image)) {
-        R3D_TRACELOG(LOG_WARNING, "Failed to load emission image: '%s'", fileName);
-        return map;
-    }
-
-    bool srgb = (R3D.colorSpace == R3D_COLORSPACE_SRGB);
-
-    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, srgb);
+    map.texture = R3D_LoadTexture(fileName, true);
     map.color = color;
     map.energy = energy;
-
-    if (map.texture.id != 0) {
-        R3D_TRACELOG(LOG_INFO, "Emission map loaded successfully: '%s'", fileName);
-    }
-    else {
-        R3D_TRACELOG(LOG_WARNING, "Failed to upload emission texture: '%s'", fileName);
-    }
-
-    UnloadImage(image);
-
     return map;
 }
 
 R3D_EmissionMap R3D_LoadEmissionMapFromMemory(const char* fileType, const void* fileData, int dataSize, Color color, float energy)
 {
     R3D_EmissionMap map = {0};
-
-    Image image = LoadImageFromMemory(fileType, fileData, dataSize);
-    if (!IsImageValid(image)) {
-        R3D_TRACELOG(LOG_WARNING, "Failed to load emission image from memory (type: '%s')", fileType);
-        return map;
-    }
-
-    bool srgb = (R3D.colorSpace == R3D_COLORSPACE_SRGB);
-
-    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, srgb);
+    map.texture = R3D_LoadTextureFromMemory(fileType, fileData, dataSize, true);
     map.color = color;
     map.energy = energy;
-
-    if (map.texture.id != 0) {
-        R3D_TRACELOG(LOG_INFO, "Emission map loaded successfully from memory (type: '%s')", fileType);
-    }
-    else {
-        R3D_TRACELOG(LOG_WARNING, "Failed to upload emission texture from memory (type: '%s')", fileType);
-    }
-
-    UnloadImage(image);
-
     return map;
 }
 
 void R3D_UnloadEmissionMap(R3D_EmissionMap map)
 {
-    if (map.texture.id == 0 || r3d_texture_is_default(map.texture.id)) {
-        return;
-    }
-
-    UnloadTexture(map.texture);
+    R3D_UnloadTexture(map.texture);
 }
 
 R3D_NormalMap R3D_LoadNormalMap(const char* fileName, float scale)
 {
     R3D_NormalMap map = {0};
-
-    Image image = LoadImage(fileName);
-    if (!IsImageValid(image)) {
-        R3D_TRACELOG(LOG_WARNING, "Failed to load normal map image: '%s'", fileName);
-        return map;
-    }
-
-    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, false);
+    map.texture = R3D_LoadTexture(fileName, false);
     map.scale = scale;
-
-    if (map.texture.id != 0) {
-        R3D_TRACELOG(LOG_INFO, "Normal map loaded successfully: '%s'", fileName);
-    }
-    else {
-        R3D_TRACELOG(LOG_WARNING, "Failed to upload normal map texture: '%s'", fileName);
-    }
-
-    UnloadImage(image);
-
     return map;
 }
 
 R3D_NormalMap R3D_LoadNormalMapFromMemory(const char* fileType, const void* fileData, int dataSize, float scale)
 {
     R3D_NormalMap map = {0};
-
-    Image image = LoadImageFromMemory(fileType, fileData, dataSize);
-    if (!IsImageValid(image)) {
-        R3D_TRACELOG(LOG_WARNING, "Failed to load normal map image from memory (type: '%s')", fileType);
-        return map;
-    }
-
-    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, false);
+    map.texture = R3D_LoadTextureFromMemory(fileType, fileData, dataSize, false);
     map.scale = scale;
-
-    if (map.texture.id != 0) {
-        R3D_TRACELOG(LOG_INFO, "Normal map loaded successfully from memory (type: '%s')", fileType);
-    }
-    else {
-        R3D_TRACELOG(LOG_WARNING, "Failed to upload normal map texture from memory (type: '%s')", fileType);
-    }
-
-    UnloadImage(image);
-
     return map;
 }
 
 void R3D_UnloadNormalMap(R3D_NormalMap map)
 {
-    if (map.texture.id == 0 || r3d_texture_is_default(map.texture.id)) {
-        return;
-    }
-
-    UnloadTexture(map.texture);
+    R3D_UnloadTexture(map.texture);
 }
 
 R3D_OrmMap R3D_LoadOrmMap(const char* fileName, float occlusion, float roughness, float metalness)
 {
     R3D_OrmMap map = {0};
-
-    Image image = LoadImage(fileName);
-    if (!IsImageValid(image)) {
-        R3D_TRACELOG(LOG_WARNING, "Failed to load ORM image: '%s'", fileName);
-        return map;
-    }
-
-    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, false);
+    map.texture = R3D_LoadTexture(fileName, false);
     map.occlusion = occlusion;
     map.roughness = roughness;
     map.metalness = metalness;
-
-    if (map.texture.id != 0) {
-        R3D_TRACELOG(LOG_INFO, "ORM map loaded successfully: '%s'", fileName);
-    }
-    else {
-        R3D_TRACELOG(LOG_WARNING, "Failed to upload ORM texture: '%s'", fileName);
-    }
-
-    UnloadImage(image);
-
     return map;
 }
 
@@ -333,35 +193,14 @@ R3D_OrmMap R3D_LoadOrmMapFromMemory(const char* fileType, const void* fileData, 
                                     float occlusion, float roughness, float metalness)
 {
     R3D_OrmMap map = {0};
-
-    Image image = LoadImageFromMemory(fileType, fileData, dataSize);
-    if (!IsImageValid(image)) {
-        R3D_TRACELOG(LOG_WARNING, "Failed to load ORM image from memory (type: '%s')", fileType);
-        return map;
-    }
-
-    map.texture = r3d_image_upload(&image, R3D.textureWrap, R3D.textureFilter, false);
+    map.texture = R3D_LoadTextureFromMemory(fileType, fileData, dataSize, false);
     map.occlusion = occlusion;
     map.roughness = roughness;
     map.metalness = metalness;
-
-    if (map.texture.id != 0) {
-        R3D_TRACELOG(LOG_INFO, "ORM map loaded successfully from memory (type: '%s')", fileType);
-    }
-    else {
-        R3D_TRACELOG(LOG_WARNING, "Failed to upload ORM texture from memory (type: '%s')", fileType);
-    }
-
-    UnloadImage(image);
-
     return map;
 }
 
 void R3D_UnloadOrmMap(R3D_OrmMap map)
 {
-    if (map.texture.id == 0 || r3d_texture_is_default(map.texture.id)) {
-        return;
-    }
-
-    UnloadTexture(map.texture);
+    R3D_UnloadTexture(map.texture);
 }

--- a/src/r3d_texture.c
+++ b/src/r3d_texture.c
@@ -1,0 +1,98 @@
+/* r3d_texture.h -- R3D Texture Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#include <r3d/r3d_texture.h>
+
+#include "./common/r3d_image.h"
+#include "./r3d_core_state.h"
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+Texture2D R3D_LoadTexture(const char* fileName, bool isColor)
+{
+    return R3D_LoadTextureEx(fileName, R3D.textureWrap, R3D.textureFilter, isColor);
+}
+
+Texture2D R3D_LoadTextureEx(const char* fileName, TextureWrap wrap, TextureFilter filter, bool isColor)
+{
+    Texture2D texture = {0};
+
+    Image image = LoadImage(fileName);
+    if (!IsImageValid(image)) {
+        R3D_TRACELOG(LOG_WARNING, "Failed to load texture (path: '%s')", fileName);
+        return texture;
+    }
+
+    bool srgb = isColor ? (R3D.colorSpace == R3D_COLORSPACE_SRGB) : false;
+    texture = r3d_image_upload(&image, wrap, filter, srgb);
+
+    if (texture.id != 0) {
+        R3D_TRACELOG(LOG_INFO, "Texture loaded successfully (path: '%s')", fileName);
+    }
+    else {
+        R3D_TRACELOG(LOG_WARNING, "Failed to load texture (path: '%s')", fileName);
+    }
+
+    UnloadImage(image);
+
+    return texture;
+}
+
+Texture2D R3D_LoadTextureFromImage(Image image, bool isColor)
+{
+    return R3D_LoadTextureFromImageEx(image, R3D.textureWrap, R3D.textureFilter, isColor);
+}
+
+Texture2D R3D_LoadTextureFromImageEx(Image image, TextureWrap wrap, TextureFilter filter, bool isColor)
+{
+    bool srgb = isColor ? (R3D.colorSpace == R3D_COLORSPACE_SRGB) : false;
+    Texture2D texture = r3d_image_upload(&image, wrap, filter, srgb);
+
+    if (texture.id != 0) {
+        R3D_TRACELOG(LOG_INFO, "Texture loaded successfully from image");
+    }
+    else {
+        R3D_TRACELOG(LOG_WARNING, "Failed to load texture from image");
+    }
+
+    UnloadImage(image);
+
+    return texture;
+}
+
+Texture2D R3D_LoadTextureFromMemory(const char* fileType, const void* fileData, int dataSize, bool isColor)
+{
+    return R3D_LoadTextureFromMemoryEx(fileType, fileData, dataSize, R3D.textureWrap, R3D.textureFilter, isColor);
+}
+
+Texture2D R3D_LoadTextureFromMemoryEx(const char* fileType, const void* fileData, int dataSize, TextureWrap wrap, TextureFilter filter, bool isColor)
+{
+    Texture2D texture = {0};
+
+    Image image = LoadImageFromMemory(fileType, fileData, dataSize);
+    if (!IsImageValid(image)) {
+        R3D_TRACELOG(LOG_WARNING, "Failed to load texture from memory (type: '%s')", fileType);
+        return texture;
+    }
+
+    bool srgb = isColor ? (R3D.colorSpace == R3D_COLORSPACE_SRGB) : false;
+    texture = r3d_image_upload(&image, wrap, filter, srgb);
+
+    if (texture.id != 0) {
+        R3D_TRACELOG(LOG_INFO, "Texture loaded successfully from memory (type: '%s')", fileType);
+    }
+    else {
+        R3D_TRACELOG(LOG_WARNING, "Failed to load texture from memory (type: '%s')", fileType);
+    }
+
+    UnloadImage(image);
+
+    return texture;
+}

--- a/src/r3d_texture.c
+++ b/src/r3d_texture.c
@@ -8,6 +8,7 @@
 
 #include <r3d/r3d_texture.h>
 
+#include "./modules/r3d_texture.h"
 #include "./common/r3d_image.h"
 #include "./r3d_core_state.h"
 
@@ -95,4 +96,13 @@ Texture2D R3D_LoadTextureFromMemoryEx(const char* fileType, const void* fileData
     UnloadImage(image);
 
     return texture;
+}
+
+void R3D_UnloadTexture(Texture2D texture)
+{
+    if (texture.id == 0 || r3d_texture_is_default(texture.id)) {
+        return;
+    }
+
+    UnloadTexture(texture);
 }


### PR DESCRIPTION
### `r3d_texture.h`

New helpers for loading textures with proper color space handling.

```
R3D_LoadTexture
R3D_LoadTextureEx
R3D_LoadTextureFromImage
R3D_LoadTextureFromImageEx
R3D_LoadTextureFromMemory
R3D_LoadTextureFromMemoryEx
R3D_UnloadTexture
```

* `isColor` allows loading textures using the current color space (sRGB by default).
* `R3D_UnloadTexture` safely wraps `UnloadTexture` and ignores internal R3D textures.

---

### `r3d_color.h`

Utilities for color space conversions.

```
R3D_ColorSrgbToLinear
R3D_ColorSrgbToLinearVector3
R3D_ColorLinearToSrgb
R3D_ColorFromCurrentSpace
R3D_ColorFromCurrentSpaceVector3
```

* Convert colors between sRGB and linear space.
* Convert colors from the currently configured color space to linear.
