### PR TITLE
[custom-shaders] Uniform default values and consistent alias state initialization

### DIFF
--- a/examples/resources/shaders/material.glsl
+++ b/examples/resources/shaders/material.glsl
@@ -1,7 +1,7 @@
 #pragma usage opaque shadow
 
 uniform sampler2D u_texture;
-uniform float u_time_scale;
+uniform float u_time_scale = 2.0;
 
 flat varying float v_time;
 

--- a/examples/shader.c
+++ b/examples/shader.c
@@ -33,7 +33,6 @@ int main(void)
 
     // Set material custom uniform/sampler
     R3D_SetSurfaceShaderSampler(material.shader, "u_texture", texture);
-    R3D_SetSurfaceShaderUniform(material.shader, "u_time_scale", (float[]){0.75f});
 
     // Load a screen shader
     R3D_ScreenShader* shader = R3D_LoadScreenShader(RESOURCES_PATH "shaders/screen.glsl");

--- a/include/r3d/r3d_screen_shader.h
+++ b/include/r3d/r3d_screen_shader.h
@@ -58,15 +58,19 @@ R3DAPI R3D_ScreenShader* R3D_LoadScreenShaderFromMemory(const char* code);
 /**
  * @brief Creates an alias of an existing screen shader.
  *
- * The alias shares the same compiled program shaders as the original but holds
- * its own independent sampler and uniform data. Typical use cases include
- * pre-configuring aliases for distinct effects (e.g. different convolution
- * kernels), or running the same shader multiple times in the same frame's
- * post-process chain with different parameters at each pass.
+ * The alias shares the same compiled program as the original but holds its own
+ * independent uniform and sampler state. Typical use cases include pre-configuring
+ * aliases for distinct effects (e.g. different convolution kernels), or running
+ * the same shader multiple times in a post-process chain with different parameters
+ * at each pass.
  *
- * @note The alias does not own the program shaders. Unloading the original shader
- *       while an alias is still in use results in undefined behavior.
- *       Always unload all aliases before unloading the original.
+ * Uniform and sampler state is copied from the original at the moment this
+ * function is called, not from the shader source defaults. Any values set
+ * on the original after compilation but before this call will be reflected
+ * in the alias; values set afterward will not.
+ *
+ * @note The alias does not own the program. Always unload all aliases before
+ *       unloading the original, or the alias program references become dangling.
  *
  * @param shader The original screen shader to alias.
  * @return Pointer to the alias, or NULL on failure.

--- a/include/r3d/r3d_sky_shader.h
+++ b/include/r3d/r3d_sky_shader.h
@@ -58,14 +58,18 @@ R3DAPI R3D_SkyShader* R3D_LoadSkyShaderFromMemory(const char* code);
 /**
  * @brief Creates an alias of an existing sky shader.
  *
- * The alias shares the same compiled program shaders as the original but holds
- * its own independent sampler and uniform data. A typical use case is to
- * pre-configure several aliases with different uniforms or textures, avoiding
- * the need to reconfigure the shader on every skybox switch.
+ * The alias shares the same compiled program as the original but holds its own
+ * independent uniform and sampler state. A typical use case is to pre-configure
+ * several aliases with different uniforms or textures, avoiding the need to
+ * reconfigure the shader on every skybox switch.
  *
- * @note The alias does not own the program shaders. Unloading the original shader
- *       while an alias is still in use results in undefined behavior.
- *       Always unload all aliases before unloading the original.
+ * Uniform and sampler state is copied from the original at the moment this
+ * function is called, not from the shader source defaults. Any values set
+ * on the original after compilation but before this call will be reflected
+ * in the alias; values set afterward will not.
+ *
+ * @note The alias does not own the program. Always unload all aliases before
+ *       unloading the original, or the alias program references become dangling.
  *
  * @param shader The original sky shader to alias.
  * @return Pointer to the alias, or NULL on failure.

--- a/include/r3d/r3d_surface_shader.h
+++ b/include/r3d/r3d_surface_shader.h
@@ -56,15 +56,17 @@ R3DAPI R3D_SurfaceShader* R3D_LoadSurfaceShaderFromMemory(const char* code);
 /**
  * @brief Creates an alias of an existing surface shader.
  *
- * The alias shares the same compiled program shaders as the original but holds
- * its own independent sampler and uniform data. This allows the same shader
- * to be used multiple times within a single frame with different values,
- * for example when several materials rely on the same shader but each draw
- * call requires distinct uniform values or texture bindings.
+ * The alias shares the same compiled program as the original but holds its own
+ * independent uniform and sampler state, allowing the same shader to be used
+ * multiple times within a single frame with different values.
  *
- * @note The alias does not own the program shaders. Unloading the original shader
- *       while an alias is still in use results in undefined behavior.
- *       Always unload all aliases before unloading the original.
+ * Uniform and sampler state is copied from the original at the moment this
+ * function is called, not from the shader source defaults. Any values set
+ * on the original after compilation but before this call will be reflected
+ * in the alias; values set afterward will not.
+ *
+ * @note The alias does not own the program. Always unload all aliases before
+ *       unloading the original, or the alias program references become dangling.
  *
  * @param shader The original surface shader to alias.
  * @return Pointer to the alias, or NULL on failure.

--- a/src/common/r3d_rshade.h
+++ b/src/common/r3d_rshade.h
@@ -258,7 +258,92 @@ static inline bool r3d_rshade_parse_varying(const char** ptr, r3d_rshade_varying
     return r3d_rshade_parse_declaration(ptr, varying->type, varying->name);
 }
 
-/* Parse uniform declaration and add to samplers or uniform buffer */
+/* Parse a GLSL literal value and write it into the uniform buffer at given offset.
+ * Returns true if a default value was found and parsed. */
+static inline bool r3d_rshade_parse_default_value(const char** ptr,
+    const char* type, uint8_t* buffer, int offset)
+{
+    r3d_rshade_skip_whitespace(ptr);
+    if (**ptr != '=') return false;
+
+    (*ptr)++;
+    r3d_rshade_skip_whitespace(ptr);
+
+    uint8_t* dst = buffer + offset;
+
+    // Scalars
+    if (strcmp(type, "float") == 0) {
+        float v = 0.0f; sscanf(*ptr, "%f", &v);
+        memcpy(dst, &v, 4);
+        return true;
+    }
+    if (strcmp(type, "int") == 0) {
+        int v = 0; sscanf(*ptr, "%d", &v);
+        memcpy(dst, &v, 4);
+        return true;
+    }
+    if (strcmp(type, "bool") == 0) {
+        // Accept both true/false keywords and 1/0 literals
+        int v = (strncmp(*ptr, "true", 4) == 0) ? 1
+              : (strncmp(*ptr, "false", 5) == 0) ? 0
+              : (*ptr[0] != '0');
+        memcpy(dst, &v, 4);
+        return true;
+    }
+
+    // Vectors and matrices
+    // std140: each column occupies a 16-byte slot (vec4 stride),
+    // so the byte offset of component [col][row] is: col * 16 + row * 4.
+    // For vectors (cols=1) this degenerates to simple contiguous layout.
+
+    int cols = 0, rows = 0;
+    bool isFloat = true;
+
+    if      (strcmp(type, "vec2")  == 0) { cols = 1; rows = 2; }
+    else if (strcmp(type, "vec3")  == 0) { cols = 1; rows = 3; }
+    else if (strcmp(type, "vec4")  == 0) { cols = 1; rows = 4; }
+    else if (strcmp(type, "ivec2") == 0) { cols = 1; rows = 2; isFloat = false; }
+    else if (strcmp(type, "ivec3") == 0) { cols = 1; rows = 3; isFloat = false; }
+    else if (strcmp(type, "ivec4") == 0) { cols = 1; rows = 4; isFloat = false; }
+    else if (strcmp(type, "mat2")  == 0) { cols = 2; rows = 2; }
+    else if (strcmp(type, "mat3")  == 0) { cols = 3; rows = 3; }
+    else if (strcmp(type, "mat4")  == 0) { cols = 4; rows = 4; }
+
+    if (cols == 0) return false;
+
+    // Advance past the opening parenthesis of the constructor
+    while (**ptr && **ptr != '(') (*ptr)++;
+    if (**ptr != '(') return false;
+    (*ptr)++;
+
+    // Parse components in column-major order
+    for (int c = 0; c < cols; c++) {
+        for (int r = 0; r < rows; r++) {
+            r3d_rshade_skip_whitespace(ptr);
+
+            int byteOffset = c * 16 + r * 4;
+            if (isFloat) {
+                float v = 0.0f;
+                sscanf(*ptr, "%f", &v);
+                memcpy(dst + byteOffset, &v, 4);
+            }
+            else {
+                int32_t v = 0;
+                sscanf(*ptr, "%d", &v);
+                memcpy(dst + byteOffset, &v, 4);
+            }
+
+            // Advance past this token to the next separator
+            while (**ptr && **ptr != ',' && **ptr != ')') (*ptr)++;
+            if (**ptr == ',') (*ptr)++;
+        }
+    }
+
+    return true;
+}
+
+/* Parse a 'uniform' declaration and register it as a sampler or UBO entry.
+ * The pointer must be positioned just after the 'uniform' keyword. */
 static inline bool r3d_rshade_parse_uniform(const char** ptr,
     r3d_rshade_sampler_t* samplers, r3d_rshade_uniform_buffer_t* uniforms,
     int* samplerCount, int* uniformCount, int* currentOffset,
@@ -267,42 +352,47 @@ static inline bool r3d_rshade_parse_uniform(const char** ptr,
     char type[R3D_RSHADE_MAX_VAR_TYPE_LENGTH];
     char name[R3D_RSHADE_MAX_VAR_NAME_LENGTH];
 
-    if (!r3d_rshade_parse_declaration(ptr, type, name)) {
+    // Stop before '=' or ';' so default value parsing can inspect what follows
+    if (!r3d_rshade_parse_identifier(ptr, type, R3D_RSHADE_MAX_VAR_TYPE_LENGTH) ||
+        !r3d_rshade_parse_identifier(ptr, name, R3D_RSHADE_MAX_VAR_NAME_LENGTH)) {
+        r3d_rshade_skip_to_semicolon(ptr);
         return false;
     }
 
-    // Check if it's a sampler
+    // Samplers are bound by texture unit, not stored in the UBO
     GLenum samplerTarget = r3d_rshade_get_sampler_target(type);
     if (samplerTarget != 0) {
         if (*samplerCount < maxSamplers) {
-            r3d_rshade_sampler_t* s = &samplers[*samplerCount];
+            r3d_rshade_sampler_t* s = &samplers[(*samplerCount)++];
             strncpy(s->name, name, R3D_RSHADE_MAX_VAR_NAME_LENGTH - 1);
             s->name[R3D_RSHADE_MAX_VAR_NAME_LENGTH - 1] = '\0';
             s->target = samplerTarget;
             s->texture = 0;
-            (*samplerCount)++;
         }
+        r3d_rshade_skip_to_semicolon(ptr);
         return true;
     }
 
-    // It's a uniform value, add to UBO with std140 alignment
     int size = r3d_rshade_get_type_size(type);
     if (size > 0 && *uniformCount < maxUniforms) {
-        int alignment = r3d_rshade_get_std140_alignment(size);
-        *currentOffset = r3d_align_offset(*currentOffset, alignment);
+        // Align offset per std140 before committing the slot
+        *currentOffset = r3d_align_offset(*currentOffset, r3d_rshade_get_std140_alignment(size));
 
-        r3d_rshade_uniform_t* u = &uniforms->entries[*uniformCount];
+        r3d_rshade_uniform_t* u = &uniforms->entries[(*uniformCount)++];
         strncpy(u->name, name, R3D_RSHADE_MAX_VAR_NAME_LENGTH - 1);
         u->name[R3D_RSHADE_MAX_VAR_NAME_LENGTH - 1] = '\0';
         strncpy(u->type, type, R3D_RSHADE_MAX_VAR_TYPE_LENGTH - 1);
         u->type[R3D_RSHADE_MAX_VAR_TYPE_LENGTH - 1] = '\0';
         u->offset = *currentOffset;
         u->size = size;
-
-        (*uniformCount)++;
         *currentOffset += size;
+
+        if (r3d_rshade_parse_default_value(ptr, type, uniforms->buffer, u->offset)) {
+            uniforms->dirty = true; // Just for security, but the data is necessarily uploaded when the buffer is created afterwards
+        }
     }
 
+    r3d_rshade_skip_to_semicolon(ptr);
     return true;
 }
 

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -1696,14 +1696,10 @@ r3d_shader_custom_t* r3d_shader_custom_clone(r3d_shader_custom_t* custom)
     clone->programOwner = false;
 
     memcpy(clone->data.samplers, custom->data.samplers, sizeof(custom->data.samplers));
-    for (int i = 0; i < ARRAY_SIZE(clone->data.samplers); i++) {
-        clone->data.samplers[i].texture = 0;
-    }
 
     if (custom->data.uniforms.bufferSize > 0)
     {
         memcpy(&clone->data.uniforms, &custom->data.uniforms, sizeof(r3d_rshade_uniform_buffer_t));
-        memset(clone->data.uniforms.buffer, 0, sizeof(clone->data.uniforms.buffer));
 
         clone->data.uniforms.dirty = false;
         clone->data.uniforms.bufferId = 0;


### PR DESCRIPTION
Custom shader uniforms can now be assigned default values directly in the source (`uniform float opacity = 1.0`, `uniform vec3 color = vec3(1.0, 0.5, 0.2)`), parsed at load time and written into the UBO. Scalars, vectors, and matrices are all supported.

Alias loading now copies the current uniform and sampler state of the original instead of zero-initializing, so default values propagate naturally to aliases without any extra bookkeeping.