### PR TITLE
Unified global GPU buffers for meshes and shapes

### DIFF
--- a/examples/kinematics.c
+++ b/examples/kinematics.c
@@ -50,7 +50,7 @@ int main(void)
 
     // Slope obstacle
     R3D_MeshData slopeMeshData = R3D_GenMeshDataSlope(2, 2, 2, (Vector3) {0, 1, -1});
-    R3D_Mesh slopeMesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, slopeMeshData, NULL, R3D_STATIC_MESH);
+    R3D_Mesh slopeMesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, slopeMeshData, NULL);
     Matrix slopeTransform = MatrixTranslate(0, 1, 5);
 
     // Player capsule

--- a/include/r3d/r3d_mesh.h
+++ b/include/r3d/r3d_mesh.h
@@ -24,15 +24,6 @@
 // ========================================
 
 /**
- * @brief Hint on how a mesh will be used.
- */
-typedef enum R3D_MeshUsage {
-    R3D_STATIC_MESH,            ///< Will never be updated.
-    R3D_DYNAMIC_MESH,           ///< Will be updated occasionally.
-    R3D_STREAMED_MESH           ///< Will be update on each frame.
-} R3D_MeshUsage;
-
-/**
  * @brief Shadow casting modes for objects.
  *
  * Controls how an object interacts with the shadow mapping system.
@@ -62,16 +53,20 @@ typedef enum R3D_ShadowCastMode {
  * Can represent a static or skinned mesh.
  */
 typedef struct R3D_Mesh {
-    uint32_t vao, vbo, ebo;                 ///< OpenGL objects handles.
-    int vertexCapacity;                     ///< Number of vertices allocated in GPU buffers.
-    int indexCapacity;                      ///< Number of indices allocated in GPU buffers.
+
+    int vertexOffset;                       ///< Offset in the internal VBO.
+    int vertexCapacity;                     ///< Number of vertices allocated in the internal VBO.
     int vertexCount;                        ///< Number of vertices currently in use.
+
+    int indexOffset;                        ///< Offset in the internal EBO.
+    int indexCapacity;                      ///< Number of indices allocated in the internal EBO.
     int indexCount;                         ///< Number of indices currently in use.
+
     R3D_ShadowCastMode shadowCastMode;      ///< Shadow casting mode for the mesh.
     R3D_PrimitiveType primitiveType;        ///< Type of primitive that constitutes the vertices.
-    R3D_MeshUsage usage;                    ///< Hint about the usage of the mesh, retained in case of update if there is a reallocation.
     R3D_Layer layerMask;                    ///< Bitfield indicating the rendering layer(s) of this mesh.
     BoundingBox aabb;                       ///< Axis-Aligned Bounding Box in local space.
+
 } R3D_Mesh;
 
 // ========================================
