### PR TITLE
[custom-shaders] Add shader aliases

### DIFF
--- a/include/r3d/r3d_screen_shader.h
+++ b/include/r3d/r3d_screen_shader.h
@@ -21,7 +21,7 @@
 // OPAQUE TYPES
 // ========================================
 
-typedef struct R3D_ScreenShader R3D_ScreenShader;
+typedef struct R3D_ShaderCustom R3D_ScreenShader;
 
 // ========================================
 // PUBLIC API
@@ -56,7 +56,30 @@ R3DAPI R3D_ScreenShader* R3D_LoadScreenShader(const char* filePath);
 R3DAPI R3D_ScreenShader* R3D_LoadScreenShaderFromMemory(const char* code);
 
 /**
+ * @brief Creates an alias of an existing screen shader.
+ *
+ * The alias shares the same compiled program shaders as the original but holds
+ * its own independent sampler and uniform data. Typical use cases include
+ * pre-configuring aliases for distinct effects (e.g. different convolution
+ * kernels), or running the same shader multiple times in the same frame's
+ * post-process chain with different parameters at each pass.
+ *
+ * @note The alias does not own the program shaders. Unloading the original shader
+ *       while an alias is still in use results in undefined behavior.
+ *       Always unload all aliases before unloading the original.
+ *
+ * @param shader The original screen shader to alias.
+ * @return Pointer to the alias, or NULL on failure.
+ */
+R3DAPI R3D_ScreenShader* R3D_LoadScreenShaderAlias(R3D_ScreenShader* shader);
+
+/**
  * @brief Unloads and destroys a screen shader.
+ *
+ * If the shader owns its program shaders (i.e. it was created with @ref R3D_LoadScreenShader
+ * or @ref R3D_LoadScreenShaderFromMemory), they are deleted. Aliases created from this
+ * shader via @ref R3D_LoadScreenShaderAlias must be unloaded beforehand, as they
+ * share the same programs and will be left with dangling references.
  *
  * @param shader Screen shader to unload.
  */

--- a/include/r3d/r3d_sky_shader.h
+++ b/include/r3d/r3d_sky_shader.h
@@ -21,7 +21,7 @@
 // OPAQUE TYPES
 // ========================================
 
-typedef struct R3D_SkyShader R3D_SkyShader;
+typedef struct R3D_ShaderCustom R3D_SkyShader;
 
 // ========================================
 // PUBLIC API
@@ -56,7 +56,29 @@ R3DAPI R3D_SkyShader* R3D_LoadSkyShader(const char* filePath);
 R3DAPI R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code);
 
 /**
+ * @brief Creates an alias of an existing sky shader.
+ *
+ * The alias shares the same compiled program shaders as the original but holds
+ * its own independent sampler and uniform data. A typical use case is to
+ * pre-configure several aliases with different uniforms or textures, avoiding
+ * the need to reconfigure the shader on every skybox switch.
+ *
+ * @note The alias does not own the program shaders. Unloading the original shader
+ *       while an alias is still in use results in undefined behavior.
+ *       Always unload all aliases before unloading the original.
+ *
+ * @param shader The original sky shader to alias.
+ * @return Pointer to the alias, or NULL on failure.
+ */
+R3DAPI R3D_SkyShader* R3D_LoadSkyShaderAlias(R3D_SkyShader* shader);
+
+/**
  * @brief Unloads and destroys a sky shader.
+ *
+ * If the shader owns its program shaders (i.e. it was created with @ref R3D_LoadSkyShader
+ * or @ref R3D_LoadSkyShaderFromMemory), they are deleted. Aliases created from this
+ * shader via @ref R3D_LoadSkyShaderAlias must be unloaded beforehand, as they
+ * share the same programs and will be left with dangling references.
  *
  * @param shader Sky shader to unload.
  */

--- a/include/r3d/r3d_surface_shader.h
+++ b/include/r3d/r3d_surface_shader.h
@@ -21,7 +21,7 @@
 // OPAQUE TYPES
 // ========================================
 
-typedef struct R3D_SurfaceShader R3D_SurfaceShader;
+typedef struct R3D_ShaderCustom R3D_SurfaceShader;
 
 // ========================================
 // PUBLIC API
@@ -54,7 +54,30 @@ R3DAPI R3D_SurfaceShader* R3D_LoadSurfaceShader(const char* filePath);
 R3DAPI R3D_SurfaceShader* R3D_LoadSurfaceShaderFromMemory(const char* code);
 
 /**
+ * @brief Creates an alias of an existing surface shader.
+ *
+ * The alias shares the same compiled program shaders as the original but holds
+ * its own independent sampler and uniform data. This allows the same shader
+ * to be used multiple times within a single frame with different values,
+ * for example when several materials rely on the same shader but each draw
+ * call requires distinct uniform values or texture bindings.
+ *
+ * @note The alias does not own the program shaders. Unloading the original shader
+ *       while an alias is still in use results in undefined behavior.
+ *       Always unload all aliases before unloading the original.
+ *
+ * @param shader The original surface shader to alias.
+ * @return Pointer to the alias, or NULL on failure.
+ */
+R3DAPI R3D_SurfaceShader* R3D_LoadSurfaceShaderAlias(R3D_SurfaceShader* shader);
+
+/**
  * @brief Unloads and destroys a surface shader.
+ *
+ * If the shader owns its program shaders (i.e. it was created with @ref R3D_LoadSurfaceShader
+ * or @ref R3D_LoadSurfaceShaderFromMemory), they are deleted. Aliases created from this
+ * shader via @ref R3D_LoadSurfaceShaderAlias must be unloaded beforehand, as they
+ * share the same programs and will be left with dangling references.
  *
  * @param shader Surface shader to unload.
  */

--- a/src/common/r3d_rshade.h
+++ b/src/common/r3d_rshade.h
@@ -446,21 +446,4 @@ static inline char* r3d_rshade_write_shader_function(char* outPtr, const char* n
     return outPtr;
 }
 
-/* Initialize OpenGL uniform buffer object (UBO) */
-static inline void r3d_rshade_init_ubo(r3d_rshade_uniform_buffer_t* uniforms, int currentOffset)
-{
-    if (uniforms->entries[0].name[0] == '\0') return;
-
-    int uboSize = r3d_align_offset(currentOffset, 16);
-    if (uboSize < 16) uboSize = 16;
-
-    uniforms->bufferSize = uboSize;
-    uniforms->dirty = true;
-
-    glGenBuffers(1, &uniforms->bufferId);
-    glBindBuffer(GL_UNIFORM_BUFFER, uniforms->bufferId);
-    glBufferData(GL_UNIFORM_BUFFER, uboSize, uniforms->buffer, GL_DYNAMIC_DRAW);
-    glBindBuffer(GL_UNIFORM_BUFFER, 0);
-}
-
 #endif // R3D_RSHADE_H

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -8,6 +8,7 @@
 
 #include "./r3d_shader.h"
 #include <r3d_config.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
@@ -95,7 +96,7 @@ struct r3d_mod_shader R3D_MOD_SHADER;
 #define DECL_SHADER_SELECT(type, category, shader_name, custom)                 \
     type* shader_name = ((custom) == NULL)                                      \
         ? &R3D_MOD_SHADER.category.shader_name                                  \
-        : &(custom)->category.shader_name
+        : &(custom)->program->category.shader_name
 
 #define LOAD_SHADER(shader_name, vsCode, fsCode) do {                           \
     shader_name->id = load_shader(vsCode, fsCode);                              \
@@ -257,7 +258,7 @@ bool r3d_shader_load_prepare_atrous_wavelet(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_prepare_atrous_wavelet_t, prepare, atrousWavelet);
     LOAD_SHADER(atrousWavelet, SCREEN_VERT, ATROUS_WAVELET_FRAG);
 
