### PR TITLE
[dof] Add near blur intensity control

### DIFF
--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -124,6 +124,7 @@
             .mode = R3D_DOF_DISABLED,                   \
             .focusPoint = 10.0f,                        \
             .focusScale = 1.0f,                         \
+            .nearScale = 1.0f,                          \
             .maxBlurSize = 20.0f,                       \
         },                                              \
         .tonemap = {                                    \
@@ -317,6 +318,7 @@ typedef struct R3D_EnvDoF {
     R3D_DoF mode;           ///< Enable/disable state (default: R3D_DOF_DISABLED)
     float focusPoint;       ///< Focus distance in meters from camera (default: 10.0)
     float focusScale;       ///< Depth of field depth: lower = shallower (default: 1.0)
+    float nearScale;        ///< Near blur intensity: 0.0 = disabled, 1.0 = symmetric to far (default: 1.0)
     float maxBlurSize;      ///< Maximum blur radius, similar to aperture (default: 20.0)
 } R3D_EnvDoF;
 

--- a/shaders/post/dof.frag
+++ b/shaders/post/dof.frag
@@ -24,5 +24,5 @@ void main()
     vec4 sharp = texelFetch(uSceneTex, ivec2(gl_FragCoord), 0);
     vec4 blur = texture(uBlurTex, vTexCoord);
 
-    FragColor = vec4(mix(sharp.rgb, blur.rgb, blur.a), 1.0);
+    FragColor = vec4(mix(blur.rgb, sharp.rgb, blur.a), 1.0);
 }

--- a/shaders/prepare/dof_blur.frag
+++ b/shaders/prepare/dof_blur.frag
@@ -60,6 +60,6 @@ void main()
     // Compute a Gaussian-like weight from the central CoC to produce a blur probability for this pixel.
     // After extensive testing, this gives the most physically plausible blending while remaining simple.
 
-    float w = 1.0 - exp(-0.5 * centerSize * centerSize);
+    float w = exp(-0.5 * centerSize * centerSize);
     FragColor = vec4(color / tot, clamp(w, 0.0, 1.0));
 }

--- a/shaders/prepare/dof_coc.frag
+++ b/shaders/prepare/dof_coc.frag
@@ -13,6 +13,7 @@ noperspective in vec2 vTexCoord;
 uniform sampler2D uDepthTex;
 uniform float uFocusPoint;
 uniform float uFocusScale;
+uniform float uNearScale;
 
 out float FragCoC;
 
@@ -20,5 +21,6 @@ void main()
 {
     float depth = texelFetch(uDepthTex, ivec2(gl_FragCoord.xy), 0).r;
     float coc = (1.0 / uFocusPoint - 1.0 / depth) * uFocusScale;
+    coc *= mix(uNearScale, 1.0, step(0.0, coc));
     FragCoC = clamp(coc, -1.0, 1.0);
 }

--- a/shaders/prepare/dof_down.frag
+++ b/shaders/prepare/dof_down.frag
@@ -8,43 +8,27 @@
 
 #version 330 core
 
-noperspective in vec2 vTexCoord;
-
 uniform sampler2D uSceneTex;
-uniform sampler2D uDepthTex;
 uniform sampler2D uCoCTex;
 