@@ -87,11 +82,10 @@ extern "C" {
  * @param type Primitive type used to interpret vertex data.
  * @param data R3D_MeshData containing vertices and indices (can be zero initialized).
  * @param aabb Optional pointer to a bounding box. If NULL, it will be computed automatically.
- * @param usage Hint on how the mesh will be used.
  * @return Created R3D_Mesh.
  * @note The function copies all vertex and index data into GPU buffers.
  */
-R3DAPI R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, R3D_MeshData data, const BoundingBox* aabb, R3D_MeshUsage usage);
+R3DAPI R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, R3D_MeshData data, const BoundingBox* aabb);
 
 /**
  * @brief Destroys a 3D mesh and frees its resources.

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -43,13 +43,13 @@ typedef enum R3D_PrimitiveType {
  * @brief Represents a vertex and all its attributes for a mesh.
  */
 typedef struct R3D_Vertex {
-    Vector3 position;       /**< The 3D position of the vertex in object space. */
-    Vector2 texcoord;       /**< The 2D texture coordinates (UV) for mapping textures. */
-    Vector3 normal;         /**< The normal vector used for lighting calculations. */
-    Color color;            /**< Vertex color, in RGBA32. */
-    Vector4 tangent;        /**< The tangent vector, used in normal mapping (often with a handedness in w). */
-    int boneIds[4];         /**< Indices of up to 4 bones that influence this vertex (for skinning). */
-    float weights[4];       /**< Corresponding bone weights (should sum to 1.0). Defines the influence of each bone. */
+    Vector3 position;       ///< The 3D position of the vertex in object space.
+    Vector2 texcoord;       ///< The 2D texture coordinates (UV) for mapping textures.
+    Vector3 normal;         ///< The normal vector used for lighting calculations.
+    Color color;            ///< Vertex color, in RGBA32. */
+    Vector4 tangent;        ///< The tangent vector, used in normal mapping (often with a handedness in w).
+    int boneIds[4];         ///< Indices of up to 4 bones that influence this vertex (for skinning).
+    float weights[4];       ///< Corresponding bone weights (should sum to 1.0). Defines the influence of each bone.
 } R3D_Vertex;
 
 /**

--- a/src/importer/r3d_importer_mesh.c
+++ b/src/importer/r3d_importer_mesh.c
@@ -310,7 +310,8 @@ static bool load_mesh_internal(
 
     // Upload the mesh
     R3D_PrimitiveType ptype = get_primitive_type(aiMesh->mPrimitiveTypes);
-    *outMesh = R3D_LoadMesh(ptype, data, &aabb, R3D_STATIC_MESH);
+    *outMesh = R3D_LoadMesh(ptype, data, &aabb);
+
     if (outMeshData == NULL) R3D_UnloadMeshData(data);
     else *outMeshData = data;
 

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -200,7 +200,8 @@ static void coalesce_free_list(r3d_render_range_t* list, int* count)
             int end = list[write].offset + list[write].count;
             int end_i = list[i].offset + list[i].count;
             if (end_i > end) list[write].count = end_i - list[write].offset;
-        } else {
+        }
+        else {
             list[++write] = list[i];
         }
     }
@@ -222,7 +223,10 @@ static bool push_free_range(r3d_render_range_t** list, int* count, int* capacity
         *capacity = newCapacity;
     }
 
-    (*list)[(*count)++] = (r3d_render_range_t){ .offset = offset, .count = rangeCount };
+    (*list)[(*count)++] = (r3d_render_range_t) {
+        .offset = offset, .count = rangeCount
+    };
+
     return true;
 }
 
@@ -242,7 +246,8 @@ static int pop_free_range(r3d_render_range_t* list, int* count, int needed)
                 // Cut: we keep the rest in the list
                 list[i].offset += needed;
                 list[i].count  -= needed;
-            } else {
+            }
+            else {
                 // Exact match: remove the entry
                 list[i] = list[--(*count)];
             }
@@ -271,7 +276,8 @@ static bool try_extend_in_place(r3d_render_range_t* list, int* count,
         if (list[i].count == needed) {
             // Exact match: remove the entry
             list[i] = list[--(*count)];
-        } else {
+        }
+        else {
             // We consume 'needed' since the beginning of the block
             list[i].offset += needed;
             list[i].count  -= needed;

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -29,6 +29,261 @@
 struct r3d_mod_render R3D_MOD_RENDER;
 
 // ========================================
+// INTERNAL BUFFER RESIZE FUNCTIONS
+// ========================================
+
+/*
+ * Reconfigures all vertex attribute pointers on the global VAO after a VBO resize.
+ * Must be called with the global VAO already bound.
+ */
+static void reconfigure_global_vao_attribs(void)
+{
+    glBindBuffer(GL_ARRAY_BUFFER, R3D_MOD_RENDER.globalVbo);
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, position));
+
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, texcoord));
+
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, normal));
+
+    glEnableVertexAttribArray(3);
+    glVertexAttribPointer(3, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, color));
+
+    glEnableVertexAttribArray(4);
+    glVertexAttribPointer(4, 4, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, tangent));
+
+    glEnableVertexAttribArray(5);
+    glVertexAttribIPointer(5, 4, GL_INT, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, boneIds));
+
+    glEnableVertexAttribArray(6);
+    glVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, weights));
+}
+
+/*
+ * Grows the global VBO to at least 'minCapacity' vertices.
+ * Creates a new buffer, copies the old content via glCopyBufferSubData,
+ * deletes the old buffer, and reconfigures the VAO attrib pointers.
+ */
+static bool grow_global_vbo(int minCapacity)
+{
+    int newCapacity = R3D_MOD_RENDER.globalVertexCapacity * 2;
+    while (newCapacity < minCapacity) newCapacity *= 2;
+
+    GLuint newVbo;
+    glGenBuffers(1, &newVbo);
+
+    // Allocate the new buffer without data
+    glBindBuffer(GL_COPY_WRITE_BUFFER, newVbo);
+    glBufferData(GL_COPY_WRITE_BUFFER, newCapacity * sizeof(R3D_Vertex), NULL, GL_DYNAMIC_DRAW);
+
+    // Copy the old content
+    glBindBuffer(GL_COPY_READ_BUFFER, R3D_MOD_RENDER.globalVbo);
+    glCopyBufferSubData(
+        GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER,
+        0, 0,
+        R3D_MOD_RENDER.globalVertexCount * sizeof(R3D_Vertex)
+    );
+
+    // Replaces the old buffer
+    glDeleteBuffers(1, &R3D_MOD_RENDER.globalVbo);
+    R3D_MOD_RENDER.globalVbo = newVbo;
+    R3D_MOD_RENDER.globalVertexCapacity = newCapacity;
+
+    // Reconfigure the assignments on the new VBO
+    glBindVertexArray(R3D_MOD_RENDER.globalVao);
+    reconfigure_global_vao_attribs();
+    glBindVertexArray(0);
+
+    return true;
+}
+
+/*
+ * Grows the global EBO to at least 'minCapacity' indices.
+ * Same strategy as grow_global_vbo: new buffer + copy + delete + rebind.
+ */
+static bool grow_global_ebo(int minCapacity)
+{
+    int newCapacity = R3D_MOD_RENDER.globalElementCapacity * 2;
+    while (newCapacity < minCapacity) newCapacity *= 2;
+
+    GLuint newEbo;
+    glGenBuffers(1, &newEbo);
+
+    glBindBuffer(GL_COPY_WRITE_BUFFER, newEbo);
+    glBufferData(GL_COPY_WRITE_BUFFER, newCapacity * sizeof(GLuint), NULL, GL_DYNAMIC_DRAW);
+
+    glBindBuffer(GL_COPY_READ_BUFFER, R3D_MOD_RENDER.globalEbo);
+    glCopyBufferSubData(
+        GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER,
+        0, 0,
+        R3D_MOD_RENDER.globalElementCount * sizeof(GLuint)
+    );
+
+    glDeleteBuffers(1, &R3D_MOD_RENDER.globalEbo);
+    R3D_MOD_RENDER.globalEbo = newEbo;
+    R3D_MOD_RENDER.globalElementCapacity = newCapacity;
+
+    // Rebind the EBO into the global VAO
+    glBindVertexArray(R3D_MOD_RENDER.globalVao);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, R3D_MOD_RENDER.globalEbo);
+    glBindVertexArray(0);
+
+    return true;
+}
+
+/*
+ * Copies 'count' vertex slots from 'srcOffset' to 'dstOffset' within
+ * the global VBO. Ranges must not overlap.
+ */
+static void copy_global_vertices(int dstOffset, int srcOffset, int count)
+{
+    GLsizeiptr size = count * sizeof(R3D_Vertex);
+
+    glBindBuffer(GL_COPY_READ_BUFFER, R3D_MOD_RENDER.globalVbo);
+    glBindBuffer(GL_COPY_WRITE_BUFFER, R3D_MOD_RENDER.globalVbo);
+    glCopyBufferSubData(
+        GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER,
+        srcOffset * sizeof(R3D_Vertex),
+        dstOffset * sizeof(R3D_Vertex),
+        size
+    );
+}
+
+/*
+ * Copies 'count' index slots from 'srcOffset' to 'dstOffset' within
+ * the global EBO. Ranges must not overlap.
+ */
+static void copy_global_elements(int dstOffset, int srcOffset, int count)
+{
+    GLsizeiptr size = count * sizeof(GLuint);
+
+    glBindBuffer(GL_COPY_READ_BUFFER, R3D_MOD_RENDER.globalEbo);
+    glBindBuffer(GL_COPY_WRITE_BUFFER, R3D_MOD_RENDER.globalEbo);
+    glCopyBufferSubData(
+        GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER,
+        srcOffset * sizeof(GLuint),
+        dstOffset * sizeof(GLuint),
+        size
+    );
+}
+
+// ========================================
+// INTERNAL FREE LIST FUNCTIONS
+// ========================================
+
+/*
+ * After inserting a range into a free list, sort by offset and merge
+ * adjacent/overlapping blocks. Keeps the list compact and prevents
+ * fragmentation from accumulating across many alloc/free cycles.
+ */
+static void coalesce_free_list(r3d_render_range_t* list, int* count)
+{
+    // Offset sorting (insertion sort, the list is almost sorted in practice)
+    for (int i = 1; i < *count; i++) {
+        r3d_render_range_t key = list[i];
+        int j = i - 1;
+        while (j >= 0 && list[j].offset > key.offset) {
+            list[j + 1] = list[j];
+            j--;
+        }
+        list[j + 1] = key;
+    }
+
+    // Merging of adjacent blocks
+    int write = 0;
+    for (int i = 1; i < *count; i++) {
+        if (list[write].offset + list[write].count >= list[i].offset) {
+            // Contiguous or overlapping blocks: we extend
+            int end = list[write].offset + list[write].count;
+            int end_i = list[i].offset + list[i].count;
+            if (end_i > end) list[write].count = end_i - list[write].offset;
+        } else {
+            list[++write] = list[i];
+        }
+    }
+    *count = write + 1;
+}
+
+/*
+ * Pushes a range onto a free list, growing the list's backing array if needed.
+ * Returns false on allocation failure.
+ */
+static bool push_free_range(r3d_render_range_t** list, int* count, int* capacity,
+                            int offset, int rangeCount)
+{
+    if (*count >= *capacity) {
+        int newCapacity = (*capacity) * 2;
+        r3d_render_range_t* p = RL_REALLOC(*list, newCapacity * sizeof(r3d_render_range_t));
+        if (!p) return false;
+        *list = p;
+        *capacity = newCapacity;
+    }
+
+    (*list)[(*count)++] = (r3d_render_range_t){ .offset = offset, .count = rangeCount };
+    return true;
+}
+
+/*
+ * First-fit search in a free list.
+ * If a block large enough is found:
+ *   - it is split if strictly larger than needed (remainder stays in the list)
+ *   - it is removed entirely if it matches exactly
+ * Returns the offset on success, -1 if nothing fits.
+ */
+static int pop_free_range(r3d_render_range_t* list, int* count, int needed)
+{
+    for (int i = 0; i < *count; i++) {
+        if (list[i].count >= needed) {
+            int offset = list[i].offset;
+            if (list[i].count > needed) {
+                // Cut: we keep the rest in the list
+                list[i].offset += needed;
+                list[i].count  -= needed;
+            } else {
+                // Exact match: remove the entry
+                list[i] = list[--(*count)];
+            }
+            return offset;
+        }
+    }
+    return -1;
+}
+
+/*
+ * Searches the free list for a block starting exactly at 'afterOffset'
+ * with at least 'needed' slots. If found, consumes 'needed' slots from it
+ * (splitting the remainder back) and returns true.
+ */
+static bool try_extend_in_place(r3d_render_range_t* list, int* count,
+                                int afterOffset, int needed)
+{
+    for (int i = 0; i < *count; i++) {
+        if (list[i].offset != afterOffset) continue;
+
+        if (list[i].count < needed) {
+            // Adjacent block but too small
+            return false;
+        }
+
+        if (list[i].count == needed) {
+            // Exact match: remove the entry
+            list[i] = list[--(*count)];
+        } else {
+            // We consume 'needed' since the beginning of the block
+            list[i].offset += needed;
+            list[i].count  -= needed;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+// ========================================
 // INTERNAL SHAPE FUNCTIONS
 // ========================================
 
@@ -46,34 +301,33 @@ static const shape_loader_func SHAPE_LOADERS[] = {
 
 void load_shape_dummy(r3d_render_shape_t* shape)
 {
-    glGenVertexArrays(1, &shape->vao);
-    shape->vertexCount = 3;
-    shape->indexCount = 0;
+    shape->vertices.count = 3;
+    shape->elements.count = 0;
 }
 
 void load_shape_quad(r3d_render_shape_t* shape)
 {
-    static const R3D_Vertex VERTS[] = {
+    static const R3D_Vertex VERTICES[] = {
         {{-0.5f, 0.5f, 0}, {0, 1}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
         {{-0.5f,-0.5f, 0}, {0, 0}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
         {{ 0.5f, 0.5f, 0}, {1, 1}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
         {{ 0.5f,-0.5f, 0}, {1, 0}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
     };
-    static const GLubyte INDICES[] = {0, 1, 2, 1, 3, 2};
+    static const uint32_t INDICES[] = {0, 1, 2, 1, 3, 2};
 
-    r3d_render_create_vertex_array(
-        &shape->vao, &shape->vbo, &shape->ebo,
-        VERTS, 4, INDICES, 6, (int)sizeof(*INDICES),
-        GL_STATIC_DRAW
-    );
+    r3d_render_alloc_vertices(ARRAY_SIZE(VERTICES), &shape->vertices.offset);
+    r3d_render_alloc_elements(ARRAY_SIZE(INDICES), &shape->elements.offset);
 
-    shape->vertexCount = 4;
-    shape->indexCount = 6;
+    r3d_render_upload_vertices(shape->vertices.offset, VERTICES, ARRAY_SIZE(VERTICES));
+    r3d_render_upload_elements(shape->elements.offset, INDICES, ARRAY_SIZE(INDICES));
+
+    shape->vertices.count = ARRAY_SIZE(VERTICES);
+    shape->elements.count = ARRAY_SIZE(INDICES);
 }
 
 void load_shape_cube(r3d_render_shape_t* shape)
 {
-    static const R3D_Vertex VERTS[] = {
+    static const R3D_Vertex VERTICES[] = {
         // Front (Z+)
         {{-0.5f, 0.5f, 0.5f}, {0, 1}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
         {{-0.5f,-0.5f, 0.5f}, {0, 0}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
@@ -105,19 +359,19 @@ void load_shape_cube(r3d_render_shape_t* shape)
         {{ 0.5f,-0.5f, 0.5f}, {1, 0}, {0,-1, 0}, {255, 255, 255, 255}, {1, 0, 0, 1}},
         {{ 0.5f,-0.5f,-0.5f}, {1, 1}, {0,-1, 0}, {255, 255, 255, 255}, {1, 0, 0, 1}},
     };
-    static const GLubyte INDICES[] = {
+    static const uint32_t INDICES[] = {
         0,1,2, 2,1,3,   6,5,4, 7,5,6,   8,9,10, 10,9,11,
         12,13,14, 14,13,15,   16,17,18, 18,17,19,   20,21,22, 22,21,23
     };
 
-    r3d_render_create_vertex_array(
-        &shape->vao, &shape->vbo, &shape->ebo,
-        VERTS, 24, INDICES, 36, (int)sizeof(*INDICES),
-        GL_STATIC_DRAW
-    );
+    r3d_render_alloc_vertices(ARRAY_SIZE(VERTICES), &shape->vertices.offset);
+    r3d_render_alloc_elements(ARRAY_SIZE(INDICES), &shape->elements.offset);
 
-    shape->vertexCount = 24;
-    shape->indexCount = 36;
+    r3d_render_upload_vertices(shape->vertices.offset, VERTICES, ARRAY_SIZE(VERTICES));
+    r3d_render_upload_elements(shape->elements.offset, INDICES, ARRAY_SIZE(INDICES));
+
+    shape->vertices.count = ARRAY_SIZE(VERTICES);
+    shape->elements.count = ARRAY_SIZE(INDICES);
 }
 
 // ========================================
@@ -273,37 +527,39 @@ static inline GLenum get_opengl_primitive(R3D_PrimitiveType primitive)
     return GL_TRIANGLES; // consider an error...
 }
 
-static void bind_draw_call_vao(const r3d_render_call_t* call, GLenum* primitive, GLenum* elemType, GLint* vertCount, GLint* elemCount)
+static void get_draw_call_info(const r3d_render_call_t* call, GLenum* primitive, r3d_render_range_t* vertexRange, r3d_render_range_t* indexRange)
 {
-    assert(primitive && elemType && vertCount && elemCount);
+    assert(primitive && vertexRange && indexRange);
 
     *primitive = GL_NONE;
-    *elemType = GL_NONE;
-    *vertCount = 0;
-    *elemCount = 0;
+    *vertexRange = (r3d_render_range_t) {0};
+    *indexRange = (r3d_render_range_t) {0};
 
     switch (call->type) {
     case R3D_RENDER_CALL_MESH:
         {
             const R3D_Mesh* mesh = &call->mesh.instance;
-            glBindVertexArray(mesh->vao);
 
             *primitive = get_opengl_primitive(mesh->primitiveType);
-            *vertCount = mesh->vertexCount;
-            *elemCount = mesh->indexCount;
-            *elemType = GL_UNSIGNED_INT;
+            vertexRange->offset = mesh->vertexOffset;
+            vertexRange->count = mesh->vertexCount;
+            indexRange->offset = mesh->indexOffset;
+            indexRange->count = mesh->indexCount;
         }
         break;
     case R3D_RENDER_CALL_DECAL:
         {
-            r3d_render_shape_t* buffer = &R3D_MOD_RENDER.shapes[R3D_RENDER_SHAPE_CUBE];
-            if (buffer->vao == 0) SHAPE_LOADERS[R3D_RENDER_SHAPE_CUBE](buffer);
-            else glBindVertexArray(buffer->vao);
+            r3d_render_shape_t* shape = &R3D_MOD_RENDER.shapes[R3D_RENDER_SHAPE_CUBE];
+            if (shape->vertices.count == 0) {
+                SHAPE_LOADERS[R3D_RENDER_SHAPE_CUBE](shape);
+                glBindVertexArray(R3D_MOD_RENDER.globalVao);
+            }
 
             *primitive = GL_TRIANGLES;
-            *vertCount = buffer->vertexCount;
-            *elemCount = buffer->indexCount;
-            *elemType = GL_UNSIGNED_BYTE;
+            vertexRange->offset = shape->vertices.offset;
+            vertexRange->count = shape->vertices.count;
+            indexRange->offset = shape->elements.offset;
+            indexRange->count = shape->elements.count;
         }
         break;
     default:
@@ -418,7 +674,7 @@ static inline void sort_fill_material_data(r3d_render_sort_t* sortData, const r3
         sortData->material.depth = r3d_hash_fnv1a_32(&call->mesh.material.depth, sizeof(call->mesh.material.depth));
         sortData->material.blend = call->mesh.material.blendMode;
         sortData->material.cull = call->mesh.material.cullMode;
-        sortData->material.transparency = sortData->material.transparency;
+        sortData->material.transparency = call->mesh.material.transparencyMode;
         sortData->material.billboard = call->mesh.material.billboardMode;
         break;
 
@@ -543,10 +799,12 @@ static int compare_materials_only(const void* a, const void* b)
 
 bool r3d_render_init(void)
 {
-    const int DRAW_RESERVE_COUNT = 1024;
+    memset(&R3D_MOD_RENDER, 0, sizeof(R3D_MOD_RENDER));
 
-    #define ALLOC_AND_ASSIGN(field, logfmt, ...)  do { \
-        void* _p = RL_CALLOC(DRAW_RESERVE_COUNT, sizeof(*R3D_MOD_RENDER.field)); \
+    /* --- CPU array allocation (draw calls, groups, etc) --- */
+
+    #define ALLOC_AND_ASSIGN(field, logfmt, ...) do { \
+        void* _p = RL_CALLOC(R3D_RENDER_INITIAL_DRAW_CALL_RESERVE, sizeof(*R3D_MOD_RENDER.field)); \
         if (_p == NULL) { \
             R3D_TRACELOG(LOG_FATAL, "Failed to init render module; " logfmt, ##__VA_ARGS__); \
             goto fail; \
@@ -554,15 +812,13 @@ bool r3d_render_init(void)
         R3D_MOD_RENDER.field = _p; \
     } while (0)
 
-    memset(&R3D_MOD_RENDER, 0, sizeof(R3D_MOD_RENDER));
-
     ALLOC_AND_ASSIGN(clusters, "Render cluster array allocation failed");
     ALLOC_AND_ASSIGN(groupVisibility, "Render group visibility array allocation failed");
     ALLOC_AND_ASSIGN(callIndices, "Draw call indices array allocation failed");
     ALLOC_AND_ASSIGN(groups, "Render group array allocation failed");
 
     for (int i = 0; i < R3D_RENDER_LIST_COUNT; i++) {
-        ALLOC_AND_ASSIGN(list[i].calls, "Draw call array %i allocation failed", i);
+        ALLOC_AND_ASSIGN(list[i].calls, "Draw call list[%i] allocation failed", i);
     }
 
     ALLOC_AND_ASSIGN(calls, "Draw call array allocation failed");
@@ -571,8 +827,76 @@ bool r3d_render_init(void)
 
     #undef ALLOC_AND_ASSIGN
 
-    R3D_MOD_RENDER.capacity = DRAW_RESERVE_COUNT;
+    R3D_MOD_RENDER.capacity = R3D_RENDER_INITIAL_DRAW_CALL_RESERVE;
     R3D_MOD_RENDER.activeCluster = -1;
+
+    /* --- CPU free list allocation --- */
+
+    #define ALLOC_FREELIST(field, cap_field, logmsg) do { \
+        R3D_MOD_RENDER.field = RL_MALLOC(R3D_RENDER_INITIAL_FREE_LIST_RESERVE * sizeof(*R3D_MOD_RENDER.field)); \
+        if (!R3D_MOD_RENDER.field) { \
+            R3D_TRACELOG(LOG_FATAL, "Failed to init render module; " logmsg); \
+            goto fail; \
+        } \
+        R3D_MOD_RENDER.cap_field = R3D_RENDER_INITIAL_FREE_LIST_RESERVE; \
+    } while (0)
+
+    ALLOC_FREELIST(freeVertices, freeVertexCapacity, "Free vertex list allocation failed");
+    ALLOC_FREELIST(freeElements, freeElementCapacity, "Free element list allocation failed");
+
+    #undef ALLOC_FREELIST
+
+    /* --- Creation of the global VAO/VBO/EBO --- */
+
+    glGenVertexArrays(1, &R3D_MOD_RENDER.globalVao);
+    glBindVertexArray(R3D_MOD_RENDER.globalVao);
+
+    glGenBuffers(1, &R3D_MOD_RENDER.globalVbo);
+    glBindBuffer(GL_ARRAY_BUFFER, R3D_MOD_RENDER.globalVbo);
+    glBufferData(GL_ARRAY_BUFFER,
+        R3D_RENDER_INITIAL_VERTICES_RESERVE * sizeof(R3D_Vertex),
+        NULL, GL_DYNAMIC_DRAW);
+
+    glGenBuffers(1, &R3D_MOD_RENDER.globalEbo);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, R3D_MOD_RENDER.globalEbo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER,
+        R3D_RENDER_INITIAL_ELEMENTS_RESERVE * sizeof(GLuint),
+        NULL, GL_DYNAMIC_DRAW);
+
+    R3D_MOD_RENDER.globalVertexCapacity  = R3D_RENDER_INITIAL_VERTICES_RESERVE;
+    R3D_MOD_RENDER.globalElementCapacity = R3D_RENDER_INITIAL_ELEMENTS_RESERVE;
+
+    /* --- Configuring vertex attributes --- */
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, position));
+
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, texcoord));
+
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, normal));
+
+    glEnableVertexAttribArray(3);
+    glVertexAttribPointer(3, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, color));
+
+    glEnableVertexAttribArray(4);
+    glVertexAttribPointer(4, 4, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, tangent));
+
+    glEnableVertexAttribArray(5);
+    glVertexAttribIPointer(5, 4, GL_INT, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, boneIds));
+
+    glEnableVertexAttribArray(6);
+    glVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, weights));
+
+    // Default values ​​for instance attributes (disabled)
+    glVertexAttrib3f(10, 0.0f, 0.0f, 0.0f);
+    glVertexAttrib4f(11, 0.0f, 0.0f, 0.0f, 1.0f);
+    glVertexAttrib3f(12, 1.0f, 1.0f, 1.0f);
+    glVertexAttrib4f(13, 1.0f, 1.0f, 1.0f, 1.0f);
+    glVertexAttrib4f(14, 0.0f, 0.0f, 0.0f, 0.0f);
+
+    glBindVertexArray(0);
 
     return true;
 
@@ -583,12 +907,13 @@ fail:
 
 void r3d_render_quit(void)
 {
-    for (int i = 0; i < R3D_RENDER_SHAPE_COUNT; i++) {
-        r3d_render_shape_t* buffer = &R3D_MOD_RENDER.shapes[i];
-        if (buffer->vao) glDeleteVertexArrays(1, &buffer->vao);
-        if (buffer->vbo) glDeleteBuffers(1, &buffer->vbo);
-        if (buffer->ebo) glDeleteBuffers(1, &buffer->ebo);
-    }
+    /* --- Delete global GL buffers --- */
+
+    if (R3D_MOD_RENDER.globalVao) glDeleteVertexArrays(1, &R3D_MOD_RENDER.globalVao);
+    if (R3D_MOD_RENDER.globalVbo) glDeleteBuffers(1, &R3D_MOD_RENDER.globalVbo);
+    if (R3D_MOD_RENDER.globalEbo) glDeleteBuffers(1, &R3D_MOD_RENDER.globalEbo);
+
+    /* --- Release CPU arrays --- */
 
     for (int i = 0; i < R3D_RENDER_LIST_COUNT; i++) {
         RL_FREE(R3D_MOD_RENDER.list[i].calls);
@@ -598,8 +923,267 @@ void r3d_render_quit(void)
     RL_FREE(R3D_MOD_RENDER.groupIndices);
     RL_FREE(R3D_MOD_RENDER.callIndices);
     RL_FREE(R3D_MOD_RENDER.sortCache);
+    RL_FREE(R3D_MOD_RENDER.clusters);
     RL_FREE(R3D_MOD_RENDER.groups);
     RL_FREE(R3D_MOD_RENDER.calls);
+
+    /* --- Realease free lists --- */
+
+    RL_FREE(R3D_MOD_RENDER.freeVertices);
+    RL_FREE(R3D_MOD_RENDER.freeElements);
+}
+
+bool r3d_render_alloc_vertices(int count, int* outOffset)
+{
+    assert(outOffset != NULL);
+    assert(count > 0);
+
+    // First search the free list
+    int offset = pop_free_range(
+        R3D_MOD_RENDER.freeVertices,
+        &R3D_MOD_RENDER.numFreeVertices,
+        count
+    );
+
+    if (offset >= 0) {
+        *outOffset = offset;
+        return true;
+    }
+
+    // No free block, we extend from the end of the buffer
+    int needed = R3D_MOD_RENDER.globalVertexCount + count;
+    if (needed > R3D_MOD_RENDER.globalVertexCapacity) {
+        if (!grow_global_vbo(needed)) {
+            R3D_TRACELOG(LOG_FATAL, "r3d_render_alloc_vertices: VBO resize failed");
+            return false;
+        }
+    }
+
+    *outOffset = R3D_MOD_RENDER.globalVertexCount;
+    R3D_MOD_RENDER.globalVertexCount += count;
+    return true;
+}
+
+bool r3d_render_alloc_elements(int count, int* outOffset)
+{
+    assert(outOffset != NULL);
+    assert(count > 0);
+
+    int offset = pop_free_range(
+        R3D_MOD_RENDER.freeElements,
+        &R3D_MOD_RENDER.numFreeElements,
+        count
+    );
+
+    if (offset >= 0) {
+        *outOffset = offset;
+        return true;
+    }
+
+    int needed = R3D_MOD_RENDER.globalElementCount + count;
+    if (needed > R3D_MOD_RENDER.globalElementCapacity) {
+        if (!grow_global_ebo(needed)) {
+            R3D_TRACELOG(LOG_FATAL, "r3d_render_alloc_elements: EBO resize failed");
+            return false;
+        }
+    }
+
+    *outOffset = R3D_MOD_RENDER.globalElementCount;
+    R3D_MOD_RENDER.globalElementCount += count;
+    return true;
+}
+
+bool r3d_render_realloc_vertices(int* offset, int* count, int newCount, bool keepData)
+{
+    assert(offset != NULL && count != NULL);
+    assert(*offset >= 0 && *count >= 0 && newCount > 0);
+
+    if (newCount == *count) {
+        return true;
+    }
+
+    // Reduction
+    // The queue is released: the (count - newCount) end slots
+    // are returned to the free list. No GPU copy is necessary
+    if (newCount < *count) {
+        r3d_render_free_vertices(*offset + newCount, *count - newCount);
+        *count = newCount;
+        return true;
+    }
+
+    // Enlargement
+    int extra = newCount - *count;
+
+    // Case 1: Extension in place if the free list
+    // has a contiguous block immediately after
+    if (try_extend_in_place(
+            R3D_MOD_RENDER.freeVertices,
+            &R3D_MOD_RENDER.numFreeVertices,
+            *offset + *count, extra))
+    {
+        *count = newCount;
+        return true;
+    }
+
+    // Case 2: Extension in place if we are at the end of
+    // the buffer and there is still uncommitted capacity
+    if (*offset + *count == R3D_MOD_RENDER.globalVertexCount) {
+        int needed = R3D_MOD_RENDER.globalVertexCount + extra;
+        if (needed > R3D_MOD_RENDER.globalVertexCapacity) {
+            if (!grow_global_vbo(needed)) {
+                R3D_TRACELOG(LOG_FATAL, "r3d_render_realloc_vertices: VBO resize failed");
+                return false;
+            }
+        }
+        R3D_MOD_RENDER.globalVertexCount += extra;
+        *count = newCount;
+        return true;
+    }
+
+    // Case 3: no contiguous space, we look for a new larger block,
+    // copy the existing data into it, then free the old one
+    int newOffset;
+    if (!r3d_render_alloc_vertices(newCount, &newOffset)) {
+        return false;
+    }
+
+    if (keepData) {
+        copy_global_vertices(newOffset, *offset, *count);
+    }
+
+    r3d_render_free_vertices(*offset, *count);
+
+    *offset = newOffset;
+    *count  = newCount;
+    return true;
+}
+
+bool r3d_render_realloc_elements(int* offset, int* count, int newCount, bool keepData)
+{
+    assert(offset != NULL && count != NULL);
+    assert(*offset >= 0 && *count >= 0 && newCount > 0);
+
+    if (newCount == *count) {
+        return true;
+    }
+
+    // Reduction
+    // The queue is released: the (count - newCount) end slots
+    // are returned to the free list. No GPU copy is necessary
+    if (newCount < *count) {
+        r3d_render_free_elements(*offset + newCount, *count - newCount);
+        *count = newCount;
+        return true;
+    }
+
+    // Enlargement
+    int extra = newCount - *count;
+
+    // Case 1: Extension in place if the free list
+    // has a contiguous block immediately after
+    if (try_extend_in_place(
+            R3D_MOD_RENDER.freeElements,
+            &R3D_MOD_RENDER.numFreeElements,
+            *offset + *count, extra))
+    {
+        *count = newCount;
+        return true;
+    }
+
+    // Case 2: Extension in place if we are at the end of
+    // the buffer and there is still uncommitted capacity
+    if (*offset + *count == R3D_MOD_RENDER.globalElementCount) {
+        int needed = R3D_MOD_RENDER.globalElementCount + extra;
+        if (needed > R3D_MOD_RENDER.globalElementCapacity) {
+            if (!grow_global_ebo(needed)) {
+                R3D_TRACELOG(LOG_FATAL, "r3d_render_realloc_elements: EBO resize failed");
+                return false;
+            }
+        }
+        R3D_MOD_RENDER.globalElementCount += extra;
+        *count = newCount;
+        return true;
+    }
+
+    // Case 3: no contiguous space, we look for a new larger block,
+    // copy the existing data into it, then free the old one
+    int newOffset;
+    if (!r3d_render_alloc_elements(newCount, &newOffset)) {
+        return false;
+    }
+
+    if (keepData) {
+        copy_global_elements(newOffset, *offset, *count);
+    }
+
+    r3d_render_free_elements(*offset, *count);
+
+    *offset = newOffset;
+    *count  = newCount;
+    return true;
+}
+
+void r3d_render_free_vertices(int offset, int count)
+{
+    assert(offset >= 0 && count > 0);
+
+    if (!push_free_range(
+            &R3D_MOD_RENDER.freeVertices,
+            &R3D_MOD_RENDER.numFreeVertices,
+            &R3D_MOD_RENDER.freeVertexCapacity,
+            offset, count))
+    {
+        R3D_TRACELOG(LOG_WARNING, "r3d_render_free_vertices: free list push failed (leak)");
+        return;
+    }
+
+    coalesce_free_list(R3D_MOD_RENDER.freeVertices, &R3D_MOD_RENDER.numFreeVertices);
+}
+
+void r3d_render_free_elements(int offset, int count)
+{
+    assert(offset >= 0 && count > 0);
+
+    if (!push_free_range(
+            &R3D_MOD_RENDER.freeElements,
+            &R3D_MOD_RENDER.numFreeElements,
+            &R3D_MOD_RENDER.freeElementCapacity,
+            offset, count))
+    {
+        R3D_TRACELOG(LOG_WARNING, "r3d_render_free_elements: free list push failed (leak)");
+        return;
+    }
+
+    coalesce_free_list(R3D_MOD_RENDER.freeElements, &R3D_MOD_RENDER.numFreeElements);
+}
+
+void r3d_render_upload_vertices(int offset, const R3D_Vertex* verts, int count)
+{
+    assert(offset >= 0 && verts != NULL && count > 0);
+    assert(offset + count <= R3D_MOD_RENDER.globalVertexCapacity);
+
+    glBindBuffer(GL_ARRAY_BUFFER, R3D_MOD_RENDER.globalVbo);
+    glBufferSubData(
+        GL_ARRAY_BUFFER,
+        offset * sizeof(R3D_Vertex),
+        count * sizeof(R3D_Vertex),
+        verts
+    );
+}
+
+void r3d_render_upload_elements(int offset, const GLuint* indices, int count)
+{
+    assert(offset >= 0 && indices != NULL && count > 0);
+    assert(offset + count <= R3D_MOD_RENDER.globalElementCapacity);
+
+    glBindVertexArray(0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, R3D_MOD_RENDER.globalEbo);
+    glBufferSubData(
+        GL_ELEMENT_ARRAY_BUFFER,
+        offset * sizeof(GLuint),
+        count * sizeof(GLuint),
+        indices
+    );
 }
 
 void r3d_render_clear(void)
@@ -833,34 +1417,57 @@ void r3d_render_sort_list(r3d_render_list_enum_t list, Vector3 viewPosition, r3d
     );
 }
 
+void r3d_render_prepare_drawing(void)
+{
+    glBindVertexArray(R3D_MOD_RENDER.globalVao);
+}
+
 void r3d_render_draw(const r3d_render_call_t* call)
 {
-    GLenum primitive, elemType;
-    GLint vertCount, elemCount;
+    GLenum primitive;
+    r3d_render_range_t vertexRange;
+    r3d_render_range_t indexRange;
 
-    bind_draw_call_vao(call, &primitive, &elemType, &vertCount, &elemCount);
+    get_draw_call_info(call, &primitive, &vertexRange, &indexRange);
 
-    if (elemCount == 0) glDrawArrays(primitive, 0, vertCount);
-    else glDrawElements(primitive, elemCount, elemType, NULL);
+    if (indexRange.count == 0) {
+        glDrawArrays(primitive, vertexRange.offset, vertexRange.count);
+    }
+    else {
+        glDrawElementsBaseVertex(
+            primitive,
+            indexRange.count,
+            GL_UNSIGNED_INT,
+            (void*)(indexRange.offset * sizeof(GLuint)),
+            vertexRange.offset
+        );
+    }
 }
 
 void r3d_render_draw_instanced(const r3d_render_call_t* call)
 {
-    GLenum primitive, elemType;
-    GLint vertCount, elemCount;
+    GLenum primitive;
+    r3d_render_range_t vertexRange;
+    r3d_render_range_t indexRange;
 
-    bind_draw_call_vao(call, &primitive, &elemType, &vertCount, &elemCount);
+    get_draw_call_info(call, &primitive, &vertexRange, &indexRange);
 
     const r3d_render_group_t* group = r3d_render_get_call_group(call);
-    const R3D_InstanceBuffer* instances = &group->instances;
 
     enable_instances(group->instances.buffers, group->instances.flags, group->instanceOffset);
 
-    if (elemCount == 0) {
-        glDrawArraysInstanced(primitive, 0, vertCount, group->instanceCount);
+    if (indexRange.count == 0) {
+        glDrawArraysInstanced(primitive, vertexRange.offset, vertexRange.count, group->instanceCount);
     }
     else {
-        glDrawElementsInstanced(primitive, elemCount, elemType, NULL, group->instanceCount);
+        glDrawElementsInstancedBaseVertex(
+            primitive,
+            indexRange.count,
+            GL_UNSIGNED_INT,
+            (void*)(indexRange.offset * sizeof(GLuint)),
+            group->instanceCount,
+            vertexRange.offset
+        );
     }
 
     disable_instances(group->instances.flags);
@@ -868,92 +1475,22 @@ void r3d_render_draw_instanced(const r3d_render_call_t* call)
 
 void r3d_render_draw_shape(r3d_render_shape_enum_t shape)
 {
-    r3d_render_shape_t* buffer = &R3D_MOD_RENDER.shapes[shape];
-
-    if (buffer->vao == 0) {
-        SHAPE_LOADERS[shape](buffer);
+    r3d_render_shape_t* s = &R3D_MOD_RENDER.shapes[shape];
+    if (s->vertices.count == 0) {
+        SHAPE_LOADERS[shape](s);
+        glBindVertexArray(R3D_MOD_RENDER.globalVao);
     }
 
-    glBindVertexArray(buffer->vao);
-
-    if (buffer->indexCount > 0) {
-        glDrawElements(GL_TRIANGLES, buffer->indexCount, GL_UNSIGNED_BYTE, 0);
+    if (s->elements.count > 0) {
+        glDrawElementsBaseVertex(
+            GL_TRIANGLES,
+            s->elements.count,
+            GL_UNSIGNED_INT,
+            (void*)(s->elements.offset * sizeof(GLuint)),
+            s->vertices.offset
+        );
     }
     else {
-        glDrawArrays(GL_TRIANGLES, 0, buffer->vertexCount);
+        glDrawArrays(GL_TRIANGLES, s->vertices.offset, s->vertices.count);
     }
-}
-
-void r3d_render_create_vertex_array(
-    GLuint* vao, GLuint* vbo, GLuint* ebo,
-    const R3D_Vertex* vertices, int vertexCount,
-    const void* indices, int indexCount, int indexStride,
-    GLenum usage)
-{
-    glGenVertexArrays(1, vao);
-    glBindVertexArray(*vao);
-
-    GLuint buffers[2] = {0};
-    glGenBuffers(2, buffers);
-    glBindBuffer(GL_ARRAY_BUFFER, buffers[0]);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buffers[1]);
-
-    *vbo = buffers[0];
-    *ebo = buffers[1];
-
-    if (vertexCount > 0) {
-        glBufferData(
-            GL_ARRAY_BUFFER,
-            vertexCount * sizeof(R3D_Vertex),
-            vertices,
-            usage
-        );
-    }
-
-    if (indexCount > 0) {
-        glBufferData(
-            GL_ELEMENT_ARRAY_BUFFER,
-            indexCount * indexStride,
-            indices,
-            usage
-        );
-    }
-
-    // position (vec3)
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, position));
-
-    // texcoord (vec2)
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, texcoord));
-
-    // normal (vec3)
-    glEnableVertexAttribArray(2);
-    glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, normal));
-
-    // tangent (vec4)
-    glEnableVertexAttribArray(4);
-    glVertexAttribPointer(4, 4, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, tangent));
-
-    // color (vec4)
-    glEnableVertexAttribArray(3);
-    glVertexAttribPointer(3, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, color));
-
-    // boneIds (ivec4)
-    glEnableVertexAttribArray(5);
-    glVertexAttribIPointer(5, 4, GL_INT, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, boneIds));
-
-    // weights (vec4)
-    glEnableVertexAttribArray(6);
-    glVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, weights));
-
-    // Instance attributes (disabled)
-    glVertexAttrib3f(10, 0.0f, 0.0f, 0.0f);
-    glVertexAttrib4f(11, 0.0f, 0.0f, 0.0f, 1.0f);
-    glVertexAttrib3f(12, 1.0f, 1.0f, 1.0f);
-    glVertexAttrib4f(13, 1.0f, 1.0f, 1.0f, 1.0f);
-    glVertexAttrib4f(14, 0.0f, 0.0f, 0.0f, 0.0f);
-
-    // VAO setup completed!
-    glBindVertexArray(0);
 }