-    SET_UNIFORM_BUFFER(atrousWavelet, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+    SET_UNIFORM_BUFFER(atrousWavelet, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
     GET_LOCATION(atrousWavelet, uInvNormalSharp);
     GET_LOCATION(atrousWavelet, uInvDepthSharp);
@@ -326,7 +327,7 @@ bool r3d_shader_load_prepare_ssao(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_prepare_ssao_t, prepare, ssao);
     LOAD_SHADER(ssao, SCREEN_VERT, SSAO_FRAG);
 
-    SET_UNIFORM_BUFFER(ssao, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+    SET_UNIFORM_BUFFER(ssao, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
     GET_LOCATION(ssao, uSampleCount);
     GET_LOCATION(ssao, uRadius);
@@ -374,7 +375,7 @@ bool r3d_shader_load_prepare_ssil(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_prepare_ssil_t, prepare, ssil);
     LOAD_SHADER(ssil, SCREEN_VERT, SSIL_FRAG);
 
-    SET_UNIFORM_BUFFER(ssil, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+    SET_UNIFORM_BUFFER(ssil, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
     GET_LOCATION(ssil, uSampleCount);
     GET_LOCATION(ssil, uSliceCount);
@@ -409,7 +410,7 @@ bool r3d_shader_load_prepare_ssgi(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_prepare_ssgi_t, prepare, ssgi);
     LOAD_SHADER(ssgi, SCREEN_VERT, SSGI_FRAG);
 
-    SET_UNIFORM_BUFFER(ssgi, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+    SET_UNIFORM_BUFFER(ssgi, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
     GET_LOCATION(ssgi, uSampleCount);
     GET_LOCATION(ssgi, uMaxRaySteps);
@@ -448,7 +449,7 @@ bool r3d_shader_load_prepare_ssr(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_prepare_ssr_t, prepare, ssr);
     LOAD_SHADER(ssr, SCREEN_VERT, SSR_FRAG);
 
-    SET_UNIFORM_BUFFER(ssr, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+    SET_UNIFORM_BUFFER(ssr, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
     GET_LOCATION(ssr, uMaxRaySteps);
     GET_LOCATION(ssr, uBinarySteps);
@@ -555,7 +556,7 @@ static bool load_prepare_smaa_edge_detection(r3d_shader_custom_t* custom, int in
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(smaaEdgeDetection, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
+    SET_UNIFORM_BUFFER(smaaEdgeDetection, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
     USE_SHADER(smaaEdgeDetection);
     SET_SAMPLER(smaaEdgeDetection, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
@@ -600,7 +601,7 @@ static bool load_prepare_smaa_blending_weights(r3d_shader_custom_t* custom, int 
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(smaaBlendingWeights, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
+    SET_UNIFORM_BUFFER(smaaBlendingWeights, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
     USE_SHADER(smaaBlendingWeights);
     SET_SAMPLER(smaaBlendingWeights, uEdgesTex, R3D_SHADER_SAMPLER_BUFFER_SMAA_EDGES);
@@ -705,15 +706,15 @@ bool r3d_shader_load_prepare_cubemap_custom_sky(r3d_shader_custom_t* custom)
 {
     assert(custom != NULL);
 
-    r3d_shader_prepare_cubemap_custom_sky_t* cubemapCustomSky = &custom->prepare.cubemapCustomSky;
-    char* fragCode = inject_content(CUBEMAP_CUSTOM_SKY_FRAG, custom->userCode, "#define fragment()", 0);
+    r3d_shader_prepare_cubemap_custom_sky_t* cubemapCustomSky = &custom->program->prepare.cubemapCustomSky;
+    char* fragCode = inject_content(CUBEMAP_CUSTOM_SKY_FRAG, custom->program->userCode, "#define fragment()", 0);
     LOAD_SHADER(cubemapCustomSky, CUBEMAP_VERT, fragCode);
     RL_FREE(fragCode);
 
-    SET_UNIFORM_BUFFER(cubemapCustomSky, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
+    SET_UNIFORM_BUFFER(cubemapCustomSky, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
-    if (custom->userCode && strstr(custom->userCode, "UserBlock") != NULL) {
-        SET_UNIFORM_BUFFER(cubemapCustomSky, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
+    if (strstr(custom->program->userCode, "UserBlock") != NULL) {
+        SET_UNIFORM_BUFFER(cubemapCustomSky, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
 
     GET_LOCATION(cubemapCustomSky, uMatProj);
@@ -735,7 +736,7 @@ bool r3d_shader_load_scene_geometry(r3d_shader_custom_t* custom)
     char* vsCode = inject_defines(SCENE_VERT,    VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
     char* fsCode = inject_defines(GEOMETRY_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
 
-    const char* userCode = custom ? custom->userCode : NULL;
+    const char* userCode = custom ? custom->program->userCode : NULL;
 
     if (userCode != NULL) {
         inject_user_code(&vsCode, &fsCode, userCode);
@@ -746,11 +747,11 @@ bool r3d_shader_load_scene_geometry(r3d_shader_custom_t* custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(geometry, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
-    SET_UNIFORM_BUFFER(geometry, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+    SET_UNIFORM_BUFFER(geometry, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
+    SET_UNIFORM_BUFFER(geometry, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
-        SET_UNIFORM_BUFFER(geometry, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
+        SET_UNIFORM_BUFFER(geometry, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
 
     GET_LOCATION(geometry, uMatNormal);
@@ -800,7 +801,7 @@ bool r3d_shader_load_scene_forward(r3d_shader_custom_t* custom)
     char* vsCode = inject_defines(SCENE_VERT,   VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
     char* fsCode = inject_defines(FORWARD_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
 
-    const char* userCode = custom ? custom->userCode : NULL;
+    const char* userCode = custom ? custom->program->userCode : NULL;
 
     if (userCode != NULL) {
         inject_user_code(&vsCode, &fsCode, userCode);
@@ -811,14 +812,14 @@ bool r3d_shader_load_scene_forward(r3d_shader_custom_t* custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(forward, LightArrayBlock, R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT);
-    SET_UNIFORM_BUFFER(forward, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
-    SET_UNIFORM_BUFFER(forward, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
-    SET_UNIFORM_BUFFER(forward, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
-    SET_UNIFORM_BUFFER(forward, FogBlock, R3D_SHADER_BLOCK_FOG_SLOT);
+    SET_UNIFORM_BUFFER(forward, LightArrayBlock, R3D_SHADER_BLOCK_SLOT_LIGHT_ARRAY);
+    SET_UNIFORM_BUFFER(forward, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
+    SET_UNIFORM_BUFFER(forward, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
+    SET_UNIFORM_BUFFER(forward, EnvBlock, R3D_SHADER_BLOCK_SLOT_ENV);
+    SET_UNIFORM_BUFFER(forward, FogBlock, R3D_SHADER_BLOCK_SLOT_FOG);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
-        SET_UNIFORM_BUFFER(forward, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
+        SET_UNIFORM_BUFFER(forward, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
 
     GET_LOCATION(forward, uMatNormal);
@@ -868,7 +869,7 @@ bool r3d_shader_load_scene_unlit(r3d_shader_custom_t *custom)
     char* vsCode = inject_defines(SCENE_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
     char* fsCode = inject_defines(UNLIT_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
 
-    const char* userCode = custom ? custom->userCode : NULL;
+    const char* userCode = custom ? custom->program->userCode : NULL;
 
     if (userCode != NULL) {
         inject_user_code(&vsCode, &fsCode, userCode);
@@ -879,12 +880,12 @@ bool r3d_shader_load_scene_unlit(r3d_shader_custom_t *custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(unlit, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
-    SET_UNIFORM_BUFFER(unlit, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
-    SET_UNIFORM_BUFFER(unlit, FogBlock, R3D_SHADER_BLOCK_FOG_SLOT);
+    SET_UNIFORM_BUFFER(unlit, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
+    SET_UNIFORM_BUFFER(unlit, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
+    SET_UNIFORM_BUFFER(unlit, FogBlock, R3D_SHADER_BLOCK_SLOT_FOG);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
-        SET_UNIFORM_BUFFER(unlit, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
+        SET_UNIFORM_BUFFER(unlit, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
 
     GET_LOCATION(unlit, uMatNormal);
@@ -923,7 +924,7 @@ bool r3d_shader_load_scene_skybox(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_scene_skybox_t, scene, skybox);
     LOAD_SHADER(skybox, SKYBOX_VERT, SKYBOX_FRAG);
 
-    SET_UNIFORM_BUFFER(skybox, FogBlock, R3D_SHADER_BLOCK_FOG_SLOT);
+    SET_UNIFORM_BUFFER(skybox, FogBlock, R3D_SHADER_BLOCK_SLOT_FOG);
 
     GET_LOCATION(skybox, uMatInvView);
     GET_LOCATION(skybox, uMatInvProj);
@@ -948,7 +949,7 @@ bool r3d_shader_load_scene_depth(r3d_shader_custom_t* custom)
     char* vsCode = inject_defines(SCENE_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
     char* fsCode = inject_defines(DEPTH_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
 
-    const char* userCode = custom ? custom->userCode : NULL;
+    const char* userCode = custom ? custom->program->userCode : NULL;
 
     if (userCode != NULL) {
         inject_user_code(&vsCode, &fsCode, userCode);
@@ -959,10 +960,10 @@ bool r3d_shader_load_scene_depth(r3d_shader_custom_t* custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(depth, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
+    SET_UNIFORM_BUFFER(depth, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
-        SET_UNIFORM_BUFFER(depth, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
+        SET_UNIFORM_BUFFER(depth, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
 
     GET_LOCATION(depth, uMatModel);
@@ -998,7 +999,7 @@ bool r3d_shader_load_scene_depth_cube(r3d_shader_custom_t* custom)
     char* vsCode = inject_defines(SCENE_VERT,      VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
     char* fsCode = inject_defines(DEPTH_CUBE_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
 
-    const char* userCode = custom ? custom->userCode : NULL;
+    const char* userCode = custom ? custom->program->userCode : NULL;
 
     if (userCode != NULL) {
         inject_user_code(&vsCode, &fsCode, userCode);
@@ -1009,10 +1010,10 @@ bool r3d_shader_load_scene_depth_cube(r3d_shader_custom_t* custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(depthCube, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
+    SET_UNIFORM_BUFFER(depthCube, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
-        SET_UNIFORM_BUFFER(depthCube, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
+        SET_UNIFORM_BUFFER(depthCube, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
 
     GET_LOCATION(depthCube, uMatModel);
@@ -1056,7 +1057,7 @@ bool r3d_shader_load_scene_probe_forward(r3d_shader_custom_t* custom)
     char* vsCode = inject_defines(SCENE_VERT,   VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
     char* fsCode = inject_defines(FORWARD_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
 
-    const char* userCode = custom ? custom->userCode : NULL;
+    const char* userCode = custom ? custom->program->userCode : NULL;
 
     if (userCode != NULL) {
         inject_user_code(&vsCode, &fsCode, userCode);
@@ -1067,14 +1068,14 @@ bool r3d_shader_load_scene_probe_forward(r3d_shader_custom_t* custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(probeForward, LightArrayBlock, R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT);
-    SET_UNIFORM_BUFFER(probeForward, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
-    SET_UNIFORM_BUFFER(probeForward, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
-    SET_UNIFORM_BUFFER(probeForward, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
-    SET_UNIFORM_BUFFER(probeForward, FogBlock, R3D_SHADER_BLOCK_FOG_SLOT);
+    SET_UNIFORM_BUFFER(probeForward, LightArrayBlock, R3D_SHADER_BLOCK_SLOT_LIGHT_ARRAY);
+    SET_UNIFORM_BUFFER(probeForward, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
+    SET_UNIFORM_BUFFER(probeForward, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
+    SET_UNIFORM_BUFFER(probeForward, EnvBlock, R3D_SHADER_BLOCK_SLOT_ENV);
+    SET_UNIFORM_BUFFER(probeForward, FogBlock, R3D_SHADER_BLOCK_SLOT_FOG);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
-        SET_UNIFORM_BUFFER(probeForward, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
+        SET_UNIFORM_BUFFER(probeForward, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
 
     GET_LOCATION(probeForward, uMatNormal);
@@ -1128,7 +1129,7 @@ bool r3d_shader_load_scene_probe_unlit(r3d_shader_custom_t *custom)
     char* vsCode = inject_defines(SCENE_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
     char* fsCode = inject_defines(UNLIT_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
 
-    const char* userCode = custom ? custom->userCode : NULL;
+    const char* userCode = custom ? custom->program->userCode : NULL;
 
     if (userCode != NULL) {
         inject_user_code(&vsCode, &fsCode, userCode);
@@ -1139,11 +1140,11 @@ bool r3d_shader_load_scene_probe_unlit(r3d_shader_custom_t *custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(probeUnlit, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
-    SET_UNIFORM_BUFFER(probeUnlit, FogBlock, R3D_SHADER_BLOCK_FOG_SLOT);
+    SET_UNIFORM_BUFFER(probeUnlit, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
+    SET_UNIFORM_BUFFER(probeUnlit, FogBlock, R3D_SHADER_BLOCK_SLOT_FOG);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
-        SET_UNIFORM_BUFFER(probeUnlit, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
+        SET_UNIFORM_BUFFER(probeUnlit, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
 
     GET_LOCATION(probeUnlit, uMatNormal);
@@ -1181,7 +1182,7 @@ bool r3d_shader_load_scene_decal(r3d_shader_custom_t* custom)
     char* vsCode = inject_defines(SCENE_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
     char* fsCode = inject_defines(DECAL_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
 
-    const char* userCode = custom ? custom->userCode : NULL;
+    const char* userCode = custom ? custom->program->userCode : NULL;
 
     if (userCode != NULL) {
         inject_user_code(&vsCode, &fsCode, userCode);
@@ -1192,11 +1193,11 @@ bool r3d_shader_load_scene_decal(r3d_shader_custom_t* custom)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(decal, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
-    SET_UNIFORM_BUFFER(decal, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+    SET_UNIFORM_BUFFER(decal, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
+    SET_UNIFORM_BUFFER(decal, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
     if (userCode && strstr(userCode, "UserBlock") != NULL) {
-        SET_UNIFORM_BUFFER(decal, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
+        SET_UNIFORM_BUFFER(decal, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
 
     GET_LOCATION(decal, uMatNormal);
@@ -1244,8 +1245,8 @@ bool r3d_shader_load_deferred_ambient(r3d_shader_custom_t* custom)
     LOAD_SHADER(ambient, SCREEN_VERT, fsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(ambient, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
-    SET_UNIFORM_BUFFER(ambient, EnvBlock, R3D_SHADER_BLOCK_ENV_SLOT);
+    SET_UNIFORM_BUFFER(ambient, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
+    SET_UNIFORM_BUFFER(ambient, EnvBlock, R3D_SHADER_BLOCK_SLOT_ENV);
 
     GET_LOCATION(ambient, uSsaoPower);
     GET_LOCATION(ambient, uSsilIntensity);
@@ -1274,8 +1275,8 @@ bool r3d_shader_load_deferred_lighting(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_deferred_lighting_t, deferred, lighting);
     LOAD_SHADER(lighting, SCREEN_VERT, LIGHTING_FRAG);
 
-    SET_UNIFORM_BUFFER(lighting, LightBlock, R3D_SHADER_BLOCK_LIGHT_SLOT);
-    SET_UNIFORM_BUFFER(lighting, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+    SET_UNIFORM_BUFFER(lighting, LightBlock, R3D_SHADER_BLOCK_SLOT_LIGHT);
+    SET_UNIFORM_BUFFER(lighting, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
     USE_SHADER(lighting);
 
@@ -1314,7 +1315,7 @@ bool r3d_shader_load_deferred_fog(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_deferred_fog_t, deferred, fog);
     LOAD_SHADER(fog, SCREEN_VERT, FOG_FRAG);
 
-    SET_UNIFORM_BUFFER(fog, FogBlock, R3D_SHADER_BLOCK_FOG_SLOT);
+    SET_UNIFORM_BUFFER(fog, FogBlock, R3D_SHADER_BLOCK_SLOT_FOG);
 
     USE_SHADER(fog);
     SET_SAMPLER(fog, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
@@ -1354,16 +1355,16 @@ bool r3d_shader_load_post_screen(r3d_shader_custom_t* custom)
 {
     assert(custom != NULL);
 
-    r3d_shader_post_screen_t* screen = &custom->post.screen;
-    char* fragCode = inject_content(SCREEN_FRAG, custom->userCode, "#define fragment()", 0);
+    r3d_shader_post_screen_t* screen = &custom->program->post.screen;
+    char* fragCode = inject_content(SCREEN_FRAG, custom->program->userCode, "#define fragment()", 0);
     LOAD_SHADER(screen, SCREEN_VERT, fragCode);
     RL_FREE(fragCode);
 
-    SET_UNIFORM_BUFFER(screen, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
-    SET_UNIFORM_BUFFER(screen, ViewBlock, R3D_SHADER_BLOCK_VIEW_SLOT);
+    SET_UNIFORM_BUFFER(screen, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
+    SET_UNIFORM_BUFFER(screen, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
-    if (custom->userCode && strstr(custom->userCode, "UserBlock") != NULL) {
-        SET_UNIFORM_BUFFER(screen, UserBlock, R3D_SHADER_BLOCK_USER_SLOT);
+    if (strstr(custom->program->userCode, "UserBlock") != NULL) {
+        SET_UNIFORM_BUFFER(screen, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
 
     USE_SHADER(screen);
@@ -1407,7 +1408,7 @@ static bool load_post_fxaa(r3d_shader_custom_t* custom, int index)
 
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(fxaa, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
+    SET_UNIFORM_BUFFER(fxaa, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
     USE_SHADER(fxaa);
     SET_SAMPLER(fxaa, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
@@ -1452,7 +1453,7 @@ static bool load_post_smaa(r3d_shader_custom_t* custom, int index)
     RL_FREE(vsCode);
     RL_FREE(fsCode);
 
-    SET_UNIFORM_BUFFER(smaa, FrameBlock, R3D_SHADER_BLOCK_FRAME_SLOT);
+    SET_UNIFORM_BUFFER(smaa, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
     USE_SHADER(smaa);
     SET_SAMPLER(smaa, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
@@ -1644,74 +1645,180 @@ void r3d_shader_bind_sampler(r3d_shader_sampler_t sampler, GLuint texture)
 
 void r3d_shader_set_uniform_block(r3d_shader_block_t block, const void* data)
 {
+    assert(block < R3D_SHADER_BLOCK_COUNT);
+
     GLuint ubo = R3D_MOD_SHADER.uniformBuffers[block];
     int blockSlot = R3D_SHADER_BLOCK_SLOTS[block];
     int blockSize = R3D_SHADER_BLOCK_SIZES[block];
 
     glBindBuffer(GL_UNIFORM_BUFFER, ubo);
     glBufferSubData(GL_UNIFORM_BUFFER, 0, blockSize, data);
-    glBindBufferBase(GL_UNIFORM_BUFFER, blockSlot, ubo);
+
+    if (R3D_MOD_SHADER.uniformBindings[block] != ubo) {
+        glBindBufferBase(GL_UNIFORM_BUFFER, blockSlot, ubo);
+        R3D_MOD_SHADER.uniformBindings[block] = ubo;
+    }
 }
 
 void r3d_shader_bind_uniform_block(r3d_shader_block_t block)
 {
+    assert(block < R3D_SHADER_BLOCK_COUNT);
+
     GLuint ubo = R3D_MOD_SHADER.uniformBuffers[block];
-    glBindBuffer(GL_UNIFORM_BUFFER, ubo);
+    int blockSlot = R3D_SHADER_BLOCK_SLOTS[block];
+
+    if (R3D_MOD_SHADER.uniformBindings[block] != ubo) {
+        glBindBufferBase(GL_UNIFORM_BUFFER, blockSlot, ubo);
+        R3D_MOD_SHADER.uniformBindings[block] = ubo;
+    }
 }
 
-bool r3d_shader_set_custom_uniform(r3d_shader_custom_t* shader, const char* name, const void* value)
+r3d_shader_custom_t* r3d_shader_custom_alloc(void)
+{
+    size_t programOffset = (sizeof(r3d_shader_custom_t) + alignof(r3d_shader_custom_program_t) - 1) & ~(alignof(r3d_shader_custom_program_t) - 1);
+    size_t size = programOffset + sizeof(r3d_shader_custom_program_t);
+
+    r3d_shader_custom_t* shader = RL_CALLOC(1, size);
+    if (shader == NULL) return NULL;
+
+    shader->program = (r3d_shader_custom_program_t*)((uint8_t*)shader + programOffset);
+    shader->programOwner = true;
+
+    return shader;
+}
+
+r3d_shader_custom_t* r3d_shader_custom_clone(r3d_shader_custom_t* custom)
+{
+    r3d_shader_custom_t* clone = RL_CALLOC(1, sizeof(r3d_shader_custom_t));
+    if (clone == NULL) return NULL;
+
+    clone->program = custom->program;
+    clone->programOwner = false;
+
+    memcpy(clone->data.samplers, custom->data.samplers, sizeof(custom->data.samplers));
+    for (int i = 0; i < ARRAY_SIZE(clone->data.samplers); i++) {
+        clone->data.samplers[i].texture = 0;
+    }
+
+    if (custom->data.uniforms.bufferSize > 0)
+    {
+        memcpy(&clone->data.uniforms, &custom->data.uniforms, sizeof(r3d_rshade_uniform_buffer_t));
+        memset(clone->data.uniforms.buffer, 0, sizeof(clone->data.uniforms.buffer));
+
+        clone->data.uniforms.dirty = false;
+        clone->data.uniforms.bufferId = 0;
+
+        glGenBuffers(1, &clone->data.uniforms.bufferId);
+        glBindBuffer(GL_UNIFORM_BUFFER, clone->data.uniforms.bufferId);
+        glBufferData(GL_UNIFORM_BUFFER, clone->data.uniforms.bufferSize, clone->data.uniforms.buffer, GL_DYNAMIC_DRAW);
+        glBindBuffer(GL_UNIFORM_BUFFER, 0);
+    }
+
+    return clone;
+}
+
+void r3d_shader_custom_free(r3d_shader_custom_t* custom)
+{
+#define DELETE_PROGRAM(id) \
+    do { if ((id) != 0) glDeleteProgram((id)); } while(0)
+
+    if (custom == NULL) return;
+
+    if (custom->data.uniforms.bufferId != 0) {
+        glDeleteBuffers(1, &custom->data.uniforms.bufferId);
+    }
+
+    if (custom->programOwner) {
+        DELETE_PROGRAM(custom->program->prepare.cubemapCustomSky.id);
+        DELETE_PROGRAM(custom->program->scene.geometry.id);
+        DELETE_PROGRAM(custom->program->scene.forward.id);
+        DELETE_PROGRAM(custom->program->scene.unlit.id);
+        DELETE_PROGRAM(custom->program->scene.depth.id);
+        DELETE_PROGRAM(custom->program->scene.depthCube.id);
+        DELETE_PROGRAM(custom->program->scene.probeForward.id);
+        DELETE_PROGRAM(custom->program->scene.probeUnlit.id);
+        DELETE_PROGRAM(custom->program->scene.decal.id);
+        DELETE_PROGRAM(custom->program->post.screen.id);
+    }
+
+    RL_FREE(custom);
+
+#undef DELETE_PROGRAM
+}
+
+void r3d_shader_custom_init_uniforms(r3d_shader_custom_t* custom, int currentOffset)
+{
+    r3d_rshade_uniform_buffer_t* uniforms = &custom->data.uniforms;
+    if (uniforms->entries[0].name[0] == '\0') return;
+
+    int uboSize = r3d_align_offset(currentOffset, 16);
+    if (uboSize < 16) uboSize = 16;
+
+    uniforms->bufferSize = uboSize;
+    uniforms->dirty = false;
+
+    glGenBuffers(1, &uniforms->bufferId);
+    glBindBuffer(GL_UNIFORM_BUFFER, uniforms->bufferId);
+    glBufferData(GL_UNIFORM_BUFFER, uboSize, uniforms->buffer, GL_DYNAMIC_DRAW);
+    glBindBuffer(GL_UNIFORM_BUFFER, 0);
+}
+
+bool r3d_shader_custom_set_uniform(r3d_shader_custom_t* shader, const char* name, const void* value)
 {
     assert(shader != NULL);
 
-    for (int i = 0; i < R3D_MAX_SHADER_UNIFORMS && shader->uniforms.entries[i].name[0] != '\0'; i++) {
-        if (strcmp(shader->uniforms.entries[i].name, name) == 0) {
-            int offset = shader->uniforms.entries[i].offset;
-            int size = shader->uniforms.entries[i].size;
-            memcpy(shader->uniforms.buffer + offset, value, size);
-            shader->uniforms.dirty = true;
+    for (int i = 0; i < R3D_MAX_SHADER_UNIFORMS && shader->data.uniforms.entries[i].name[0] != '\0'; i++) {
+        if (strcmp(shader->data.uniforms.entries[i].name, name) == 0) {
+            int offset = shader->data.uniforms.entries[i].offset;
+            int size = shader->data.uniforms.entries[i].size;
+            memcpy(shader->data.uniforms.buffer + offset, value, size);
+            shader->data.uniforms.dirty = true;
             return true;
         }
     }
     return false;
 }
 
-bool r3d_shader_set_custom_sampler(r3d_shader_custom_t* shader, const char* name, Texture texture)
+bool r3d_shader_custom_set_sampler(r3d_shader_custom_t* shader, const char* name, Texture texture)
 {
     assert(shader != NULL);
 
-    for (int i = 0; i < R3D_MAX_SHADER_SAMPLERS && shader->samplers[i].name[0] != '\0'; i++) {
-        if (strcmp(shader->samplers[i].name, name) == 0) {
-            shader->samplers->texture = texture.id;
+    for (int i = 0; i < R3D_MAX_SHADER_SAMPLERS && shader->data.samplers[i].name[0] != '\0'; i++) {
+        if (strcmp(shader->data.samplers[i].name, name) == 0) {
+            shader->data.samplers->texture = texture.id;
             return true;
         }
     }
     return false;
 }
 
-void r3d_shader_bind_custom_uniforms(r3d_shader_custom_t* shader)
+void r3d_shader_custom_bind_uniforms(r3d_shader_custom_t* shader)
 {
     assert(shader != NULL);
 
-    if (shader->uniforms.bufferId == 0) return;
+    if (shader->data.uniforms.bufferId == 0) return;
 
-    if (shader->uniforms.dirty) {
-        glBindBuffer(GL_UNIFORM_BUFFER, shader->uniforms.bufferId);
-        glBufferSubData(GL_UNIFORM_BUFFER, 0, shader->uniforms.bufferSize, shader->uniforms.buffer);
-        shader->uniforms.dirty = false;
+    if (shader->data.uniforms.dirty) {
+        glBindBuffer(GL_UNIFORM_BUFFER, shader->data.uniforms.bufferId);
+        glBufferSubData(GL_UNIFORM_BUFFER, 0, shader->data.uniforms.bufferSize, shader->data.uniforms.buffer);
+        shader->data.uniforms.dirty = false;
     }
 
-    glBindBufferBase(GL_UNIFORM_BUFFER, R3D_SHADER_BLOCK_USER_SLOT, shader->uniforms.bufferId);
+    if (R3D_MOD_SHADER.uniformBindings[R3D_SHADER_BLOCK_USER] != shader->data.uniforms.bufferId) {
+        glBindBufferBase(GL_UNIFORM_BUFFER, R3D_SHADER_BLOCK_SLOT_USER, shader->data.uniforms.bufferId);
+        R3D_MOD_SHADER.uniformBindings[R3D_SHADER_BLOCK_USER] = shader->data.uniforms.bufferId;
+    }
 }
 
-void r3d_shader_bind_custom_samplers(r3d_shader_custom_t* shader)
+void r3d_shader_custom_bind_samplers(r3d_shader_custom_t* shader)
 {
     assert(shader != NULL);
 
-    for (int i = 0; i < R3D_MAX_SHADER_SAMPLERS && shader->samplers[i].name[0] != '\0'; i++)
+    for (int i = 0; i < R3D_MAX_SHADER_SAMPLERS && shader->data.samplers[i].name[0] != '\0'; i++)
     {
         r3d_shader_sampler_t sampler = R3D_SHADER_SAMPLER_CUSTOM_2D;
 
-        switch (shader->samplers[i].target) {
+        switch (shader->data.samplers[i].target) {
         case GL_TEXTURE_1D:
             sampler = R3D_SHADER_SAMPLER_CUSTOM_1D;
             break;
@@ -1729,15 +1836,17 @@ void r3d_shader_bind_custom_samplers(r3d_shader_custom_t* shader)
             break;
         }
 
-        r3d_shader_bind_sampler(sampler + i, shader->samplers[i].texture);
+        r3d_shader_bind_sampler(sampler + i, shader->data.samplers[i].texture);
     }
 }
 
 void r3d_shader_invalidate_cache(void)
 {
+    // Disable current program shader
     R3D_MOD_SHADER.currentProgram = 0;
     glUseProgram(0);
 
+    // Unbind all textures
     for (int iSampler = 0; iSampler < R3D_SHADER_SAMPLER_COUNT; iSampler++) {
         if (R3D_MOD_SHADER.samplerBindings[iSampler] != 0) {
             glActiveTexture(GL_TEXTURE0 + iSampler);
@@ -1746,6 +1855,9 @@ void r3d_shader_invalidate_cache(void)
         }
     }
     glActiveTexture(GL_TEXTURE0);
+
+    // Only reset current UBO binding state
+    memset(&R3D_MOD_SHADER.uniformBindings, 0, sizeof(R3D_MOD_SHADER.uniformBindings));
 }
 
 // ========================================
@@ -1896,11 +2008,11 @@ void inject_user_code(char** vsCode, char** fsCode, const char* userCode)
 
 void set_custom_samplers(GLuint id, r3d_shader_custom_t* custom)
 {
-    for (int i = 0; i < R3D_MAX_SHADER_SAMPLERS && custom->samplers[i].name[0] != '\0'; i++)
+    for (int i = 0; i < R3D_MAX_SHADER_SAMPLERS && custom->data.samplers[i].name[0] != '\0'; i++)
     {
         r3d_shader_sampler_t sampler = R3D_SHADER_SAMPLER_CUSTOM_2D;
 
-        switch (custom->samplers[i].target) {
+        switch (custom->data.samplers[i].target) {
         case GL_TEXTURE_1D:
             sampler = R3D_SHADER_SAMPLER_CUSTOM_1D;
             break;
@@ -1918,7 +2030,7 @@ void set_custom_samplers(GLuint id, r3d_shader_custom_t* custom)
             break;
         }
 
-        GLint loc = glGetUniformLocation(id, custom->samplers[i].name);
+        GLint loc = glGetUniformLocation(id, custom->data.samplers[i].name);
         glUniform1i(loc, sampler + i);
     }
 }

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -25,8 +25,8 @@
 // ========================================
 
 #define R3D_SHADER_GET(shader_name, custom)                                     \
-    (((r3d_shader_custom_t*)(custom) != NULL)                                   \
-        ? &((r3d_shader_custom_t*)(custom))->shader_name                        \
+    (((custom) != NULL)                                                         \
+        ? &(custom)->program->shader_name                                       \
         : &R3D_MOD_SHADER.shader_name)
 
 #define R3D_SHADER_USE(shader_name) do {                                        \
@@ -41,23 +41,21 @@
 } while(0)
 
 #define R3D_SHADER_USE_CUSTOM(custom, shader_name) do {                         \
-    r3d_shader_custom_t* c_shader = (r3d_shader_custom_t*)(custom);             \
-    assert(c_shader != NULL);                                                   \
-    if (c_shader->shader_name.id == 0) {                                        \
-        bool ok = R3D_MOD_SHADER_LOADER.shader_name(c_shader);                  \
+    assert((custom) != NULL);                                                   \
+    if ((custom)->program->shader_name.id == 0) {                               \
+        bool ok = R3D_MOD_SHADER_LOADER.shader_name(custom);                    \
         assert(ok);                                                             \
     }                                                                           \
-    if (R3D_MOD_SHADER.currentProgram != c_shader->shader_name.id) {            \
-        R3D_MOD_SHADER.currentProgram = c_shader->shader_name.id;               \
-        glUseProgram(c_shader->shader_name.id);                                 \
-        r3d_shader_bind_custom_samplers(c_shader);                              \
-        r3d_shader_bind_custom_uniforms(c_shader);                              \
+    if (R3D_MOD_SHADER.currentProgram != (custom)->program->shader_name.id) {   \
+        R3D_MOD_SHADER.currentProgram = (custom)->program->shader_name.id;      \
+        glUseProgram((custom)->program->shader_name.id);                        \
     }                                                                           \
+    r3d_shader_custom_bind_samplers(custom);                                    \
+    r3d_shader_custom_bind_uniforms(custom);                                    \
 } while(0)
 
 #define R3D_SHADER_USE_SELECT(shader_name, custom) do {                         \
-    r3d_shader_custom_t* c_shader = (r3d_shader_custom_t*)(custom);             \
-    if (c_shader == NULL) R3D_SHADER_USE(shader_name);                          \
+    if ((custom) == NULL) R3D_SHADER_USE(shader_name);                          \
     else R3D_SHADER_USE_CUSTOM(custom, shader_name);                            \
 } while(0)
 
@@ -66,14 +64,12 @@
 } while(0)
 
 #define R3D_SHADER_BIND_SAMPLER_CUSTOM(custom, shader_name, uniform, texId) do {\
-    r3d_shader_custom_t* c_shader = (r3d_shader_custom_t*)(custom);             \
-    r3d_shader_bind_sampler(c_shader->shader_name.uniform.slot, (texId));       \
+    r3d_shader_bind_sampler((custom)->program->shader_name.uniform.slot, (texId));\
 } while(0)
 
 #define R3D_SHADER_BIND_SAMPLER_SELECT(shader_name, custom, uniform, texId) do {\
-    r3d_shader_custom_t* c_shader = (r3d_shader_custom_t*)(custom);             \
-    r3d_shader_bind_sampler((c_shader != NULL)                                  \
-        ? c_shader->shader_name.uniform.slot                                    \
+    r3d_shader_bind_sampler(((custom) != NULL)                                  \
+        ? (custom)->program->shader_name.uniform.slot                           \
         : R3D_MOD_SHADER.shader_name.uniform.slot,                              \
         (texId));                                                               \
 } while(0)
@@ -89,9 +85,9 @@
 } while(0)
 
 #define R3D_SHADER_SET_INT_CUSTOM(custom, shader_name, uniform, value) do {     \
-    if (((r3d_shader_custom_t*)(custom))->shader_name.uniform.val != (value)) { \
-        ((r3d_shader_custom_t*)(custom))->shader_name.uniform.val = (value);    \
-        glUniform1i(((r3d_shader_custom_t*)(custom))->shader_name.uniform.loc, (value)); \
+    if ((custom)->program->shader_name.uniform.val != (value)) {                \
+        (custom)->program->shader_name.uniform.val = (value);                   \
+        glUniform1i((custom)->program->shader_name.uniform.loc, (value));       \
     }                                                                           \
 } while(0)
 
@@ -113,9 +109,9 @@
 } while(0)
 
 #define R3D_SHADER_SET_FLOAT_CUSTOM(custom, shader_name, uniform, value) do {   \
-    if (((r3d_shader_custom_t*)(custom))->shader_name.uniform.val != (value)) { \
-        ((r3d_shader_custom_t*)(custom))->shader_name.uniform.val = (value);    \
-        glUniform1f(((r3d_shader_custom_t*)(custom))->shader_name.uniform.loc, (value)); \
+    if ((custom)->program->shader_name.uniform.val != (value)) {                \
+        (custom)->program->shader_name.uniform.val = (value);                   \
+        glUniform1f((custom)->program->shader_name.uniform.loc, (value));       \
     }                                                                           \
 } while(0)
 
@@ -140,9 +136,9 @@
 
 #define R3D_SHADER_SET_VEC2_CUSTOM(custom, shader_name, uniform, ...) do {      \
     const Vector2 tmp = (__VA_ARGS__);                                          \
-    if (!Vector2Equals(((r3d_shader_custom_t*)(custom))->shader_name.uniform.val, tmp)) { \
-        ((r3d_shader_custom_t*)(custom))->shader_name.uniform.val = tmp;        \
-        glUniform2fv(((r3d_shader_custom_t*)(custom))->shader_name.uniform.loc, 1, (float*)(&tmp)); \
+    if (!Vector2Equals((custom)->program->shader_name.uniform.val, tmp)) {      \
+        (custom)->program->shader_name.uniform.val = tmp;                       \
+        glUniform2fv((custom)->program->shader_name.uniform.loc, 1, (float*)(&tmp)); \
     }                                                                           \
 } while(0)
 
@@ -168,9 +164,9 @@
 
 #define R3D_SHADER_SET_VEC3_CUSTOM(custom, shader_name, uniform, ...) do {      \
     const Vector3 tmp = (__VA_ARGS__);                                          \
-    if (!Vector3Equals(((r3d_shader_custom_t*)(custom))->shader_name.uniform.val, tmp)) { \
-        ((r3d_shader_custom_t*)(custom))->shader_name.uniform.val = tmp;        \
-        glUniform3fv(((r3d_shader_custom_t*)(custom))->shader_name.uniform.loc, 1, (float*)(&tmp)); \
+    if (!Vector3Equals((custom)->program->shader_name.uniform.val, tmp)) {      \
+        (custom)->program->shader_name.uniform.val = tmp;                       \
+        glUniform3fv((custom)->program->shader_name.uniform.loc, 1, (float*)(&tmp)); \
     }                                                                           \
 } while(0)
 
@@ -196,9 +192,9 @@
 
 #define R3D_SHADER_SET_VEC4_CUSTOM(custom, shader_name, uniform, ...) do {      \
     const Vector4 tmp = (__VA_ARGS__);                                          \
-    if (!Vector4Equals(((r3d_shader_custom_t*)(custom))->shader_name.uniform.val, tmp)) { \
-        ((r3d_shader_custom_t*)(custom))->shader_name.uniform.val = tmp;        \
-        glUniform4fv(((r3d_shader_custom_t*)(custom))->shader_name.uniform.loc, 1, (float*)(&tmp)); \
+    if (!Vector4Equals((custom)->program->shader_name.uniform.val, tmp)) {      \
+        (custom)->program->shader_name.uniform.val = tmp;                       \
+        glUniform4fv((custom)->program->shader_name.uniform.loc, 1, (float*)(&tmp)); \
     }                                                                           \
 } while(0)
 
@@ -228,12 +224,12 @@
 
 #define R3D_SHADER_SET_COL3_CUSTOM(custom, shader_name, uniform, space, ...) do { \
     const Color tmp = (__VA_ARGS__);                                            \
-    if (((r3d_shader_custom_t*)(custom))->shader_name.uniform.colorSpace != (space) || \
-        memcmp(&((r3d_shader_custom_t*)(custom))->shader_name.uniform.val, &tmp, sizeof(Color)) != 0) { \
+    if ((custom)->program->shader_name.uniform.colorSpace != (space) ||         \
+        memcmp(&(custom)->program->shader_name.uniform.val, &tmp, sizeof(Color)) != 0) { \
         Vector3 v = r3d_color_to_linear_vec3(tmp, (space));                     \
-        ((r3d_shader_custom_t*)(custom))->shader_name.uniform.val = tmp;        \
-        ((r3d_shader_custom_t*)(custom))->shader_name.uniform.colorSpace = (space); \
-        glUniform3fv(((r3d_shader_custom_t*)(custom))->shader_name.uniform.loc, 1, (float*)(&v)); \
+        (custom)->program->shader_name.uniform.val = tmp;                       \
+        (custom)->program->shader_name.uniform.colorSpace = (space);            \
+        glUniform3fv((custom)->program->shader_name.uniform.loc, 1, (float*)(&v)); \
     }                                                                           \
 } while(0)
 
@@ -266,12 +262,12 @@
 
 #define R3D_SHADER_SET_COL4_CUSTOM(custom, shader_name, uniform, space, ...) do { \
     const Color tmp = (__VA_ARGS__);                                            \
-    if (((r3d_shader_custom_t*)(custom))->shader_name.uniform.colorSpace != (space) || \
-        memcmp(&((r3d_shader_custom_t*)(custom))->shader_name.uniform.val, &tmp, sizeof(Color)) != 0) { \
+    if ((custom)->program->shader_name.uniform.colorSpace != (space) ||         \
+        memcmp(&(custom)->program->shader_name.uniform.val, &tmp, sizeof(Color)) != 0) { \
         Vector4 v = r3d_color_to_linear_vec4(tmp, (space));                     \
-        ((r3d_shader_custom_t*)(custom))->shader_name.uniform.val = tmp;        \
-        ((r3d_shader_custom_t*)(custom))->shader_name.uniform.colorSpace = (space); \
-        glUniform4fv(((r3d_shader_custom_t*)(custom))->shader_name.uniform.loc, 1, (float*)(&v)); \
+        (custom)->program->shader_name.uniform.val = tmp;                       \
+        (custom)->program->shader_name.uniform.colorSpace = (space);            \
+        glUniform4fv((custom)->program->shader_name.uniform.loc, 1, (float*)(&v)); \
     }                                                                           \
 } while(0)
 
@@ -297,10 +293,8 @@
 
 #define R3D_SHADER_SET_MAT4_CUSTOM(custom, shader_name, uniform, value) do {    \
     glUniformMatrix4fv(                                                         \
-        ((r3d_shader_custom_t*)(custom))->shader_name.uniform.loc,              \
-        1,                                                                      \
-        GL_TRUE,                                                                \
-        (float*)(&(value))                                                      \
+        (custom)->program->shader_name.uniform.loc,                             \
+        1, GL_TRUE, (float*)(&(value))                                          \
     );                                                                          \
 } while(0)
 
@@ -459,16 +453,18 @@ typedef enum {
     R3D_SHADER_BLOCK_LIGHT,
     R3D_SHADER_BLOCK_LIGHT_ARRAY,
     R3D_SHADER_BLOCK_FOG,
-    R3D_SHADER_BLOCK_COUNT
+    R3D_SHADER_BLOCK_COUNT,
+    R3D_SHADER_BLOCK_USER = R3D_SHADER_BLOCK_COUNT,
+    R3D_SHADER_BLOCK_SLOT_COUNT,
 } r3d_shader_block_t;
 
-#define R3D_SHADER_BLOCK_FRAME_SLOT         0
-#define R3D_SHADER_BLOCK_VIEW_SLOT          1
-#define R3D_SHADER_BLOCK_ENV_SLOT           2
-#define R3D_SHADER_BLOCK_LIGHT_SLOT         3
-#define R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT   4
-#define R3D_SHADER_BLOCK_FOG_SLOT           5
-#define R3D_SHADER_BLOCK_USER_SLOT          6
+#define R3D_SHADER_BLOCK_SLOT_FRAME         0
+#define R3D_SHADER_BLOCK_SLOT_VIEW          1
+#define R3D_SHADER_BLOCK_SLOT_ENV           2
+#define R3D_SHADER_BLOCK_SLOT_LIGHT         3
+#define R3D_SHADER_BLOCK_SLOT_LIGHT_ARRAY   4
+#define R3D_SHADER_BLOCK_SLOT_FOG           5
+#define R3D_SHADER_BLOCK_SLOT_USER          6
 
 // ========================================
 // UNIFORM BLOCK STRUCTS
@@ -569,12 +565,12 @@ static const int R3D_SHADER_BLOCK_SIZES[R3D_SHADER_BLOCK_COUNT] = {
 };
 
 static const int R3D_SHADER_BLOCK_SLOTS[R3D_SHADER_BLOCK_COUNT] = {
-    [R3D_SHADER_BLOCK_FRAME]       = R3D_SHADER_BLOCK_FRAME_SLOT,
-    [R3D_SHADER_BLOCK_VIEW]        = R3D_SHADER_BLOCK_VIEW_SLOT,
-    [R3D_SHADER_BLOCK_ENV]         = R3D_SHADER_BLOCK_ENV_SLOT,
-    [R3D_SHADER_BLOCK_LIGHT]       = R3D_SHADER_BLOCK_LIGHT_SLOT,
-    [R3D_SHADER_BLOCK_LIGHT_ARRAY] = R3D_SHADER_BLOCK_LIGHT_ARRAY_SLOT,
-    [R3D_SHADER_BLOCK_FOG]         = R3D_SHADER_BLOCK_FOG_SLOT,
+    [R3D_SHADER_BLOCK_FRAME]       = R3D_SHADER_BLOCK_SLOT_FRAME,
+    [R3D_SHADER_BLOCK_VIEW]        = R3D_SHADER_BLOCK_SLOT_VIEW,
+    [R3D_SHADER_BLOCK_ENV]         = R3D_SHADER_BLOCK_SLOT_ENV,
+    [R3D_SHADER_BLOCK_LIGHT]       = R3D_SHADER_BLOCK_SLOT_LIGHT,
+    [R3D_SHADER_BLOCK_LIGHT_ARRAY] = R3D_SHADER_BLOCK_SLOT_LIGHT_ARRAY,
+    [R3D_SHADER_BLOCK_FOG]         = R3D_SHADER_BLOCK_SLOT_FOG,
 };
 
 // ========================================
@@ -1115,7 +1111,6 @@ typedef struct {
         struct {
             r3d_shader_prepare_cubemap_custom_sky_t cubemapCustomSky;
         } prepare;
-
         // Must follow the same naming pattern as `r3d_mod_shader`
         struct {
             r3d_shader_scene_geometry_t geometry;
@@ -1127,15 +1122,23 @@ typedef struct {
             r3d_shader_scene_probe_unlit_t probeUnlit;
             r3d_shader_scene_decal_t decal;
         } scene;
-
         // Must follow the same naming pattern as `r3d_shader_loader`
         struct {
             r3d_shader_post_screen_t screen;
         } post;
     };
+    char userCode[R3D_MAX_SHADER_CODE_LENGTH];
+} r3d_shader_custom_program_t;
+
+typedef struct {
     r3d_rshade_sampler_t samplers[R3D_MAX_SHADER_SAMPLERS];
     r3d_rshade_uniform_buffer_t uniforms;
-    const char* userCode;
+} r3d_shader_custom_data_t;
+
+typedef struct R3D_ShaderCustom {
+    r3d_shader_custom_program_t* program;
+    r3d_shader_custom_data_t data;
+    bool programOwner;
 } r3d_shader_custom_t;
 
 // ========================================
@@ -1153,6 +1156,7 @@ extern struct r3d_mod_shader {
 
     // Uniform buffers
     GLuint uniformBuffers[R3D_SHADER_BLOCK_COUNT];
+    GLuint uniformBindings[R3D_SHADER_BLOCK_SLOT_COUNT];
 
     // Prepare shaders
     struct {
@@ -1479,26 +1483,59 @@ void r3d_shader_set_uniform_block(r3d_shader_block_t block, const void* data);
 void r3d_shader_bind_uniform_block(r3d_shader_block_t block);
 
 /*
+ * Allocates a new custom shader with its program in a single contiguous block.
+ * The shader is marked as the program owner and is responsible for freeing it.
+ * Returns NULL on allocation failure.
+ */
+r3d_shader_custom_t* r3d_shader_custom_alloc(void);
+
+/*
+ * Creates a shallow clone of an existing custom shader.
+ * The clone shares the same program pointer but is not its owner.
+ * Sampler slots are copied without their texture bindings.
+ * If the source has a uniform buffer, a new GPU buffer is allocated
+ * with the same layout but zeroed data.
+ * Returns NULL on allocation failure.
+ */
+r3d_shader_custom_t* r3d_shader_custom_clone(r3d_shader_custom_t* custom);
+
+/*
+ * Releases the GPU and CPU resources of a custom shader.
+ * Always frees the uniform buffer if present.
+ * Only deletes the GL programs if the shader owns them.
+ * Safe to call with NULL.
+ */
+void r3d_shader_custom_free(r3d_shader_custom_t* custom);
+
+/*
+ * Finalizes the uniform buffer layout and allocates the GPU buffer.
+ * Must be called after all uniform entries have been registered,
+ * passing the current accumulated byte offset as `currentOffset`.
+ * Does nothing if no uniform entries are defined.
+ */
+void r3d_shader_custom_init_uniforms(r3d_shader_custom_t* custom, int currentOffset);
+
+/*
  * Sets the value of a client-side uniform, marks its state as dirty, and flags it for upload.
  */
-bool r3d_shader_set_custom_uniform(r3d_shader_custom_t* shader, const char* name, const void* value);
+bool r3d_shader_custom_set_uniform(r3d_shader_custom_t* shader, const char* name, const void* value);
 
 /*
  * Assigns a texture to a sampler; it must be bound afterwards.
  */
-bool r3d_shader_set_custom_sampler(r3d_shader_custom_t* shader, const char* name, Texture texture);
+bool r3d_shader_custom_set_sampler(r3d_shader_custom_t* shader, const char* name, Texture texture);
 
 /*
  * Checks if any uniforms are dirty and need to be uploaded then bind it.
  * Automatically called when `R3D_SHADER_USE` (OVR/OPT) is invoked with a custom shader.
  */
-void r3d_shader_bind_custom_uniforms(r3d_shader_custom_t* shader);
+void r3d_shader_custom_bind_uniforms(r3d_shader_custom_t* shader);
 
 /*
  * Binds the textures of a custom shader and verifies the state of its samplers then bind them.
  * Automatically called when `R3D_SHADER_USE` (OVR/OPT) is invoked with a custom shader.
  */
-void r3d_shader_bind_custom_samplers(r3d_shader_custom_t* shader);
+void r3d_shader_custom_bind_samplers(r3d_shader_custom_t* shader);
 
 /*
  * Invalidate the internal state cache.

--- a/src/r3d_screen_shader.c
+++ b/src/r3d_screen_shader.c
@@ -19,15 +19,6 @@
 #include "./r3d_core_state.h"
 
 // ========================================
-// OPAQUE STRUCTS
-// ========================================
-
-struct R3D_ScreenShader {
-    r3d_shader_custom_t program;
-    char userCode[R3D_MAX_SHADER_CODE_LENGTH];
-};
-
-// ========================================
 // INTERNAL FUNCTIONS
 // ========================================
 
@@ -64,7 +55,7 @@ R3D_ScreenShader* R3D_LoadScreenShaderFromMemory(const char* code)
         return NULL;
     }
 
-    R3D_ScreenShader* shader = RL_CALLOC(1, sizeof(R3D_ScreenShader));
+    R3D_ScreenShader* shader = r3d_shader_custom_alloc();
     if (!shader) {
         R3D_TRACELOG(LOG_ERROR, "Bad alloc during screen shader loading");
         return NULL;
@@ -97,8 +88,8 @@ R3D_ScreenShader* R3D_LoadScreenShaderFromMemory(const char* code)
         if (r3d_rshade_match_keyword(ptr, "uniform", 7)) {
             ptr += 7;
             r3d_rshade_parse_uniform(&ptr,
-                shader->program.samplers,
-                &shader->program.uniforms,
+                shader->data.samplers,
+                &shader->data.uniforms,
                 &samplerCount,
                 &uniformCount,
                 &currentOffset,
@@ -126,8 +117,8 @@ R3D_ScreenShader* R3D_LoadScreenShaderFromMemory(const char* code)
     /* --- PHASE 2: Generate transformed shader code --- */
 
     // Write uniform block and samplers
-    outPtr = r3d_rshade_write_uniform_block(outPtr, shader->program.uniforms.entries, uniformCount);
-    outPtr = r3d_rshade_write_samplers(outPtr, shader->program.samplers, samplerCount);
+    outPtr = r3d_rshade_write_uniform_block(outPtr, shader->data.uniforms.entries, uniformCount);
+    outPtr = r3d_rshade_write_samplers(outPtr, shader->data.samplers, samplerCount);
 
     // Copy global code (excluding comments, uniforms, fragment()) then write fragment stage section
     outPtr = r3d_rshade_copy_global_code(outPtr, code, false, NULL, &fragmentFunc);
@@ -144,7 +135,7 @@ R3D_ScreenShader* R3D_LoadScreenShaderFromMemory(const char* code)
         return NULL;
     }
 
-    memcpy(shader->userCode, output, finalLen + 1);
+    memcpy(shader->program->userCode, output, finalLen + 1);
     RL_FREE(output);
 
     /* --- PHASE 3: Compile shader --- */
@@ -156,7 +147,7 @@ R3D_ScreenShader* R3D_LoadScreenShaderFromMemory(const char* code)
 
     /* --- PHASE 4: Initialize uniform buffer --- */
 
-    r3d_rshade_init_ubo(&shader->program.uniforms, currentOffset);
+    r3d_shader_custom_init_uniforms(shader, currentOffset);
 
     R3D_TRACELOG(LOG_INFO, "Screen shader loaded successfully");
     R3D_TRACELOG(LOG_INFO, "    > Sampler count: %i", samplerCount);
@@ -165,19 +156,19 @@ R3D_ScreenShader* R3D_LoadScreenShaderFromMemory(const char* code)
     return shader;
 }
 
+R3D_ScreenShader* R3D_LoadScreenShaderAlias(R3D_ScreenShader* shader)
+{
+    R3D_ScreenShader* alias = r3d_shader_custom_clone(shader);
+    if (!alias) {
+        R3D_TRACELOG(LOG_ERROR, "Bad alloc during screen shader alias loading");
+        return NULL;
+    }
+    return alias;
+}
+
 void R3D_UnloadScreenShader(R3D_ScreenShader* shader)
 {
-    if (!shader) return;
-
-    if (shader->program.uniforms.bufferId != 0) {
-        glDeleteBuffers(1, &shader->program.uniforms.bufferId);
-    }
-
-    if (shader->program.post.screen.id != 0) {
-        glDeleteProgram(shader->program.post.screen.id);
-    }
-
-    RL_FREE(shader);
+    r3d_shader_custom_free(shader);
 }
 
 void R3D_SetScreenShaderUniform(R3D_ScreenShader* shader, const char* name, const void* value)
@@ -187,7 +178,7 @@ void R3D_SetScreenShaderUniform(R3D_ScreenShader* shader, const char* name, cons
         return;
     }
 
-    if (!r3d_shader_set_custom_uniform(&shader->program, name, value)) {
+    if (!r3d_shader_custom_set_uniform(shader, name, value)) {
         R3D_TRACELOG(LOG_WARNING, "Failed to set custom uniform '%s'", name);
     }
 }
@@ -199,7 +190,7 @@ void R3D_SetScreenShaderSampler(R3D_ScreenShader* shader, const char* name, Text
         return;
     }
 
-    if (!r3d_shader_set_custom_sampler(&shader->program, name, texture)) {
+    if (!r3d_shader_custom_set_sampler(shader, name, texture)) {
         R3D_TRACELOG(LOG_WARNING, "Failed to set custom sampler '%s'", name);
     }
 }
@@ -225,10 +216,7 @@ void R3D_SetScreenShaderChain(R3D_ScreenShader** shaders, int count)
 
 bool compile_shader(R3D_ScreenShader* shader)
 {
-    // Store reference to the user code in custom shader struct
-    shader->program.userCode = shader->userCode;
-
-    bool ok = R3D_MOD_SHADER_LOADER.post.screen(&shader->program);
+    bool ok = R3D_MOD_SHADER_LOADER.post.screen(shader);
     if (!ok) {
         R3D_TRACELOG(LOG_ERROR, "Failed to compile screen shader");
     }

--- a/src/r3d_sky_shader.c
+++ b/src/r3d_sky_shader.c
@@ -17,15 +17,6 @@
 #include "./common/r3d_rshade.h"
 
 // ========================================
-// OPAQUE STRUCTS
-// ========================================
-
-struct R3D_SkyShader {
-    r3d_shader_custom_t program;
-    char userCode[R3D_MAX_SHADER_CODE_LENGTH];
-};
-
-// ========================================
 // INTERNAL FUNCTIONS
 // ========================================
 
@@ -62,7 +53,7 @@ R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code)
         return NULL;
     }
 
-    R3D_SkyShader* shader = RL_CALLOC(1, sizeof(R3D_SkyShader));
+    R3D_SkyShader* shader = r3d_shader_custom_alloc();
     if (!shader) {
         R3D_TRACELOG(LOG_ERROR, "Bad alloc during sky shader loading");
         return NULL;
@@ -95,8 +86,8 @@ R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code)
         if (r3d_rshade_match_keyword(ptr, "uniform", 7)) {
             ptr += 7;
             r3d_rshade_parse_uniform(&ptr,
-                shader->program.samplers,
-                &shader->program.uniforms,
+                shader->data.samplers,
+                &shader->data.uniforms,
                 &samplerCount,
                 &uniformCount,
                 &currentOffset,
@@ -124,8 +115,8 @@ R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code)
     /* --- PHASE 2: Generate transformed shader code --- */
 
     // Write uniform block and samplers
-    outPtr = r3d_rshade_write_uniform_block(outPtr, shader->program.uniforms.entries, uniformCount);
-    outPtr = r3d_rshade_write_samplers(outPtr, shader->program.samplers, samplerCount);
+    outPtr = r3d_rshade_write_uniform_block(outPtr, shader->data.uniforms.entries, uniformCount);
+    outPtr = r3d_rshade_write_samplers(outPtr, shader->data.samplers, samplerCount);
 
     // Copy global code (excluding comments, uniforms, fragment()) then write fragment stage section
     outPtr = r3d_rshade_copy_global_code(outPtr, code, false, NULL, &fragmentFunc);
@@ -142,7 +133,7 @@ R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code)
         return NULL;
     }
 
-    memcpy(shader->userCode, output, finalLen + 1);
+    memcpy(shader->program->userCode, output, finalLen + 1);
     RL_FREE(output);
 
     /* --- PHASE 3: Compile shader --- */
@@ -154,7 +145,7 @@ R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code)
 
     /* --- PHASE 4: Initialize uniform buffer --- */
 
-    r3d_rshade_init_ubo(&shader->program.uniforms, currentOffset);
+    r3d_shader_custom_init_uniforms(shader, currentOffset);
 
     R3D_TRACELOG(LOG_INFO, "Sky shader loaded successfully");
     R3D_TRACELOG(LOG_INFO, "    > Sampler count: %i", samplerCount);
@@ -163,19 +154,19 @@ R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code)
     return shader;
 }
 
+R3D_SkyShader* R3D_LoadSkyShaderAlias(R3D_SkyShader* shader)
+{
+    R3D_SkyShader* alias = r3d_shader_custom_clone(shader);
+    if (!alias) {
+        R3D_TRACELOG(LOG_ERROR, "Bad alloc during sky shader alias loading");
+        return NULL;
+    }
+    return alias;
+}
+
 void R3D_UnloadSkyShader(R3D_SkyShader* shader)
 {
-    if (!shader) return;
-
-    if (shader->program.uniforms.bufferId != 0) {
-        glDeleteBuffers(1, &shader->program.uniforms.bufferId);
-    }
-
-    if (shader->program.prepare.cubemapCustomSky.id != 0) {
-        glDeleteProgram(shader->program.prepare.cubemapCustomSky.id);
-    }
-
-    RL_FREE(shader);
+    r3d_shader_custom_free(shader);
 }
 
 void R3D_SetSkyShaderUniform(R3D_SkyShader* shader, const char* name, const void* value)
@@ -185,7 +176,7 @@ void R3D_SetSkyShaderUniform(R3D_SkyShader* shader, const char* name, const void
         return;
     }
 
-    if (!r3d_shader_set_custom_uniform(&shader->program, name, value)) {
+    if (!r3d_shader_custom_set_uniform(shader, name, value)) {
         R3D_TRACELOG(LOG_WARNING, "Failed to set custom uniform '%s'", name);
     }
 }
@@ -197,7 +188,7 @@ void R3D_SetSkyShaderSampler(R3D_SkyShader* shader, const char* name, Texture te
         return;
     }
 
-    if (!r3d_shader_set_custom_sampler(&shader->program, name, texture)) {
+    if (!r3d_shader_custom_set_sampler(shader, name, texture)) {
         R3D_TRACELOG(LOG_WARNING, "Failed to set custom sampler '%s'", name);
     }
 }
@@ -208,10 +199,7 @@ void R3D_SetSkyShaderSampler(R3D_SkyShader* shader, const char* name, Texture te
 
 bool compile_shader(R3D_SkyShader* shader)
 {
-    // Store reference to the user code in custom shader struct
-    shader->program.userCode = shader->userCode;
-
-    bool ok = R3D_MOD_SHADER_LOADER.prepare.cubemapCustomSky(&shader->program);
+    bool ok = R3D_MOD_SHADER_LOADER.prepare.cubemapCustomSky(shader);
     if (!ok) {
         R3D_TRACELOG(LOG_ERROR, "Failed to compile sky shader");
     }

--- a/src/r3d_surface_shader.c
+++ b/src/r3d_surface_shader.c
@@ -33,15 +33,6 @@ typedef uint32_t usage_hint_t;
 #define USAGE_HINT_PROBE         (1 << 6)   //< Build: probe
 
 // ========================================
-// OPAQUE STRUCTS
-// ========================================
-
-struct R3D_SurfaceShader {
-    r3d_shader_custom_t program;
-    char userCode[R3D_MAX_SHADER_CODE_LENGTH];
-};
-
-// ========================================
 // INTERNAL FUNCTIONS
 // ========================================
 
@@ -85,7 +76,7 @@ R3D_SurfaceShader* R3D_LoadSurfaceShaderFromMemory(const char* code)
         return NULL;
     }
 
-    R3D_SurfaceShader* shader = RL_CALLOC(1, sizeof(R3D_SurfaceShader));
+    R3D_SurfaceShader* shader = r3d_shader_custom_alloc();
     if (!shader) {
         R3D_TRACELOG(LOG_ERROR, "Bad alloc during surface shader loading");
         return NULL;
@@ -128,8 +119,8 @@ R3D_SurfaceShader* R3D_LoadSurfaceShaderFromMemory(const char* code)
         if (r3d_rshade_match_keyword(ptr, "uniform", 7)) {
             ptr += 7;
             r3d_rshade_parse_uniform(&ptr,
-                shader->program.samplers,
-                &shader->program.uniforms,
+                shader->data.samplers,
+                &shader->data.uniforms,
                 &samplerCount,
                 &uniformCount,
                 &currentOffset,
@@ -170,8 +161,8 @@ R3D_SurfaceShader* R3D_LoadSurfaceShaderFromMemory(const char* code)
     /* --- PHASE 2: Generate transformed shader code --- */
 
     // Write uniform block and samplers
-    outPtr = r3d_rshade_write_uniform_block(outPtr, shader->program.uniforms.entries, uniformCount);
-    outPtr = r3d_rshade_write_samplers(outPtr, shader->program.samplers, samplerCount);
+    outPtr = r3d_rshade_write_uniform_block(outPtr, shader->data.uniforms.entries, uniformCount);
+    outPtr = r3d_rshade_write_samplers(outPtr, shader->data.samplers, samplerCount);
 
     // Copy global code (excluding pragma, comments, uniforms, varyings, entry points)
     outPtr = r3d_rshade_copy_global_code(outPtr, code, true, &vertexFunc, &fragmentFunc);
@@ -199,7 +190,7 @@ R3D_SurfaceShader* R3D_LoadSurfaceShaderFromMemory(const char* code)
         return NULL;
     }
 
-    memcpy(shader->userCode, output, finalLen + 1);
+    memcpy(shader->program->userCode, output, finalLen + 1);
     RL_FREE(output);
 
     /* --- PHASE 3: Pre-compile needed shader variants --- */
@@ -211,7 +202,7 @@ R3D_SurfaceShader* R3D_LoadSurfaceShaderFromMemory(const char* code)
 
     /* --- PHASE 4: Initialize uniform buffer --- */
 
-    r3d_rshade_init_ubo(&shader->program.uniforms, currentOffset);
+    r3d_shader_custom_init_uniforms(shader, currentOffset);
 
     R3D_TRACELOG(LOG_INFO, "Surface shader loaded successfully");
     R3D_TRACELOG(LOG_INFO, "    > Usage hints: %s", get_usage_hint_string(usage));
@@ -222,28 +213,19 @@ R3D_SurfaceShader* R3D_LoadSurfaceShaderFromMemory(const char* code)
     return shader;
 }
 
+R3D_SurfaceShader* R3D_LoadSurfaceShaderAlias(R3D_SurfaceShader* shader)
+{
+    R3D_SurfaceShader* alias = r3d_shader_custom_clone(shader);
+    if (!alias) {
+        R3D_TRACELOG(LOG_ERROR, "Bad alloc during surface shader alias loading");
+        return NULL;
+    }
+    return alias;
+}
+
 void R3D_UnloadSurfaceShader(R3D_SurfaceShader* shader)
 {
-    #define DELETE_PROGRAM(id) \
-        do { if ((id) != 0) glDeleteProgram((id)); } while(0)
-
-    if (shader == NULL) return;
-
-    if (shader->program.uniforms.bufferId != 0) {
-        glDeleteBuffers(1, &shader->program.uniforms.bufferId);
-    }
-
-    DELETE_PROGRAM(shader->program.scene.geometry.id);
-    DELETE_PROGRAM(shader->program.scene.forward.id);
-    DELETE_PROGRAM(shader->program.scene.depth.id);
-    DELETE_PROGRAM(shader->program.scene.depthCube.id);
-    DELETE_PROGRAM(shader->program.scene.probeForward.id);
-    DELETE_PROGRAM(shader->program.scene.probeUnlit.id);
-    DELETE_PROGRAM(shader->program.scene.decal.id);
-
-    RL_FREE(shader);
-
-#undef DELETE_PROGRAM
+    r3d_shader_custom_free(shader);
 }
 
 void R3D_SetSurfaceShaderUniform(R3D_SurfaceShader* shader, const char* name, const void* value)
@@ -253,7 +235,7 @@ void R3D_SetSurfaceShaderUniform(R3D_SurfaceShader* shader, const char* name, co
         return;
     }
 
-    if (!r3d_shader_set_custom_uniform(&shader->program, name, value)) {
+    if (!r3d_shader_custom_set_uniform(shader, name, value)) {
         R3D_TRACELOG(LOG_WARNING, "Failed to set custom uniform '%s'", name);
     }
 }
@@ -265,7 +247,7 @@ void R3D_SetSurfaceShaderSampler(R3D_SurfaceShader* shader, const char* name, Te
         return;
     }
 
-    if (!r3d_shader_set_custom_sampler(&shader->program, name, texture)) {
+    if (!r3d_shader_custom_set_sampler(shader, name, texture)) {
         R3D_TRACELOG(LOG_WARNING, "Failed to set custom sampler '%s'", name);
     }
 }
@@ -366,11 +348,8 @@ const char* get_usage_hint_string(usage_hint_t hints)
 
 bool compile_shader_variants(R3D_SurfaceShader* shader, usage_hint_t usage)
 {
-    // Store reference to the user code in custom shader struct
-    shader->program.userCode = shader->userCode;
-
     if (usage == 0) {
-        bool ok = R3D_MOD_SHADER_LOADER.scene.geometry(&shader->program);
+        bool ok = R3D_MOD_SHADER_LOADER.scene.geometry(shader);
         if (!ok) {
             R3D_TRACELOG(LOG_ERROR, "Failed to compile surface shader");
         }
@@ -394,7 +373,7 @@ bool compile_shader_variants(R3D_SurfaceShader* shader, usage_hint_t usage)
 
     for (int i = 0; i < 6; i++) {
         if (BIT_TEST_ANY(usage, variants[i].condition)) {
-            if (!variants[i].func(&shader->program)) {
+            if (!variants[i].func(shader)) {
                 R3D_TRACELOG(LOG_ERROR, "Failed to compile surface shader (variant: '%s')", variants[i].name);
                 return false;
             }


### PR DESCRIPTION
Adds support for shader aliases across all three custom shader types (surface, sky, screen).

An alias shares the compiled GL programs of its original but holds its own independent sampler and uniform data, allowing the same shader to be used multiple times within a frame with different configurations without recompilation or full reconfiguration.

New public API:
- `R3D_LoadSurfaceShaderAlias`
- `R3D_LoadSkyShaderAlias`
- `R3D_LoadScreenShaderAlias`

Internally, this is implemented as a shallow clone (`programOwner = false`) with its own GPU uniform buffer when applicable. The original must outlive all its aliases.

Also introduces a per-frame UBO binding cache tracking which buffer is currently bound to each binding point, avoiding redundant `glBindBufferBase` calls. Previously binds only occurred on _first_ shader use, but aliased shaders may require a rebind on each use since they carry different UBOs. The cache is now applied to all UBOs, internal ones included, which already reduces API calls during the deferred light accumulation pass and might be even more useful later.