### PR TITLE
Revise cylinder mesh API (split into basic + extended)

### DIFF
--- a/examples/decal.c
+++ b/examples/decal.c
@@ -17,7 +17,7 @@ int main(void)
     // Create meshes
     R3D_Mesh plane = R3D_GenMeshPlane(5.0f, 5.0f, 1, 1);
     R3D_Mesh sphere = R3D_GenMeshSphere(0.5f, 64, 64);
-    R3D_Mesh cylinder = R3D_GenMeshCylinder(0.5f, 0.5f, 1, 64);
+    R3D_Mesh cylinder = R3D_GenMeshCylinder(0.5f, 1, 64);
     R3D_Material material = R3D_GetDefaultMaterial();
     material.albedo.color = GRAY;
 

--- a/include/r3d/r3d_mesh.h
+++ b/include/r3d/r3d_mesh.h
@@ -198,15 +198,27 @@ R3DAPI R3D_Mesh R3D_GenMeshHemiSphere(float radius, int rings, int slices);
 
 /**
  * @brief Generate a cylinder mesh.
+ * @param radius Radius of the cylinder.
+ * @param height Height along Y axis.
+ * @param slices Radial subdivisions.
+ * @return Mesh ready for rendering.
+ * @see R3D_GenMeshDataCylinder
+ */
+R3DAPI R3D_Mesh R3D_GenMeshCylinder(float radius, float height, int slices);
+
+/**
+ * @brief Generate a cylinder, cone or truncated cone mesh.
  * @param bottomRadius Bottom radius.
  * @param topRadius Top radius.
  * @param height Height along Y axis.
  * @param slices Radial subdivisions.
  * @param stacks Vertical subdivisions.
+ * @param bottomCap Generate bottom cap.
+ * @param topCap Generate top cap.
  * @return Mesh ready for rendering.
- * @see R3D_GenMeshDataCylinder
+ * @see R3D_GenMeshDataCylinderEx
  */
-R3DAPI R3D_Mesh R3D_GenMeshCylinder(float bottomRadius, float topRadius, float height, int slices, int stacks);
+R3DAPI R3D_Mesh R3D_GenMeshCylinderEx(float bottomRadius, float topRadius, float height, int slices, int stacks, bool bottomCap, bool topCap);
 
 /**
  * @brief Generate a capsule mesh.

--- a/include/r3d/r3d_mesh.h
+++ b/include/r3d/r3d_mesh.h
@@ -202,10 +202,11 @@ R3DAPI R3D_Mesh R3D_GenMeshHemiSphere(float radius, int rings, int slices);
  * @param topRadius Top radius.
  * @param height Height along Y axis.
  * @param slices Radial subdivisions.
+ * @param stacks Vertical subdivisions.
  * @return Mesh ready for rendering.
  * @see R3D_GenMeshDataCylinder
  */
-R3DAPI R3D_Mesh R3D_GenMeshCylinder(float bottomRadius, float topRadius, float height, int slices);
+R3DAPI R3D_Mesh R3D_GenMeshCylinder(float bottomRadius, float topRadius, float height, int slices, int stacks);
 
 /**
  * @brief Generate a capsule mesh.

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -251,20 +251,22 @@ R3DAPI R3D_MeshData R3D_GenMeshDataSphere(float radius, int rings, int slices);
 R3DAPI R3D_MeshData R3D_GenMeshDataHemiSphere(float radius, int rings, int slices);
 
 /**
- * @brief Generate a cylinder mesh with specified parameters.
+ * @brief Generates a cylinder or cone mesh centered at the origin along the Y axis.
  *
- * Creates a mesh centered at the origin, extending along the Y axis.
- * The mesh includes top and bottom caps and smooth side surfaces.
- * A cone is produced when bottomRadius and topRadius differ.
+ * The mesh origin is at the center: the bottom cap sits at Y = -height/2
+ * and the top cap at Y = +height/2. Setting one radius to 0 produces a cone.
+ * Caps are omitted for zero-radius ends.
  *
- * @param bottomRadius Radius of the bottom cap.
- * @param topRadius Radius of the top cap.
- * @param height Height of the shape along the Y axis.
- * @param slices Number of radial subdivisions around the shape.
+ * @param bottomRadius Radius of the bottom cap. Must be >= 0.
+ * @param topRadius Radius of the top cap. Must be >= 0. Cannot both be 0.
+ * @param height Total height along the Y axis. Must be > 0.
+ * @param slices Radial subdivisions around the circumference. Must be >= 3.
+ * @param stacks Vertical subdivisions along the height. Must be >= 1.
+ *               Higher values reduce faceting, especially on cones.
  *
- * @return Generated mesh structure.
+ * @return The generated mesh data, or an empty mesh on invalid input.
  */