--- a/src/modules/r3d_render.h
+++ b/src/modules/r3d_render.h
@@ -153,12 +153,19 @@ typedef enum {
 // ========================================
 
 /*
+ * Interval [offset, offset+count) into the global VBO or EBO.
+ */
+typedef struct {
+    int offset;
+    int count;
+} r3d_render_range_t;
+
+/*
  * Internal structure for storing built-in shapes.
  */
 typedef struct {
-    GLuint vao, vbo, ebo;
-    int vertexCount;
-    int indexCount;
+    r3d_render_range_t vertices;
+    r3d_render_range_t elements;
 } r3d_render_shape_t;
 
 /*
@@ -270,6 +277,21 @@ typedef struct {
  */
 extern struct r3d_mod_render {
 
+    GLuint globalVao;                                   //< Single VAO shared by all mesh and shape draw calls
+    GLuint globalVbo;                                   //< Global vertex buffer holding all mesh and shape vertices
+    GLuint globalEbo;                                   //< Global index buffer holding all mesh and shape indices
+    int globalVertexCapacity;                           //< Number of vertex slots allocated in the VBO
+    int globalElementCapacity;                          //< Number of index slots allocated in the EBO
+    int globalVertexCount;                              //< High-water mark: first never-allocated vertex offset
+    int globalElementCount;                             //< High-water mark: first never-allocated index offset
+
+    r3d_render_range_t* freeVertices;                   //< Free list of released vertex ranges available for reuse
+    r3d_render_range_t* freeElements;                   //< Free list of released index ranges available for reuse
+    int numFreeVertices;                                //< Number of entries in the vertex free list
+    int numFreeElements;                                //< Number of entries in the element free list
+    int freeVertexCapacity;                             //< Allocated capacity of the vertex free list array
+    int freeElementCapacity;                            //< Allocated capacity of the element free list array
+
     r3d_render_shape_t shapes[R3D_RENDER_SHAPE_COUNT];  //< Array of built-in shapes buffers
 
     r3d_render_cluster_t* clusters;                     //< Array of render clusters
@@ -311,6 +333,56 @@ bool r3d_render_init(void);
  * Called once during `R3D_Close()`
  */
 void r3d_render_quit(void);
+
+/*
+ * Allocates 'count' vertex slots from the global VBO; returns their offset via 'outOffset'.
+ * Reuses a free block when possible, otherwise extends the buffer (growing it if needed).
+ */
+bool r3d_render_alloc_vertices(int count, int* outOffset);
+
+/*
+ * Allocates 'count' index slots from the global EBO; returns their offset via 'outOffset'.
+ * Reuses a free block when possible, otherwise extends the buffer (growing it if needed).
+ */
+bool r3d_render_alloc_elements(int count, int* outOffset);
+
+/*
+ * Resizes an existing vertex allocation to 'newCount' slots, updating '*offset' and '*count'.
+ * Shrinking always succeeds in-place. Growing tries to extend in-place before relocating;
+ * if relocated and 'keepData' is true, existing GPU data is copied to the new location.
+ */
+bool r3d_render_realloc_vertices(int* offset, int* count, int newCount, bool keepData);
+
+/*
+ * Resizes an existing element allocation to 'newCount' slots, updating '*offset' and '*count'.
+ * Shrinking always succeeds in-place. Growing tries to extend in-place before relocating;
+ * if relocated and 'keepData' is true, existing GPU data is copied to the new location.
+ */
+bool r3d_render_realloc_elements(int* offset, int* count, int newCount, bool keepData);
+
+/*
+ * Returns 'count' vertex slots starting at 'offset' to the free list.
+ * Adjacent free blocks are merged immediately to limit fragmentation.
+ */
+void r3d_render_free_vertices(int offset, int count);
+
+/*
+ * Returns 'count' index slots starting at 'offset' to the free list.
+ * Adjacent free blocks are merged immediately to limit fragmentation.
+ */
+void r3d_render_free_elements(int offset, int count);
+
+/*
+ * Uploads 'count' vertices to the global VBO at 'offset'. Does not allocate; caller must
+ * hold a valid allocation covering [offset, offset+count).
+ */
+void r3d_render_upload_vertices(int offset, const R3D_Vertex* verts, int count);
+
+/*
+ * Uploads 'count' indices to the global EBO at 'offset'. Does not allocate; caller must
+ * hold a valid allocation covering [offset, offset+count).
+ */
+void r3d_render_upload_elements(int offset, const GLuint* indices, int count);
 
 /*
  * Clear all render lists and reset the draw call buffer for the next frame.
@@ -368,6 +440,12 @@ bool r3d_render_call_is_visible(const r3d_render_call_t* call, const r3d_frustum
 void r3d_render_sort_list(r3d_render_list_enum_t list, Vector3 viewPosition, r3d_render_sort_enum_t mode);
 
 /*
+ * Binds the global VAO, making it active for all subsequent draw calls.
+ * Must be called once before any r3d_render_draw* calls in a rendering pass.
+ */
+void r3d_render_prepare_drawing(void);
+
+/*
  * Issue a non-instanced draw call.
  */
 void r3d_render_draw(const r3d_render_call_t* call);
@@ -382,15 +460,6 @@ void r3d_render_draw_instanced(const r3d_render_call_t* call);
  * Bind, draws the shape, and unbind the VAO of the shape.
  */
 void r3d_render_draw_shape(r3d_render_shape_enum_t shape);
-
-/*
- * Generate the vao/vbo/ebo and upload provided data to the buffers.
- */
-void r3d_render_create_vertex_array(
-    GLuint* vao, GLuint* vbo, GLuint* ebo,
-    const R3D_Vertex* vertices, int vertexCount,
-    const void* indices, int indexCount, int indexStride,
-    GLenum usage);
 
 // ----------------------------------------
 // INLINE QUERIES

--- a/src/r3d_ambient_map.c
+++ b/src/r3d_ambient_map.c
@@ -18,6 +18,7 @@
 #include "./common/r3d_pass.h"
 
 #include "./modules/r3d_driver.h"
+#include "./modules/r3d_render.h"
 #include "./modules/r3d_env.h"
 
 // ========================================
@@ -66,6 +67,7 @@ R3D_AmbientMap R3D_GenAmbientMap(R3D_Cubemap cubemap, R3D_AmbientFlags flags)
 
     r3d_driver_invalidate_cache();
     r3d_driver_store_viewport();
+    r3d_render_prepare_drawing();
 
     int irradiance = -1;
     if (BIT_TEST(flags, R3D_AMBIENT_ILLUMINATION)) {
@@ -88,6 +90,7 @@ R3D_AmbientMap R3D_GenAmbientMap(R3D_Cubemap cubemap, R3D_AmbientFlags flags)
         r3d_pass_prepare_prefilter(prefilter, cubemap.texture, cubemap.size);
     }
 
+    glBindVertexArray(0);
     r3d_driver_restore_viewport();
 
     ambientMap.irradiance = irradiance + 1;
@@ -112,6 +115,7 @@ void R3D_UpdateAmbientMap(R3D_AmbientMap ambientMap, R3D_Cubemap cubemap)
 {
     r3d_driver_invalidate_cache();
     r3d_driver_store_viewport();
+    r3d_render_prepare_drawing();
 
     if (BIT_TEST(ambientMap.flags, R3D_AMBIENT_ILLUMINATION) && ambientMap.irradiance > 0) {
         r3d_pass_prepare_irradiance((int)ambientMap.irradiance - 1, cubemap.texture, cubemap.size);
@@ -121,5 +125,6 @@ void R3D_UpdateAmbientMap(R3D_AmbientMap ambientMap, R3D_Cubemap cubemap)
         r3d_pass_prepare_prefilter((int)ambientMap.prefilter - 1, cubemap.texture, cubemap.size);
     }
 
+    glBindVertexArray(0);
     r3d_driver_restore_viewport();
 }

--- a/src/r3d_config.h.in
+++ b/src/r3d_config.h.in
@@ -108,6 +108,30 @@
 #define R3D_MAX_SCREEN_SHADERS @R3D_MAX_SCREEN_SHADERS@
 
 // ========================================
+// Render Module
+// ========================================
+
+/*
+ * Initial number of vertex slots pre-allocated in the global VBO at startup.
+ */
+#define R3D_RENDER_INITIAL_VERTICES_RESERVE (1 << 16)   // 65 536 vertices (~5.5 MB)
+
+/*
+ * Initial number of index slots pre-allocated in the global EBO at startup.
+ */
+#define R3D_RENDER_INITIAL_ELEMENTS_RESERVE (1 << 17)   // 131 072 indices (~0.5 MB)
+
+/*
+ * Initial capacity of the CPU-side draw call, group, and cluster arrays.
+ */
+#define R3D_RENDER_INITIAL_DRAW_CALL_RESERVE 1024
+
+/*
+ * Initial capacity of the vertex and element free list arrays.
+ */
+#define R3D_RENDER_INITIAL_FREE_LIST_RESERVE 128
+
+// ========================================
 // Debug
 // ========================================
 

--- a/src/r3d_cubemap.c
+++ b/src/r3d_cubemap.c
@@ -240,20 +240,21 @@ R3D_Cubemap load_cubemap_from_panorama(Image image, int size)
     glBindFramebuffer(GL_FRAMEBUFFER, cubemap.fbo);
     glViewport(0, 0, size, size);
     r3d_driver_disable(GL_CULL_FACE);
+    r3d_render_prepare_drawing();
 
     for (int i = 0; i < 6; i++) {
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, cubemap.texture, 0);
-        glClear(GL_DEPTH_BUFFER_BIT);
-
         R3D_SHADER_SET_MAT4(prepare.cubemapFromEquirectangular, uMatView, R3D.matCubeViews[i]);
         R3D_RENDER_CUBE();
     }
 
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    UnloadTexture(panorama);
+    glBindVertexArray(0);
 
     r3d_driver_enable(GL_CULL_FACE);
     r3d_driver_restore_viewport();
+
+    UnloadTexture(panorama);
 
     return cubemap;
 }

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -34,8 +34,7 @@
 // HELPER MACROS
 // ========================================
 
