### PR TITLE
Animation player review

### DIFF
--- a/examples/animation.c
+++ b/examples/animation.c
@@ -39,7 +39,6 @@ int main(void)
     R3D_AnimationPlayer modelPlayer = R3D_LoadAnimationPlayer(model.skeleton, modelAnims);
 
     // Setup animation playing
-    R3D_SetAnimationWeight(&modelPlayer, 0, 1.0f);
     R3D_SetAnimationLoop(&modelPlayer, 0, true);
     R3D_PlayAnimation(&modelPlayer, 0);
 

--- a/include/r3d/r3d_animation_player.h
+++ b/include/r3d/r3d_animation_player.h
@@ -63,18 +63,17 @@ typedef void (*R3D_AnimationEventCallback)(
 /**
  * @brief Describes the playback state of a single animation within a player.
  *
- * Tracks the current time, blending weight, speed, play/pause state, and looping behavior.
+ * Tracks the current time, speed, play/pause state, and looping behavior.
  */
 typedef struct R3D_AnimationState {
     float currentTime;  ///< Current playback time in animation ticks.
-    float weight;       ///< Blending weight; any positive value is valid.
     float speed;        ///< Playback speed; can be negative for reverse playback.
     bool play;          ///< Whether the animation is currently playing.
     bool loop;          ///< True to enable looping playback.
 } R3D_AnimationState;
 
 /**
- * @brief Manages playback and blending of multiple animations for a skeleton.
+ * @brief Manages playback of multiple animations for a skeleton.
  *
  * The animation player updates animation states, interpolates keyframes,
  * blends animations according to their weights, and stores the resulting
@@ -83,9 +82,11 @@ typedef struct R3D_AnimationState {
  */
 typedef struct R3D_AnimationPlayer {
 
-    R3D_AnimationState* states; ///< Array of active animation states, one per animation.
     R3D_AnimationLib animLib;   ///< Animation library providing the available animations.
     R3D_Skeleton skeleton;      ///< Skeleton to animate.
+
+    R3D_AnimationState* states; ///< Array of active animation states, one per animation.
+    int activeAnimIndex;        ///< Index of the current animation.
 
     Matrix* localPose;          ///< Array of bone transforms representing the blended local pose.
     Matrix* modelPose;          ///< Array of bone transforms in model space, obtained by hierarchical accumulation.
@@ -132,13 +133,12 @@ R3DAPI void R3D_UnloadAnimationPlayer(R3D_AnimationPlayer player);
 R3DAPI bool R3D_IsAnimationPlayerValid(R3D_AnimationPlayer player);
 
 /**
- * @brief Returns whether a given animation is currently playing.
+ * @brief Returns whether an animation is currently playing.
  *
  * @param player Animation player.
- * @param animIndex Index of the animation.
  * @return true if playing, false otherwise.
  */
-R3DAPI bool R3D_IsAnimationPlaying(R3D_AnimationPlayer player, int animIndex);
+R3DAPI bool R3D_IsAnimationPlaying(R3D_AnimationPlayer player);
 
 /**
  * @brief Starts playback of the specified animation.
@@ -149,20 +149,20 @@ R3DAPI bool R3D_IsAnimationPlaying(R3D_AnimationPlayer player, int animIndex);
 R3DAPI void R3D_PlayAnimation(R3D_AnimationPlayer* player, int animIndex);
 
 /**
- * @brief Pauses the specified animation.
+ * @brief Pauses the current animation.
  *
  * @param player Animation player.
  * @param animIndex Index of the animation to pause.
  */
-R3DAPI void R3D_PauseAnimation(R3D_AnimationPlayer* player, int animIndex);
+R3DAPI void R3D_PauseAnimation(R3D_AnimationPlayer* player);
 
 /**
- * @brief Stops the specified animation and clamps its time.
+ * @brief Stops the current animation and clamps its time.
  *
  * @param player Animation player.
  * @param animIndex Index of the animation to stop.
  */
-R3DAPI void R3D_StopAnimation(R3D_AnimationPlayer* player, int animIndex);
+R3DAPI void R3D_StopAnimation(R3D_AnimationPlayer* player);
 
 /**
  * @brief Rewinds the animation to the start or end depending on playback direction.
@@ -170,7 +170,7 @@ R3DAPI void R3D_StopAnimation(R3D_AnimationPlayer* player, int animIndex);
  * @param player Animation player.
  * @param animIndex Index of the animation to rewind.
  */
-R3DAPI void R3D_RewindAnimation(R3D_AnimationPlayer* player, int animIndex);
+R3DAPI void R3D_RewindAnimation(R3D_AnimationPlayer* player);
 
 /**
  * @brief Gets the current playback time of an animation.
@@ -189,24 +189,6 @@ R3DAPI float R3D_GetAnimationTime(R3D_AnimationPlayer player, int animIndex);
  * @param time Time in animation ticks.
  */
 R3DAPI void R3D_SetAnimationTime(R3D_AnimationPlayer* player, int animIndex, float time);
-
-/**
- * @brief Gets the blending weight of an animation.
- *
- * @param player Animation player.
- * @param animIndex Index of the animation.
- * @return Current weight.
- */
-R3DAPI float R3D_GetAnimationWeight(R3D_AnimationPlayer player, int animIndex);
-
-/**
- * @brief Sets the blending weight of an animation.
- *
- * @param player Animation player.
- * @param animIndex Index of the animation.
- * @param weight Blending weight to apply.
- */
-R3DAPI void R3D_SetAnimationWeight(R3D_AnimationPlayer* player, int animIndex, float weight);
 
 /**
  * @brief Gets the playback speed of an animation.
@@ -248,9 +230,9 @@ R3DAPI bool R3D_GetAnimationLoop(R3D_AnimationPlayer player, int animIndex);
 R3DAPI void R3D_SetAnimationLoop(R3D_AnimationPlayer* player, int animIndex, bool loop);
 
 /**
- * @brief Advances the time of all active animations.
+ * @brief Advances the time of the current animation.
  *
- * Updates all internal animation timers based on speed and delta time.
+ * Updates animation timer based on speed and delta time.
  * Does NOT recalculate the skeleton pose.
  *
  * @param player Animation player.

--- a/include/r3d/r3d_animation_player.h
+++ b/include/r3d/r3d_animation_player.h
@@ -238,54 +238,56 @@ R3DAPI void R3D_SetAnimationLoop(R3D_AnimationPlayer* player, int animIndex, boo
  * @param player Animation player.
  * @param dt Delta time in seconds.
  */
-R3DAPI void R3D_AdvanceAnimationPlayerTime(R3D_AnimationPlayer* player, float dt);
+R3DAPI void R3D_AdvanceAnimationTime(R3D_AnimationPlayer* player, float dt);
 
 /**
- * @brief Calculates the current blended local pose of the skeleton.
+ * @brief Computes the local-space transform of each bone for the current animation.
  *
- * Interpolates keyframes and blends all active animations according to their weights,
- * but only computes the local transforms of each bone relative to its parent.
- * Does NOT advance animation time.
+ * Samples and interpolates the current animation keyframes at the current playback time,
+ * and stores the resulting bone transforms in local space into @p player->localPose.
+ * Does NOT advance animation time, and does NOT compute model-space transforms.
  *
  * @param player Animation player whose local pose will be updated.
  */
-R3DAPI void R3D_CalculateAnimationPlayerLocalPose(R3D_AnimationPlayer* player);
+R3DAPI void R3D_ComputeAnimationLocalPose(R3D_AnimationPlayer* player);
 
 /**
- * @brief Calculates the current blended model (global) pose of the skeleton.
+ * @brief Computes the model-space transform of each bone from the current local pose.
  *
- * Interpolates keyframes and blends all active animations according to their weights,
- * but only computes the global transforms of each bone in model space.
- * This assumes the local pose is already up-to-date.
- * Does NOT advance animation time.
+ * Traverses the bone hierarchy and accumulates local transforms into model-space matrices,
+ * stored into @p player->modelPose. This assumes @p player->localPose is already up-to-date.
+ * Does NOT sample animation keyframes, and does NOT advance animation time.
  *
  * @param player Animation player whose model pose will be updated.
  */
-R3DAPI void R3D_CalculateAnimationPlayerModelPose(R3D_AnimationPlayer* player);
+R3DAPI void R3D_ComputeAnimationModelPose(R3D_AnimationPlayer* player);
 
 /**
- * @brief Calculates the current blended skeleton pose (local and model).
+ * @brief Computes both the local and model-space transforms for the current animation.
  *
- * Interpolates keyframes and blends all active animations according to their weights,
- * then computes both local and model transforms for the entire skeleton.
+ * Equivalent to calling R3D_ComputeAnimationLocalPose() followed by R3D_ComputeAnimationModelPose().
  * Does NOT advance animation time.
  *
  * @param player Animation player whose local and model poses will be updated.
  */
-R3DAPI void R3D_CalculateAnimationPlayerPose(R3D_AnimationPlayer* player);
+R3DAPI void R3D_ComputeAnimationPose(R3D_AnimationPlayer* player);
 
 /**
- * @brief Calculates the skinning matrices and uploads them to the GPU.
+ * @brief Computes the final skinning matrices and uploads them to the GPU.
  *
- * @param player Animation player.
+ * Multiplies each bone's model-space transform by its inverse bind matrix to produce
+ * the skinning matrices, then uploads them to the GPU skin texture.
+ * This assumes @p player->modelPose is already up-to-date.
+ *
+ * @param player Animation player whose skinning matrices will be uploaded.
  */
-R3DAPI void R3D_UploadAnimationPlayerPose(R3D_AnimationPlayer* player);
+R3DAPI void R3D_UploadAnimationPose(R3D_AnimationPlayer* player);
 
 /**
- * @brief Updates the animation player: calculates and upload blended pose, then advances time.
+ * @brief Updates the animation player: calculates and upload the current pose pose, then advances time.
  *
- * Equivalent to calling R3D_CalculateAnimationPlayerPose() followed by
- * R3D_UploadAnimationPlayerPose() and R3D_AdvanceAnimationPlayerTime().
+ * Equivalent to calling R3D_ComputeAnimationLocalPose() followed by
+ * R3D_ComputeAnimationModelPose() and R3D_AdvanceAnimationTime().
  *
  * @param player Animation player.
  * @param dt Delta time in seconds.

--- a/include/r3d/r3d_animation_player.h
+++ b/include/r3d/r3d_animation_player.h
@@ -85,7 +85,7 @@ typedef struct R3D_AnimationPlayer {
     R3D_AnimationLib animLib;   ///< Animation library providing the available animations.
     R3D_Skeleton skeleton;      ///< Skeleton to animate.
 
-    R3D_AnimationState* states; ///< Array of active animation states, one per animation.
+    R3D_AnimationState* states; ///< Array of animation states, one per animation.
     int activeAnimIndex;        ///< Index of the current animation.
 
     Matrix* localPose;          ///< Array of bone transforms representing the blended local pose.

--- a/src/r3d_animation_player.c
+++ b/src/r3d_animation_player.c
@@ -171,7 +171,7 @@ void R3D_SetAnimationLoop(R3D_AnimationPlayer* player, int animIndex, bool loop)
     }
 }
 
-void R3D_AdvanceAnimationPlayerTime(R3D_AnimationPlayer* player, float dt)
+void R3D_AdvanceAnimationTime(R3D_AnimationPlayer* player, float dt)
 {
     int animIndex = player->activeAnimIndex;
     if (!is_anim_index_valid(player, animIndex)) {
@@ -198,19 +198,19 @@ void R3D_AdvanceAnimationPlayerTime(R3D_AnimationPlayer* player, float dt)
     }
 }
 
-void R3D_CalculateAnimationPlayerLocalPose(R3D_AnimationPlayer* player)
+void R3D_ComputeAnimationLocalPose(R3D_AnimationPlayer* player)
 {
     if (is_anim_index_valid(player, player->activeAnimIndex)) compute_local_matrices(player);
     else memcpy(player->localPose, player->skeleton.localBind, player->skeleton.boneCount * sizeof(Matrix));
 }
 
-void R3D_CalculateAnimationPlayerModelPose(R3D_AnimationPlayer* player)
+void R3D_ComputeAnimationModelPose(R3D_AnimationPlayer* player)
 {
     if (is_anim_index_valid(player, player->activeAnimIndex)) r3d_anim_matrices_compute(player);
     else memcpy(player->modelPose, player->skeleton.modelBind, player->skeleton.boneCount * sizeof(Matrix));
 }
 
-void R3D_CalculateAnimationPlayerPose(R3D_AnimationPlayer* player)
+void R3D_ComputeAnimationPose(R3D_AnimationPlayer* player)
 {
     if (is_anim_index_valid(player, player->activeAnimIndex)) {
         compute_local_matrices(player);
@@ -222,7 +222,7 @@ void R3D_CalculateAnimationPlayerPose(R3D_AnimationPlayer* player)
     }
 }
 
-void R3D_UploadAnimationPlayerPose(R3D_AnimationPlayer* player)
+void R3D_UploadAnimationPose(R3D_AnimationPlayer* player)
 {
     for (int i = 0; i < player->skeleton.boneCount; i++) {
         player->skinBuffer[i] = MatrixMultiply(player->skeleton.invBind[i], player->modelPose[i]);
@@ -236,10 +236,10 @@ void R3D_UploadAnimationPlayerPose(R3D_AnimationPlayer* player)
 
 void R3D_UpdateAnimationPlayer(R3D_AnimationPlayer* player, float dt)
 {
-    R3D_CalculateAnimationPlayerPose(player);
-    R3D_UploadAnimationPlayerPose(player);
+    R3D_ComputeAnimationPose(player);
+    R3D_UploadAnimationPose(player);
 
-    R3D_AdvanceAnimationPlayerTime(player, dt);
+    R3D_AdvanceAnimationTime(player, dt);
 }
 
 // ========================================

--- a/src/r3d_animation_player.c
+++ b/src/r3d_animation_player.c
@@ -7,8 +7,10 @@
  */
 
 #include <r3d/r3d_animation_player.h>
+#include <r3d_config.h>
 #include <raymath.h>
 #include <stdlib.h>
+#include <assert.h>
 #include <glad.h>
 
 #include "./common/r3d_anim.h"
@@ -18,7 +20,9 @@
 // ========================================
 
 static void emit_event(R3D_AnimationPlayer* player, R3D_AnimationEvent event, int animIndex);
-static void compute_local_matrices(R3D_AnimationPlayer* player, float totalWeight);
+static bool is_anim_index_valid(R3D_AnimationPlayer* player, int animIndex);
+static void reset_anim_time(R3D_AnimationPlayer* player, int animIndex);
+static void compute_local_matrices(R3D_AnimationPlayer* player);
 
 // ========================================
 // PUBLIC API
@@ -39,12 +43,12 @@ R3D_AnimationPlayer R3D_LoadAnimationPlayer(R3D_Skeleton skeleton, R3D_Animation
     for (int i = 0; i < animLib.count; i++) {
         player.states[i] = (R3D_AnimationState) {
             .currentTime = 0.0f,
-            .weight = 0.0f,
             .speed = 1.0f,
             .play = false,
             .loop = false
         };
     }
+    player.activeAnimIndex = -1;
 
     glGenTextures(1, &player.skinTexture);
     glBindTexture(GL_TEXTURE_1D, player.skinTexture);
@@ -74,172 +78,147 @@ bool R3D_IsAnimationPlayerValid(R3D_AnimationPlayer player)
     return (player.skinTexture > 0);
 }
 
-bool R3D_IsAnimationPlaying(R3D_AnimationPlayer player, int animIndex)
+bool R3D_IsAnimationPlaying(R3D_AnimationPlayer player)
 {
-    return player.states[animIndex].play;
+    if (is_anim_index_valid(&player, player.activeAnimIndex)) {
+        return player.states[player.activeAnimIndex].play;
+    }
+    return false;
 }
 
 void R3D_PlayAnimation(R3D_AnimationPlayer* player, int animIndex)
 {
+    if (!is_anim_index_valid(player, animIndex)) {
+        R3D_TRACELOG(LOG_WARNING, "Failed to play animation %i; Animation index invalid", animIndex);
+        return;
+    }
+
+    if (is_anim_index_valid(player, player->activeAnimIndex)) {
+        player->states[player->activeAnimIndex].play = false;
+    }
+
     player->states[animIndex].play = true;
+    player->activeAnimIndex = animIndex;
 }
 
-void R3D_PauseAnimation(R3D_AnimationPlayer* player, int animIndex)
+void R3D_PauseAnimation(R3D_AnimationPlayer* player)
 {
-    player->states[animIndex].play = false;
+    if (is_anim_index_valid(player, player->activeAnimIndex)) {
+        player->states[player->activeAnimIndex].play = false;
+    }
 }
 
-void R3D_StopAnimation(R3D_AnimationPlayer* player, int animIndex)
+void R3D_StopAnimation(R3D_AnimationPlayer* player)
 {
-    R3D_AnimationState* state = &player->states[animIndex];
-
-    if (state->speed >= 0.0f) {
-        state->currentTime = 0.0f;
+    if (is_anim_index_valid(player, player->activeAnimIndex)) {
+        player->states[player->activeAnimIndex].play = false;
+        reset_anim_time(player, player->activeAnimIndex);
     }
-    else {
-        const R3D_Animation* anim = &player->animLib.animations[animIndex];
-        state->currentTime = anim->duration / anim->ticksPerSecond;
-    }
-
-    state->play = false;
 }
 
-void R3D_RewindAnimation(R3D_AnimationPlayer* player, int animIndex)
+void R3D_RewindAnimation(R3D_AnimationPlayer* player)
 {
-    R3D_AnimationState* state = &player->states[animIndex];
-
-    if (state->speed >= 0.0f) {
-        state->currentTime = 0.0f;
-    }
-    else {
-        const R3D_Animation* anim = &player->animLib.animations[animIndex];
-        state->currentTime = anim->duration / anim->ticksPerSecond;
+    if (is_anim_index_valid(player, player->activeAnimIndex)) {
+        reset_anim_time(player, player->activeAnimIndex);
     }
 }
 
 float R3D_GetAnimationTime(R3D_AnimationPlayer player, int animIndex)
 {
-    return player.states[animIndex].currentTime;
+    if (is_anim_index_valid(&player, animIndex)) {
+        return player.states[animIndex].currentTime;
+    }
+    return 0.0f;
 }
 
 void R3D_SetAnimationTime(R3D_AnimationPlayer* player, int animIndex, float time)
 {
+    if (!is_anim_index_valid(player, animIndex)) return;
+
     const R3D_Animation* anim = &player->animLib.animations[animIndex];
     float duration = anim->duration / anim->ticksPerSecond;
 
     player->states[animIndex].currentTime = Wrap(time, 0.0f, duration);
 }
 
-float R3D_GetAnimationWeight(R3D_AnimationPlayer player, int animIndex)
-{
-    return player.states[animIndex].weight;
-}
-
-void R3D_SetAnimationWeight(R3D_AnimationPlayer* player, int animIndex, float weight)
-{
-    player->states[animIndex].weight = weight;
-}
-
 float R3D_GetAnimationSpeed(R3D_AnimationPlayer player, int animIndex)
 {
-    return player.states[animIndex].speed;
+    if (is_anim_index_valid(&player, animIndex)) {
+        return player.states[animIndex].speed;
+    }
+    return 0.0f;
 }
 
 void R3D_SetAnimationSpeed(R3D_AnimationPlayer* player, int animIndex, float speed)
 {
-    player->states[animIndex].speed = speed;
+    if (is_anim_index_valid(player, animIndex)) {
+        player->states[animIndex].speed = speed;
+    }
 }
 
 bool R3D_GetAnimationLoop(R3D_AnimationPlayer player, int animIndex)
 {
-    return player.states[animIndex].loop;
+    if (is_anim_index_valid(&player, animIndex)) {
+        return player.states[animIndex].loop;
+    }
+    return false;
 }
 
 void R3D_SetAnimationLoop(R3D_AnimationPlayer* player, int animIndex, bool loop)
 {
-    player->states[animIndex].loop = loop;
+    if (is_anim_index_valid(player, animIndex)) {
+        player->states[animIndex].loop = loop;
+    }
 }
 
 void R3D_AdvanceAnimationPlayerTime(R3D_AnimationPlayer* player, float dt)
 {
-    const int animCount = player->animLib.count;
-    R3D_AnimationState* states = player->states;
+    int animIndex = player->activeAnimIndex;
+    if (!is_anim_index_valid(player, animIndex)) {
+        return;
+    }
 
-    for (int i = 0; i < animCount; i++)
-    {
-        R3D_AnimationState* s = &states[i];
-        if (!s->play) continue;
+    R3D_AnimationState* state = &player->states[animIndex];
+    if (!state->play) return;
 
-        const R3D_Animation* anim = &player->animLib.animations[i];
-        float duration = anim->duration / anim->ticksPerSecond;
+    state->currentTime += state->speed * dt;
 
-        s->currentTime += s->speed * dt;
+    const R3D_Animation* anim = &player->animLib.animations[animIndex];
+    float duration = anim->duration / anim->ticksPerSecond;
 
-        if ((s->speed > 0.0f && s->currentTime >= duration) || (s->speed < 0.0f && s->currentTime <= 0.0f)) {
-            if ((s->play = s->loop)) {
-                emit_event(player, R3D_ANIM_EVENT_LOOPED, i);
-                s->currentTime -= copysignf(duration, s->speed);
-            }
-            else {
-                emit_event(player, R3D_ANIM_EVENT_FINISHED, i);
-                s->currentTime = Clamp(s->currentTime, 0.0f, duration);
-            }
+    if ((state->speed > 0.0f && state->currentTime >= duration) || (state->speed < 0.0f && state->currentTime <= 0.0f)) {
+        if ((state->play = state->loop)) {
+            emit_event(player, R3D_ANIM_EVENT_LOOPED, animIndex);
+            state->currentTime -= copysignf(duration, state->speed);
+        }
+        else {
+            emit_event(player, R3D_ANIM_EVENT_FINISHED, animIndex);
+            state->currentTime = Clamp(state->currentTime, 0.0f, duration);
         }
     }
 }
 
 void R3D_CalculateAnimationPlayerLocalPose(R3D_AnimationPlayer* player)
 {
-    const R3D_AnimationState* states = player->states;
-    int boneCount = player->skeleton.boneCount;
-    int animCount = player->animLib.count;
-
-    float totalWeight = 0.0f;
-    for (int iAnim = 0; iAnim < animCount; iAnim++) {
-        totalWeight += states[iAnim].weight;
-    }
-
-    if (totalWeight > 0.0f) compute_local_matrices(player, totalWeight);
-    else memcpy(player->localPose, player->skeleton.localBind, boneCount * sizeof(Matrix));
+    if (is_anim_index_valid(player, player->activeAnimIndex)) compute_local_matrices(player);
+    else memcpy(player->localPose, player->skeleton.localBind, player->skeleton.boneCount * sizeof(Matrix));
 }
 
 void R3D_CalculateAnimationPlayerModelPose(R3D_AnimationPlayer* player)
 {
-    const R3D_AnimationState* states = player->states;
-    int boneCount = player->skeleton.boneCount;
-    int animCount = player->animLib.count;
-
-    bool hasWeight = false;
-    for (int iAnim = 0; iAnim < animCount; iAnim++) {
-        if (states[iAnim].weight > 0.0f) {
-            hasWeight = true;
-            break;
-        }
-    }
-
-    if (hasWeight) r3d_anim_matrices_compute(player);
-    else memcpy(player->modelPose, player->skeleton.modelBind, boneCount * sizeof(Matrix));
+    if (is_anim_index_valid(player, player->activeAnimIndex)) r3d_anim_matrices_compute(player);
+    else memcpy(player->modelPose, player->skeleton.modelBind, player->skeleton.boneCount * sizeof(Matrix));
 }
 
 void R3D_CalculateAnimationPlayerPose(R3D_AnimationPlayer* player)
 {
-    const int boneCount = player->skeleton.boneCount;
-    const int animCount = player->animLib.count;
-
-    R3D_AnimationState* states = player->states;
-
-    float totalWeight = 0.0f;
-    for (int iAnim = 0; iAnim < animCount; iAnim++) {
-        totalWeight += states[iAnim].weight;
-    }
-
-    if (totalWeight > 0.0f) {
-        compute_local_matrices(player, totalWeight);
+    if (is_anim_index_valid(player, player->activeAnimIndex)) {
+        compute_local_matrices(player);
         r3d_anim_matrices_compute(player);
     }
     else {
-        memcpy(player->localPose, player->skeleton.localBind, boneCount * sizeof(Matrix));
-        memcpy(player->modelPose, player->skeleton.modelBind, boneCount * sizeof(Matrix));
+        memcpy(player->localPose, player->skeleton.localBind, player->skeleton.boneCount * sizeof(Matrix));
+        memcpy(player->modelPose, player->skeleton.modelBind, player->skeleton.boneCount * sizeof(Matrix));
     }
 }
 
@@ -274,44 +253,40 @@ void emit_event(R3D_AnimationPlayer* player, R3D_AnimationEvent event, int animI
     }
 }
 
-void compute_local_matrices(R3D_AnimationPlayer* player, float totalWeight)
+bool is_anim_index_valid(R3D_AnimationPlayer* player, int animIndex)
 {
-    int boneCount = player->skeleton.boneCount;
-    int animCount = player->animLib.count;
+    return animIndex >= 0 && animIndex < player->animLib.count;
+}
 
-    const Matrix* localBind = player->skeleton.localBind;
+void reset_anim_time(R3D_AnimationPlayer* player, int animIndex)
+{
+    assert(is_anim_index_valid(player, animIndex));
+
+    R3D_AnimationState* state = &player->states[animIndex];
+    const R3D_Animation* anim = &player->animLib.animations[animIndex];
+
+    state->currentTime = (state->speed >= 0.0f)
+        ? 0.0f : anim->duration / anim->ticksPerSecond;
+}
+
+void compute_local_matrices(R3D_AnimationPlayer* player)
+{
+    assert(is_anim_index_valid(player, player->activeAnimIndex));
+
+    const R3D_AnimationState* state = &player->states[player->activeAnimIndex];
+    const R3D_Animation* anim = &player->animLib.animations[player->activeAnimIndex];
+
+    float tick = state->currentTime * anim->ticksPerSecond;
+    int boneCount = player->skeleton.boneCount;
     Matrix* localPose = player->localPose;
 
-    float invTotalWeight = 1.0f / totalWeight;
-
-    for (int iBone = 0; iBone < boneCount; iBone++)
-    {
-        Transform blended = {0};
-        bool isAnimated = false;
-
-        for (int iAnim = 0; iAnim < animCount; iAnim++)
-        {
-            const R3D_Animation* anim = &player->animLib.animations[iAnim];
-            const R3D_AnimationState* state = &player->states[iAnim];
-            if (state->weight <= 0.0f) continue;
-
-            const R3D_AnimationChannel* channel = r3d_anim_channel_find(anim, iBone);
-            if (!channel) continue;
-            isAnimated = true;
-
-            Transform local = r3d_anim_channel_lerp(channel, state->currentTime * anim->ticksPerSecond,
-                                                    NULL, NULL);
-            float w = state->weight * invTotalWeight;
-
-            blended = r3d_anim_transform_addx_v(blended, local, w);
-        }
-
-        if (!isAnimated) {
-            localPose[iBone] = localBind[iBone];
+    for (int iBone = 0; iBone < boneCount; iBone++) {
+        const R3D_AnimationChannel* channel = r3d_anim_channel_find(anim, iBone);
+        if (channel == NULL) {
+            localPose[iBone] = player->skeleton.localBind[iBone];
             continue;
         }
-
-        blended.rotation = QuaternionNormalize(blended.rotation);
-        localPose[iBone] = r3d_matrix_srt_quat(blended.scale, blended.rotation, blended.translation);
+        Transform local = r3d_anim_channel_lerp(channel, tick, NULL, NULL);
+        localPose[iBone] = r3d_matrix_srt_quat(local.scale, QuaternionNormalize(local.rotation), local.translation);
     }
 }

--- a/src/r3d_animation_tree.c
+++ b/src/r3d_animation_tree.c
@@ -1163,14 +1163,14 @@ static void atree_update(R3D_AnimationTree* atree, float elapsedTime,
     }
 
     r3d_anim_matrices_compute(player);
-    R3D_UploadAnimationPlayerPose(player);
+    R3D_UploadAnimationPose(player);
     return;
 
 failure:
     R3D_TRACELOG(LOG_ERROR, "Animation tree failed");
     memcpy(player->localPose, player->skeleton.localBind, boneCount * sizeof(Matrix));
     memcpy(player->modelPose, player->skeleton.modelBind, boneCount * sizeof(Matrix));
-    R3D_UploadAnimationPlayerPose(player);
+    R3D_UploadAnimationPose(player);
 }
 
 static void atree_travel(r3d_animtree_stm_t* node, R3D_AnimationStmIndex targetIdx)


### PR DESCRIPTION
Following the [discussion](https://github.com/Bigfoot71/r3d/discussions/220) opened after the AnimationTree PR, `R3D_AnimationPlayer` has been stripped of multi-animation blending, which is now entirely handled by `R3D_AnimationTree`.

### What changed

`R3D_AnimationState` no longer holds a `weight` field. The player now tracks one active animation at a time via `activeAnimIndex`, while still maintaining a persistent state per animation (time, speed, loop).

### API changes

`animIndex` removed from all functions except `R3D_PlayAnimation`:
```c
void R3D_PlayAnimation(R3D_AnimationPlayer* player, int animIndex);
void R3D_PauseAnimation(R3D_AnimationPlayer* player);
void R3D_StopAnimation(R3D_AnimationPlayer* player);
void R3D_RewindAnimation(R3D_AnimationPlayer* player);
```

Pipeline functions renamed for consistency and brevity:
```c
// Before                                   After
R3D_AdvanceAnimationPlayerTime(...)         -> R3D_AdvanceAnimationTime(...)
R3D_CalculateAnimationPlayerLocalPose(...)  -> R3D_ComputeAnimationLocalPose(...)
R3D_CalculateAnimationPlayerModelPose(...)  -> R3D_ComputeAnimationModelPose(...)
R3D_CalculateAnimationPlayerPose(...)       -> R3D_ComputeAnimationPose(...)
R3D_UploadAnimationPlayerPose(...)          -> R3D_UploadAnimationPose(...)
```

State accessors (`Get/Set` for time, speed, loop) are unchanged and still take an `animIndex`, allowing state manipulation on any animation regardless of which one is currently active.