-out vec4 FragColor;
-out float FragDepth;
+out vec4 FragCoC;
 
 void main()
 {
     ivec2 pixCoord = 2 * ivec2(gl_FragCoord.xy);
 
-    ivec2 p0 = pixCoord + ivec2(0, 0);
-    ivec2 p1 = pixCoord + ivec2(1, 0);
-    ivec2 p2 = pixCoord + ivec2(0, 1);
-    ivec2 p3 = pixCoord + ivec2(1, 1);
+    vec4 color0 = texelFetch(uSceneTex, pixCoord + ivec2(0, 0), 0);
+    vec4 color1 = texelFetch(uSceneTex, pixCoord + ivec2(1, 0), 0);
+    vec4 color2 = texelFetch(uSceneTex, pixCoord + ivec2(0, 1), 0);
+    vec4 color3 = texelFetch(uSceneTex, pixCoord + ivec2(1, 1), 0);
 
-    vec3 c0 = texelFetch(uSceneTex, p0, 0).rgb;
-    vec3 c1 = texelFetch(uSceneTex, p1, 0).rgb;
-    vec3 c2 = texelFetch(uSceneTex, p2, 0).rgb;
-    vec3 c3 = texelFetch(uSceneTex, p3, 0).rgb;
+    float coc0 = texelFetch(uCoCTex, pixCoord + ivec2(0, 0), 0).r;
+    float coc1 = texelFetch(uCoCTex, pixCoord + ivec2(1, 0), 0).r;
+    float coc2 = texelFetch(uCoCTex, pixCoord + ivec2(0, 1), 0).r;
+    float coc3 = texelFetch(uCoCTex, pixCoord + ivec2(1, 1), 0).r;
 
-    float d0 = texelFetch(uDepthTex, p0, 0).r;
-    float d1 = texelFetch(uDepthTex, p1, 0).r;
-    float d2 = texelFetch(uDepthTex, p2, 0).r;
-    float d3 = texelFetch(uDepthTex, p3, 0).r;
+    vec4 color = (color0 + color1 + color2 + color3) * 0.25;
+    float coc = min(min(min(coc0, coc1), coc2), coc3);
 
-    ivec2 selectedPixel = p0;
-    float selectedDepth = d0;
-
-    if (d1 < selectedDepth) { selectedPixel = p1; selectedDepth = d1; }
-    if (d2 < selectedDepth) { selectedPixel = p2; selectedDepth = d2; }
-    if (d3 < selectedDepth) { selectedPixel = p3; selectedDepth = d3; }
-
-    float coc = texelFetch(uCoCTex, selectedPixel, 0).r;
-
-    FragColor = vec4((c0 + c1 + c2 + c3) * 0.25, coc);
-    FragDepth = selectedDepth;
+    FragCoC = vec4(color.rgb, coc);
 }

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -488,8 +488,8 @@ bool r3d_shader_load_prepare_dof_down(r3d_shader_custom_t* custom)
     LOAD_SHADER(dofDown, SCREEN_VERT, DOF_DOWN_FRAG);
 
     USE_SHADER(dofDown);