-#define IS_MESH_VALID(mesh)                     \
-    (((mesh).vao != 0) && ((mesh).vertexCount > 0))
+#define IS_MESH_VALID(mesh) ((mesh).vertexCount > 0)
 
 #define IS_MESH_DRAWABLE(mesh, cullMask)        \
     (IS_MESH_VALID(mesh) && BIT_TEST_ANY((cullMask), (mesh).layerMask))
@@ -122,6 +121,8 @@ void R3D_BeginEx(RenderTexture target, Camera3D camera)
 
 void R3D_End(void)
 {
+    r3d_render_prepare_drawing(); // bind global VAO
+
     /* --- Invalidates OpenGL cache and save some infos --- */
 
     r3d_driver_invalidate_cache();

--- a/src/r3d_mesh.c
+++ b/src/r3d_mesh.c
@@ -17,47 +17,37 @@
 #include "./common/r3d_helper.h"
 
 // ========================================
-// INTERNAL FUNCTIONS
-// ========================================
-
-static GLenum get_opengl_usage(R3D_MeshUsage usage)
-{
-    GLenum glUsage = GL_STATIC_DRAW;
-
-    switch (usage) {
-    case R3D_STATIC_MESH: glUsage = GL_STATIC_DRAW; break;
-    case R3D_DYNAMIC_MESH: glUsage = GL_DYNAMIC_DRAW; break;
-    case R3D_STREAMED_MESH: glUsage = GL_STREAM_DRAW; break;
-    default:
-        R3D_TRACELOG(LOG_WARNING, "Invalid mesh usage; R3D_STATIC_MESH will be used");
-        break;
-    }
-
-    return glUsage;
-}
-
-// ========================================
 // PUBLIC API
 // ========================================
 
-R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, R3D_MeshData data, const BoundingBox* aabb, R3D_MeshUsage usage)
+R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, R3D_MeshData data, const BoundingBox* aabb)
 {
     R3D_Mesh mesh = {0};
 
-    r3d_render_create_vertex_array(
-        &mesh.vao, &mesh.vbo, &mesh.ebo,
-        data.vertices, data.vertexCount,
-        data.indices, data.indexCount,
-        (int)sizeof(*data.indices),
-        get_opengl_usage(usage)
-    );
+    if (!r3d_render_alloc_vertices(data.vertexCount, &mesh.vertexOffset)) {
+        R3D_TRACELOG(LOG_WARNING, "Failed to load mesh; Vertices allocation in VRAM failed");
+        return mesh;
+    }
+
+    if (data.indexCount > 0) {
+        if (!r3d_render_alloc_elements(data.indexCount, &mesh.indexOffset)) {
+            R3D_TRACELOG(LOG_WARNING, "Failed to load mesh; Elements allocation in VRAM failed");
+            r3d_render_free_vertices(mesh.vertexOffset, data.vertexCount);
+            mesh.vertexOffset = 0;
+            return mesh;
+        }
+    }
+
+    r3d_render_upload_vertices(mesh.vertexOffset, data.vertices, data.vertexCount);
+    if (data.indexCount > 0) {
+        r3d_render_upload_elements(mesh.indexOffset, data.indices, data.indexCount);
+    }
 
     mesh.vertexCount = mesh.vertexCapacity = data.vertexCount;
     mesh.indexCount = mesh.indexCapacity = data.indexCount;
     mesh.shadowCastMode = R3D_SHADOW_CAST_ON_AUTO;
     mesh.layerMask = R3D_LAYER_01;
     mesh.primitiveType = type;
-    mesh.usage = usage;
 
     // Compute the bounding box, if needed
     mesh.aabb = (aabb != NULL) ? *aabb
@@ -68,14 +58,15 @@ R3D_Mesh R3D_LoadMesh(R3D_PrimitiveType type, R3D_MeshData data, const BoundingB
 
 void R3D_UnloadMesh(R3D_Mesh mesh)
 {
-    if (mesh.vao != 0) glDeleteVertexArrays(1, &mesh.vao);
-    if (mesh.vbo != 0) glDeleteBuffers(1, &mesh.vbo);
-    if (mesh.ebo != 0) glDeleteBuffers(1, &mesh.ebo);
+    r3d_render_free_vertices(mesh.vertexOffset, mesh.vertexCapacity);
+    if (mesh.indexCapacity > 0) {
+        r3d_render_free_elements(mesh.indexOffset, mesh.indexCapacity);
+    }
 }
 
 bool R3D_IsMeshValid(R3D_Mesh mesh)
 {
-    return (mesh.vao != 0) && (mesh.vbo != 0);
+    return mesh.vertexCount > 0;
 }
 
 R3D_Mesh R3D_GenMeshQuad(float width, float length, int resX, int resZ, Vector3 frontDir)
@@ -85,7 +76,7 @@ R3D_Mesh R3D_GenMeshQuad(float width, float length, int resX, int resZ, Vector3 
     R3D_MeshData data = R3D_GenMeshDataQuad(width, length, resX, resZ, frontDir);
     if (!R3D_IsMeshDataValid(data)) return mesh;
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, NULL, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, NULL);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -103,7 +94,7 @@ R3D_Mesh R3D_GenMeshPlane(float width, float length, int resX, int resZ)
         { width * 0.5f, 0.0f,  length * 0.5f}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -121,7 +112,7 @@ R3D_Mesh R3D_GenMeshPoly(int sides, float radius, Vector3 frontDir)
         { radius, 0.0f,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -139,7 +130,7 @@ R3D_Mesh R3D_GenMeshCube(float width, float height, float length)
         { width * 0.5f,  height * 0.5f,  length * 0.5f}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -157,7 +148,7 @@ R3D_Mesh R3D_GenMeshCubeEx(float width, float height, float length, int resX, in
         { width * 0.5f,  height * 0.5f,  length * 0.5f}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -175,7 +166,7 @@ R3D_Mesh R3D_GenMeshSlope(float width, float height, float length, Vector3 slope
         { width * 0.5f,  height * 0.5f,  length * 0.5f}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -193,7 +184,7 @@ R3D_Mesh R3D_GenMeshSphere(float radius, int rings, int slices)
         { radius,  radius,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -211,7 +202,7 @@ R3D_Mesh R3D_GenMeshHemiSphere(float radius, int rings, int slices)
         { radius, radius,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -229,7 +220,7 @@ R3D_Mesh R3D_GenMeshCylinder(float radius, float height, int slices)
         { radius,  height * 0.5f,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -249,7 +240,7 @@ R3D_Mesh R3D_GenMeshCylinderEx(float bottomRadius, float topRadius, float height
         { radius,  height * 0.5f,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -267,7 +258,7 @@ R3D_Mesh R3D_GenMeshCapsule(float radius, float height, int rings, int slices)
         { radius,  height + radius,  radius}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -285,7 +276,7 @@ R3D_Mesh R3D_GenMeshTorus(float radius, float size, int radSeg, int sides)
         { radius + size,  size,  radius + size}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -303,7 +294,7 @@ R3D_Mesh R3D_GenMeshKnot(float radius, float size, int radSeg, int sides)
         { radius + size,  size,  radius + size}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -321,7 +312,7 @@ R3D_Mesh R3D_GenMeshHeightmap(Image heightmap, Vector3 size)
         { size.x * 0.5f, size.y,  size.z * 0.5f}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -339,7 +330,7 @@ R3D_Mesh R3D_GenMeshCubicmap(Image cubicmap, Vector3 cubeSize)
         {cubicmap.width * cubeSize.x, cubeSize.y, cubicmap.height * cubeSize.z}
     };
 
-    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb, R3D_STATIC_MESH);
+    mesh = R3D_LoadMesh(R3D_PRIMITIVE_TRIANGLES, data, &aabb);
     R3D_UnloadMeshData(data);
 
     return mesh;
@@ -347,7 +338,7 @@ R3D_Mesh R3D_GenMeshCubicmap(Image cubicmap, Vector3 cubeSize)
 
 bool R3D_UpdateMesh(R3D_Mesh* mesh, R3D_MeshData data, const BoundingBox* aabb)
 {
-    if (!mesh || mesh->vao == 0 || mesh->vbo == 0 || mesh->ebo == 0) {
+    if (!mesh) {
         R3D_TRACELOG(LOG_WARNING, "Cannot update mesh; Invalid mesh instance");
         return false;
     }
@@ -357,33 +348,29 @@ bool R3D_UpdateMesh(R3D_Mesh* mesh, R3D_MeshData data, const BoundingBox* aabb)
         return false;
     }
 
-    GLenum glUsage = get_opengl_usage(mesh->usage);
-
-    glBindVertexArray(mesh->vao);
-    glBindBuffer(GL_ARRAY_BUFFER, mesh->vbo);
-
     if (mesh->vertexCapacity < data.vertexCount) {
-        glBufferData(GL_ARRAY_BUFFER, data.vertexCount * sizeof(R3D_Vertex), data.vertices, glUsage);
-        mesh->vertexCapacity = data.vertexCount;
+        if (!r3d_render_realloc_vertices(&mesh->vertexOffset, &mesh->vertexCapacity, data.vertexCount, false)) {
+            R3D_TRACELOG(LOG_WARNING, "Cannot update mesh; Vertex reallocation failed");
+            return false;
+        }
     }
-    else {
-        glBufferSubData(GL_ARRAY_BUFFER, 0, data.vertexCount * sizeof(R3D_Vertex), data.vertices);
-    }
+    r3d_render_upload_vertices(mesh->vertexOffset, data.vertices, data.vertexCount);
 
     if (data.indexCount > 0) {
         if (mesh->indexCapacity < data.indexCount) {
-            glBufferData(GL_ELEMENT_ARRAY_BUFFER, data.indexCount * sizeof(uint32_t), data.indices, glUsage);
-            mesh->indexCapacity = data.indexCount;
+            if (!r3d_render_realloc_elements(&mesh->indexOffset, &mesh->indexCapacity, data.indexCount, false)) {
+                R3D_TRACELOG(LOG_WARNING, "Cannot update mesh; Element reallocation failed");
+                return false;
+            }
         }
-        else {
-            glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, data.indexCount * sizeof(uint32_t), data.indices);
-        }
+        r3d_render_upload_elements(mesh->indexOffset, data.indices, data.indexCount);
     }
-
-    glBindVertexArray(0);
 
     mesh->vertexCount = data.vertexCount;
     mesh->indexCount = data.indexCount;
+
+    mesh->aabb = (aabb != NULL) ? *aabb
+        : R3D_CalculateMeshDataBoundingBox(data);
 
     return true;
 }

--- a/src/r3d_sky.c
+++ b/src/r3d_sky.c
@@ -47,6 +47,7 @@ R3D_Cubemap R3D_GenCustomSky(int size, R3D_SkyShader* shader)
 void R3D_UpdateProceduralSky(R3D_Cubemap* cubemap, R3D_ProceduralSky params)
 {
     r3d_driver_invalidate_cache();
+    r3d_driver_store_viewport();
 
     Matrix matProj = MatrixPerspective(90.0 * DEG2RAD, 1.0, 0.1, 10.0);
 
@@ -55,6 +56,7 @@ void R3D_UpdateProceduralSky(R3D_Cubemap* cubemap, R3D_ProceduralSky params)
 
     R3D_SHADER_USE(prepare.cubemapProceduralSky);
     r3d_driver_disable(GL_CULL_FACE);
+    r3d_render_prepare_drawing();
 
     R3D_SHADER_SET_MAT4(prepare.cubemapProceduralSky, uMatProj, matProj);
     R3D_SHADER_SET_COL3(prepare.cubemapProceduralSky, uSkyTopColor, R3D.colorSpace, params.skyTopColor);
@@ -73,17 +75,17 @@ void R3D_UpdateProceduralSky(R3D_Cubemap* cubemap, R3D_ProceduralSky params)
 
     for (int i = 0; i < 6; i++) {
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, cubemap->texture, 0);
-        glClear(GL_DEPTH_BUFFER_BIT);
-
         R3D_SHADER_SET_MAT4(prepare.cubemapProceduralSky, uMatView, R3D.matCubeViews[i]);
         R3D_RENDER_CUBE();
     }
 
     r3d_cubemap_gen_mipmap(cubemap);
 
-    glViewport(0, 0, rlGetFramebufferWidth(), rlGetFramebufferHeight());
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glBindVertexArray(0);
+
     r3d_driver_enable(GL_CULL_FACE);
+    r3d_driver_restore_viewport();
 }
 
 void R3D_UpdateCustomSky(R3D_Cubemap* cubemap, R3D_SkyShader* shader)
@@ -94,6 +96,7 @@ void R3D_UpdateCustomSky(R3D_Cubemap* cubemap, R3D_SkyShader* shader)
     }
 
     r3d_driver_invalidate_cache();
+    r3d_driver_store_viewport();
 
     Matrix matProj = MatrixPerspective(90.0 * DEG2RAD, 1.0, 0.1, 10.0);
 
@@ -102,20 +105,21 @@ void R3D_UpdateCustomSky(R3D_Cubemap* cubemap, R3D_SkyShader* shader)
 
     R3D_SHADER_USE_CUSTOM(shader, prepare.cubemapCustomSky);
     r3d_driver_disable(GL_CULL_FACE);
+    r3d_render_prepare_drawing();
 
     R3D_SHADER_SET_MAT4_CUSTOM(shader, prepare.cubemapCustomSky, uMatProj, matProj);
 
     for (int i = 0; i < 6; i++) {
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, cubemap->texture, 0);
-        glClear(GL_DEPTH_BUFFER_BIT);
-
         R3D_SHADER_SET_MAT4_CUSTOM(shader, prepare.cubemapCustomSky, uMatView, R3D.matCubeViews[i]);
         R3D_RENDER_CUBE();
     }
 
     r3d_cubemap_gen_mipmap(cubemap);
 
-    glViewport(0, 0, rlGetFramebufferWidth(), rlGetFramebufferHeight());
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glBindVertexArray(0);
+
     r3d_driver_enable(GL_CULL_FACE);
+    r3d_driver_restore_viewport();
 }


### PR DESCRIPTION
### What changed

Previously every `R3D_Mesh` and built-in shape owned its own VAO/VBO/EBO. This PR replaces that with a single global VAO/VBO/EBO shared across all meshes and shapes. Meshes now hold `vertexOffset` and `indexOffset` into the global buffers instead of owning GL handles directly.

A free list allocator manages vertex and index ranges, with in-place extension and relocation support (`alloc`, `realloc`, `free`, `upload`). GPU buffer growth is handled via `glCopyBufferSubData`.

**Breaking API changes:**
- `R3D_Mesh` no longer exposes `vao`, `vbo`, `ebo`, replaced by `vertexOffset` and `indexOffset`
- `R3D_LoadMesh` no longer takes a `R3D_MeshUsage` parameter, internal buffers are always `GL_DYNAMIC_DRAW`
- `R3D_MeshUsage` enum has been removed

### What remains

- Instance buffers follow the same old per-object pattern and will be possibly reviewed in a follow-up