-R3DAPI R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float height, int slices);
+R3DAPI R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float height, int slices, int stacks);
 
 /**
  * @brief Generate a capsule mesh with specified parameters.

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -251,22 +251,37 @@ R3DAPI R3D_MeshData R3D_GenMeshDataSphere(float radius, int rings, int slices);
 R3DAPI R3D_MeshData R3D_GenMeshDataHemiSphere(float radius, int rings, int slices);
 
 /**
- * @brief Generates a cylinder or cone mesh centered at the origin along the Y axis.
+ * @brief Generates a cylinder mesh centered at the origin along the Y axis.
  *
- * The mesh origin is at the center: the bottom cap sits at Y = -height/2
- * and the top cap at Y = +height/2. Setting one radius to 0 produces a cone.
- * Caps are omitted for zero-radius ends.
+ * Both caps are included. For a cone or truncated cone, use R3D_GenMeshDataCylinderEx.
  *
- * @param bottomRadius Radius of the bottom cap. Must be >= 0.
- * @param topRadius Radius of the top cap. Must be >= 0. Cannot both be 0.
+ * @param radius Radius of the cylinder. Must be > 0.
+ * @param height Total height along the Y axis. Must be > 0.
+ * @param slices Radial subdivisions around the circumference. Must be >= 3.
+ *
+ * @return The generated mesh data, or an empty mesh on invalid input.
+ * @see R3D_GenMeshDataCylinderEx
+ */
+R3DAPI R3D_MeshData R3D_GenMeshDataCylinder(float radius, float height, int slices);
+
+/**
+ * @brief Generates a cylinder, cone, or truncated cone mesh centered at the origin along the Y axis.
+ *
+ * The bottom cap sits at Y = -height/2 and the top cap at Y = +height/2.
+ * Setting one radius to 0 produces a cone; caps can be toggled independently.
+ *
+ * @param bottomRadius Radius of the bottom end. Must be >= 0. Cannot both be 0.
+ * @param topRadius Radius of the top end. Must be >= 0. Cannot both be 0.
  * @param height Total height along the Y axis. Must be > 0.
  * @param slices Radial subdivisions around the circumference. Must be >= 3.
  * @param stacks Vertical subdivisions along the height. Must be >= 1.
  *               Higher values reduce faceting, especially on cones.
+ * @param bottomCap Whether to generate the bottom cap.
+ * @param topCap Whether to generate the top cap.
  *
  * @return The generated mesh data, or an empty mesh on invalid input.
  */