+
     SET_SAMPLER(dofDown, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
-    SET_SAMPLER(dofDown, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
     SET_SAMPLER(dofDown, uCoCTex, R3D_SHADER_SAMPLER_BUFFER_DOF_COC);
 
     return true;

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -474,6 +474,7 @@ bool r3d_shader_load_prepare_dof_coc(r3d_shader_custom_t* custom)
 
     GET_LOCATION(dofCoc, uFocusPoint);
     GET_LOCATION(dofCoc, uFocusScale);
+    GET_LOCATION(dofCoc, uNearScale);
 
     USE_SHADER(dofCoc);
     SET_SAMPLER(dofCoc, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -706,7 +706,6 @@ typedef struct {
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSceneTex;
-    r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_sampler_t uCoCTex;
 } r3d_shader_prepare_dof_down_t;
 

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -700,6 +700,7 @@ typedef struct {
     r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_float_t uFocusPoint;
     r3d_shader_uniform_float_t uFocusScale;
+    r3d_shader_uniform_float_t uNearScale;
 } r3d_shader_prepare_dof_coc_t;
 
 typedef struct {

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -101,6 +101,13 @@ typedef enum {
         0, (depth)                                                      \
     )
 
+#define R3D_TARGET_CLEAR_LEVEL(level, ...)                              \
+    r3d_target_clear(                                                   \
+        (r3d_target_t[]) {__VA_ARGS__},                                 \
+        sizeof((r3d_target_t[]) {__VA_ARGS__}) / sizeof(r3d_target_t),  \
+        (level), false                                                  \
+    )
+
 #define R3D_TARGET_BIND(depth, ...)                                     \
     r3d_target_bind(                                                    \
         (r3d_target_t[]){ __VA_ARGS__ },                                \

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -193,8 +193,9 @@ void R3D_End(void)
         bool ssil = R3D.environment.ssil.enabled;
         bool ssgi = R3D.environment.ssgi.enabled;
         bool ssr = R3D.environment.ssr.enabled;
+        bool dof = R3D.environment.dof.mode;
 
-        if (ssao || ssil || ssgi || ssr) {
+        if (ssao || ssil || ssgi || ssr || dof) {
             pass_prepare_depth_pyramid();
         }
 
@@ -2165,12 +2166,10 @@ r3d_target_t pass_post_dof(r3d_target_t sceneTarget)
 
     /* --- Downsample CoC to half resolution --- */
 
-    R3D_TARGET_BIND(false, R3D_TARGET_DOF_0, R3D_TARGET_DEPTH);
-    r3d_target_set_write_level(1, 1);
+    R3D_TARGET_BIND(false, R3D_TARGET_DOF_0);
 
     R3D_SHADER_USE(prepare.dofDown);
     R3D_SHADER_BIND_SAMPLER(prepare.dofDown, uSceneTex, r3d_target_get(r3d_target_swap_scene(sceneTarget)));
-    R3D_SHADER_BIND_SAMPLER(prepare.dofDown, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 0));
     R3D_SHADER_BIND_SAMPLER(prepare.dofDown, uCoCTex, r3d_target_get(R3D_TARGET_DOF_COC));
 
     R3D_RENDER_SCREEN();

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -181,9 +181,9 @@ void R3D_End(void)
     r3d_driver_set_depth_mask(GL_TRUE);
     r3d_driver_set_stencil_mask(0xFF);
 
-    if (r3d_render_has_deferred() || r3d_render_has_prepass()) {
-        R3D_TARGET_CLEAR(true, R3D_TARGET_ALL_DEFERRED);
+    R3D_TARGET_CLEAR(true, R3D_TARGET_ALL_DEFERRED);
 
+    if (r3d_render_has_deferred() || r3d_render_has_prepass()) {
         if (r3d_render_has_deferred()) pass_scene_geometry();
         if (r3d_render_has_prepass()) pass_scene_prepass();
         if (r3d_render_has_decal()) pass_scene_decals();
@@ -212,7 +212,10 @@ void R3D_End(void)
         }
     }
     else {
-        r3d_target_clear(NULL, 0, 0, true);
+        int numLevels = r3d_target_get_num_levels(R3D_TARGET_DEPTH);
+        for (int i = 1; i < numLevels; i++) {
+            R3D_TARGET_CLEAR_LEVEL(i, R3D_TARGET_DEPTH);
+        }
     }
 
     /* --- Then background and transparent rendering --- */

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -2159,6 +2159,7 @@ r3d_target_t pass_post_dof(r3d_target_t sceneTarget)
     R3D_SHADER_BIND_SAMPLER(prepare.dofCoc, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 0));
     R3D_SHADER_SET_FLOAT(prepare.dofCoc, uFocusPoint, R3D.environment.dof.focusPoint);
     R3D_SHADER_SET_FLOAT(prepare.dofCoc, uFocusScale, R3D.environment.dof.focusScale);
+    R3D_SHADER_SET_FLOAT(prepare.dofCoc, uNearScale, R3D.environment.dof.nearScale);
 
     R3D_RENDER_SCREEN();
 


### PR DESCRIPTION
Adds `nearScale` to `R3D_EnvDoF`, allowing near blur to be scaled independently from far blur or disabled entirely (`nearScale = 0.0`).

Reworked the CoC downsampling pass to remove the redundant depth re-downsampling, and minor composition weight tweak.