-R3DAPI R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float height, int slices, int stacks);
+R3DAPI R3D_MeshData R3D_GenMeshDataCylinderEx(float bottomRadius, float topRadius, float height, int slices, int stacks, bool bottomCap, bool topCap);
 
 /**
  * @brief Generate a capsule mesh with specified parameters.

--- a/src/r3d_mesh.c
+++ b/src/r3d_mesh.c
@@ -217,11 +217,11 @@ R3D_Mesh R3D_GenMeshHemiSphere(float radius, int rings, int slices)
     return mesh;
 }
 
-R3D_Mesh R3D_GenMeshCylinder(float bottomRadius, float topRadius, float height, int slices)
+R3D_Mesh R3D_GenMeshCylinder(float bottomRadius, float topRadius, float height, int slices, int stacks)
 {
     R3D_Mesh mesh = {0};
 
-    R3D_MeshData data = R3D_GenMeshDataCylinder(bottomRadius, topRadius, height, slices);
+    R3D_MeshData data = R3D_GenMeshDataCylinder(bottomRadius, topRadius, height, slices, stacks);
     if (!R3D_IsMeshDataValid(data)) return mesh;
 
     float radius = MAX(bottomRadius, topRadius);

--- a/src/r3d_mesh.c
+++ b/src/r3d_mesh.c
@@ -217,18 +217,36 @@ R3D_Mesh R3D_GenMeshHemiSphere(float radius, int rings, int slices)
     return mesh;
 }
 
-R3D_Mesh R3D_GenMeshCylinder(float bottomRadius, float topRadius, float height, int slices, int stacks)
+R3D_Mesh R3D_GenMeshCylinder(float radius, float height, int slices)
 {
     R3D_Mesh mesh = {0};
 
-    R3D_MeshData data = R3D_GenMeshDataCylinder(bottomRadius, topRadius, height, slices, stacks);
+    R3D_MeshData data = R3D_GenMeshDataCylinder(radius, height, slices);
+    if (!R3D_IsMeshDataValid(data)) return mesh;
+
+    BoundingBox aabb = {
+        {-radius, -height * 0.5f, -radius},
+        { radius,  height * 0.5f,  radius}
+    };
+
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    R3D_UnloadMeshData(data);
+
+    return mesh;
+}
+
+R3D_Mesh R3D_GenMeshCylinderEx(float bottomRadius, float topRadius, float height, int slices, int stacks, bool bottomCap, bool topCap)
+{
+    R3D_Mesh mesh = {0};
+
+    R3D_MeshData data = R3D_GenMeshDataCylinderEx(bottomRadius, topRadius, height, slices, stacks, bottomCap, topCap);
     if (!R3D_IsMeshDataValid(data)) return mesh;
 
     float radius = MAX(bottomRadius, topRadius);
 
     BoundingBox aabb = {
-        {-radius,   0.0f, -radius},
-        { radius, height,  radius}
+        {-radius, -height * 0.5f, -radius},
+        { radius,  height * 0.5f,  radius}
     };
 
     mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -875,11 +875,11 @@ R3D_MeshData R3D_GenMeshDataHemiSphere(float radius, int rings, int slices)
     return meshData;
 }
 
-R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float height, int slices)
+R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float height, int slices, int stacks)
 {
     R3D_MeshData meshData = {0};
 
-    if (bottomRadius < 0.0f || topRadius < 0.0f || height <= 0.0f || slices < 3) {
+    if (bottomRadius < 0.0f || topRadius < 0.0f ||  height <= 0.0f || slices < 3 || stacks < 1) {
         return meshData;
     }
 
@@ -887,17 +887,17 @@ R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float 
         return meshData;
     }
 
-    int vertCountPerRing = slices + 1;
-    int bodyVertCount = 2 * vertCountPerRing;
-    int capVertCount = 0;
-    if (bottomRadius > 0.0f) capVertCount += 1 + slices;
-    if (topRadius > 0.0f) capVertCount += 1 + slices;
-    
+    bool hasBottom = bottomRadius > 0.0f;
+    bool hasTop = topRadius > 0.0f;
+
+    int ringCount = stacks + 1;
+    int ringStride = slices + 1;
+    int bodyVertCount = ringCount * ringStride;
+    int capVertCount = (hasBottom ? 1 + slices : 0) + (hasTop   ? 1 + slices : 0);
     int totalVertCount = bodyVertCount + capVertCount;
-    int bodyIndexCount = slices * 6;
-    int capIndexCount = 0;
-    if (bottomRadius > 0.0f) capIndexCount += slices * 3;
-    if (topRadius > 0.0f) capIndexCount += slices * 3;
+
+    int bodyIndexCount = stacks * slices * 6;
+    int capIndexCount = (hasBottom ? slices * 3 : 0) + (hasTop   ? slices * 3 : 0);
     int totalIndexCount = bodyIndexCount + capIndexCount;
 
     if (!alloc_mesh(&meshData, totalVertCount, totalIndexCount)) {
@@ -907,53 +907,49 @@ R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float 
     float halfHeight = height * 0.5f;
     float sliceStep = 2.0f * PI / slices;
     float invSlices = 1.0f / slices;
+    float invStacks = 1.0f / stacks;
+
+    float slopeR = height;
+    float slopeY = bottomRadius - topRadius;
+    float invLen = 1.0f / sqrtf(slopeR * slopeR + slopeY * slopeY);
+    float normalR = slopeR * invLen;
+    float normalY = slopeY * invLen;
 
     R3D_Vertex* vertex = meshData.vertices;
 
-    for (int slice = 0; slice <= slices; slice++, vertex++)
+    for (int stack = 0; stack <= stacks; stack++)
     {
-        float theta = slice * sliceStep;
-        float cosTheta = cosf(theta);
-        float sinTheta = sinf(theta);
+        float t = stack * invStacks;
+        float radius = bottomRadius + (topRadius - bottomRadius) * t;
+        float y = -halfHeight + height * t;
 
-        float x = bottomRadius * cosTheta;
-        float z = -bottomRadius * sinTheta;
+        for (int slice = 0; slice <= slices; slice++, vertex++)
+        {
+            float theta = slice * sliceStep;
+            float cosTheta = cosf(theta);
+            float sinTheta = sinf(theta);
 
-        vertex->position = (Vector3){x, -halfHeight, z};
-        vertex->texcoord = (Vector2){slice * invSlices, 0.0f};
-        vertex->normal = (Vector3){cosTheta, 0.0f, -sinTheta};
-        vertex->color = WHITE;
-        vertex->tangent = (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f};
-    }
-
-    for (int slice = 0; slice <= slices; slice++, vertex++)
-    {
-        float theta = slice * sliceStep;
-        float cosTheta = cosf(theta);
-        float sinTheta = sinf(theta);
-
-        float x = topRadius * cosTheta;
-        float z = -topRadius * sinTheta;
-
-        vertex->position = (Vector3){x, halfHeight, z};
-        vertex->texcoord = (Vector2){slice * invSlices, 1.0f};
-        vertex->normal = (Vector3){cosTheta, 0.0f, -sinTheta};
-        vertex->color = WHITE;
-        vertex->tangent = (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f};
+            vertex->position = (Vector3){radius * cosTheta, y, -radius * sinTheta};
+            vertex->texcoord = (Vector2){slice * invSlices, t};
+            vertex->normal = (Vector3){normalR * cosTheta, normalY, -normalR * sinTheta};
+            vertex->color = WHITE;
+            vertex->tangent = (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f};
+        }
     }
 
     uint32_t bottomCapStart = 0;
     uint32_t topCapStart = 0;
 
-    if (bottomRadius > 0.0f)
+    if (hasBottom)
     {
-        bottomCapStart = bodyVertCount;
+        bottomCapStart = (uint32_t)bodyVertCount;
+
         *vertex++ = (R3D_Vertex){
-            .position = {0.0f, -halfHeight, 0.0f},
-            .texcoord = {0.5f, 0.5f},
-            .normal = {0.0f, -1.0f, 0.0f},
+            .position = {0.0f, -halfHeight, 0.0f },
+            .texcoord = {0.5f, 0.5f },
+            .normal = {0.0f, -1.0f, 0.0f },
             .color = WHITE,
-            .tangent = {1.0f, 0.0f, 0.0f, 1.0f}
+            .tangent = {1.0f, 0.0f, 0.0f, 1.0f }
         };
 
         for (int slice = 0; slice < slices; slice++, vertex++)
@@ -962,10 +958,7 @@ R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float 
             float cosTheta = cosf(theta);
             float sinTheta = sinf(theta);
 
-            float x = bottomRadius * cosTheta;
-            float z = -bottomRadius * sinTheta;
-
-            vertex->position = (Vector3){x, -halfHeight, z};
+            vertex->position = (Vector3){bottomRadius * cosTheta, -halfHeight, -bottomRadius * sinTheta};
             vertex->texcoord = (Vector2){0.5f + 0.5f * cosTheta, 0.5f - 0.5f * sinTheta};
             vertex->normal = (Vector3){0.0f, -1.0f, 0.0f};
             vertex->color = WHITE;
@@ -973,9 +966,12 @@ R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float 
         }
     }
 
-    if (topRadius > 0.0f)
+    if (hasTop)
     {
-        topCapStart = bottomRadius > 0.0f ? bottomCapStart + 1 + slices : bodyVertCount;
+        topCapStart = hasBottom
+            ? bottomCapStart + 1 + (uint32_t)slices
+            : (uint32_t)bodyVertCount;
+
         *vertex++ = (R3D_Vertex){
             .position = {0.0f, halfHeight, 0.0f},
             .texcoord = {0.5f, 0.5f},
@@ -990,10 +986,7 @@ R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float 
             float cosTheta = cosf(theta);
             float sinTheta = sinf(theta);
 
-            float x = topRadius * cosTheta;
-            float z = -topRadius * sinTheta;
-
-            vertex->position = (Vector3){x, halfHeight, z};
+            vertex->position = (Vector3){topRadius * cosTheta, halfHeight, -topRadius * sinTheta};
             vertex->texcoord = (Vector2){0.5f + 0.5f * cosTheta, 0.5f - 0.5f * sinTheta};
             vertex->normal = (Vector3){0.0f, 1.0f, 0.0f};
             vertex->color = WHITE;
@@ -1003,36 +996,34 @@ R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float 
 
     uint32_t* index = meshData.indices;
 
-    for (int slice = 0; slice < slices; slice++) {
-        uint32_t i0 = slice;
-        uint32_t i1 = slice + 1;
-        uint32_t i2 = vertCountPerRing + slice;
-        uint32_t i3 = vertCountPerRing + slice + 1;
-        *index++ = i0; *index++ = i1; *index++ = i3;
-        *index++ = i0; *index++ = i3; *index++ = i2;
-    }
-
-    if (bottomRadius > 0.0f) {
-        uint32_t centerIdx = bottomCapStart;
-        uint32_t perimeterStart = bottomCapStart + 1;
+    for (int stack = 0; stack < stacks; stack++) {
         for (int slice = 0; slice < slices; slice++) {
-            uint32_t current = perimeterStart + slice;
-            uint32_t next = perimeterStart + (slice + 1) % slices;
-            *index++ = centerIdx;
-            *index++ = next;
-            *index++ = current;
+            uint32_t b0 = (uint32_t)(stack * ringStride + slice);
+            uint32_t b1 = b0 + 1;
+            uint32_t t0 = b0 + (uint32_t)ringStride;
+            uint32_t t1 = t0 + 1;
+            *index++ = b0; *index++ = b1; *index++ = t1;
+            *index++ = b0; *index++ = t1; *index++ = t0;
         }
     }
 
-    if (topRadius > 0.0f) {
-        uint32_t centerIdx = topCapStart;
-        uint32_t perimeterStart = topCapStart + 1;
+    if (hasBottom) {
+        uint32_t center = bottomCapStart;
+        uint32_t peri = bottomCapStart + 1;
         for (int slice = 0; slice < slices; slice++) {
-            uint32_t current = perimeterStart + slice;
-            uint32_t next = perimeterStart + (slice + 1) % slices;
-            *index++ = centerIdx;
-            *index++ = current;
-            *index++ = next;
+            *index++ = center;
+            *index++ = peri + (slice + 1) % slices;
+            *index++ = peri + slice;
+        }
+    }
+
+    if (hasTop) {
+        uint32_t center = topCapStart;
+        uint32_t peri = topCapStart + 1;
+        for (int slice = 0; slice < slices; slice++) {
+            *index++ = center;
+            *index++ = peri + slice;
+            *index++ = peri + (slice + 1) % slices;
         }
     }
 

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -884,7 +884,7 @@ R3D_MeshData R3D_GenMeshDataCylinderEx(float bottomRadius, float topRadius, floa
 {
     R3D_MeshData meshData = {0};
 
-    if (bottomRadius < 0.0f || topRadius < 0.0f ||  height <= 0.0f || slices < 3 || stacks < 1) {
+    if (bottomRadius < 0.0f || topRadius < 0.0f || height <= 0.0f || slices < 3 || stacks < 1) {
         return meshData;
     }
 
@@ -898,11 +898,11 @@ R3D_MeshData R3D_GenMeshDataCylinderEx(float bottomRadius, float topRadius, floa
     int ringCount = stacks + 1;
     int ringStride = slices + 1;
     int bodyVertCount = ringCount * ringStride;
-    int capVertCount = (hasBottom ? 1 + slices : 0) + (hasTop   ? 1 + slices : 0);
+    int capVertCount = (hasBottom ? 1 + slices : 0) + (hasTop ? 1 + slices : 0);
     int totalVertCount = bodyVertCount + capVertCount;
 
     int bodyIndexCount = stacks * slices * 6;
-    int capIndexCount = (hasBottom ? slices * 3 : 0) + (hasTop   ? slices * 3 : 0);
+    int capIndexCount = (hasBottom ? slices * 3 : 0) + (hasTop ? slices * 3 : 0);
     int totalIndexCount = bodyIndexCount + capIndexCount;
 
     if (!alloc_mesh(&meshData, totalVertCount, totalIndexCount)) {

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -875,7 +875,12 @@ R3D_MeshData R3D_GenMeshDataHemiSphere(float radius, int rings, int slices)
     return meshData;
 }
 
-R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float height, int slices, int stacks)
+R3D_MeshData R3D_GenMeshDataCylinder(float radius, float height, int slices)
+{
+    return R3D_GenMeshDataCylinderEx(radius, radius, height, slices, 1, true, true);
+}
+
+R3D_MeshData R3D_GenMeshDataCylinderEx(float bottomRadius, float topRadius, float height, int slices, int stacks, bool bottomCap, bool topCap)
 {
     R3D_MeshData meshData = {0};
 
@@ -887,8 +892,8 @@ R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float 
         return meshData;
     }
 
-    bool hasBottom = bottomRadius > 0.0f;
-    bool hasTop = topRadius > 0.0f;
+    bool hasBottom = bottomCap && (bottomRadius > 0.0f);
+    bool hasTop = topCap && (topRadius > 0.0f);
 
     int ringCount = stacks + 1;
     int ringStride = slices + 1;


### PR DESCRIPTION
Cylinder mesh generation has been revised.

The previous function:

```c
R3DAPI R3D_MeshData R3D_GenMeshDataCylinder(float bottomRadius, float topRadius, float height, int slices);
```

has been split into two functions:

```c
R3DAPI R3D_MeshData R3D_GenMeshDataCylinder(float radius, float height, int slices);
R3DAPI R3D_MeshData R3D_GenMeshDataCylinderEx(float bottomRadius, float topRadius, float height, int slices, int stacks, bool bottomCap, bool topCap);
```

`R3D_GenMeshDataCylinder` now only generates a simple cylinder using a single radius, height, and slice count. Caps are always generated and the stack count is fixed to 1.

For more advanced shapes (cone or truncated cone), use `R3D_GenMeshDataCylinderEx`.
