### PR TITLE
Add instance buffer resize and VAO instance state cache

### DIFF
--- a/include/r3d/r3d_instance.h
+++ b/include/r3d/r3d_instance.h
@@ -10,6 +10,7 @@
 #define R3D_INSTANCE_H
 
 #include "./r3d_platform.h"
+#include <raylib.h>
 #include <stdint.h>
 
 /**
@@ -75,6 +76,20 @@ R3DAPI R3D_InstanceBuffer R3D_LoadInstanceBuffer(int capacity, R3D_InstanceFlags
  * @brief Destroy all GPU buffers owned by this instance buffer.
  */
 R3DAPI void R3D_UnloadInstanceBuffer(R3D_InstanceBuffer buffer);
+
+/**
+ * @brief Grow the GPU buffers of an instance buffer to a new capacity.
+ *
+ * Only expands; if newCapacity <= buffer->capacity the call is a no-op.
+ * All attribute buffers present in buffer->flags are reallocated and
+ * if keepData is true, their existing content is copied to the new
+ * buffers before the old ones are deleted.
+ *
+ * @param buffer Instance buffer to resize (updated in place).
+ * @param newCapacity Desired minimum capacity in number of instances.
+ * @param keepData If true, preserves existing instance data.
+ */
+R3DAPI void R3D_ResizeInstanceBuffer(R3D_InstanceBuffer* buffer, int newCapacity, bool keepData);
 
 /**
  * @brief Upload a contiguous range of instance data.

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -1486,7 +1486,10 @@ void r3d_render_draw_shape(r3d_render_shape_enum_t shape)
         glBindVertexArray(R3D_MOD_RENDER.globalVao);
     }
 
-    if (s->elements.count > 0) {
+    if (s->elements.count == 0) {
+        glDrawArrays(GL_TRIANGLES, s->vertices.offset, s->vertices.count);
+    }
+    else {
         glDrawElementsBaseVertex(
             GL_TRIANGLES,
             s->elements.count,
@@ -1494,8 +1497,5 @@ void r3d_render_draw_shape(r3d_render_shape_enum_t shape)
             (void*)(s->elements.offset * sizeof(GLuint)),
             s->vertices.offset
         );
-    }
-    else {
-        glDrawArrays(GL_TRIANGLES, s->vertices.offset, s->vertices.count);
     }
 }

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -35,9 +35,11 @@ struct r3d_mod_render R3D_MOD_RENDER;
  * Reconfigures all vertex attribute pointers on the global VAO after a VBO resize.
  * Must be called with the global VAO already bound.
  */
-static void reconfigure_global_vao_attribs(void)
+static void configure_global_vao_attributes(bool rebindVbo, bool configInstances)
 {
-    glBindBuffer(GL_ARRAY_BUFFER, R3D_MOD_RENDER.globalVbo);
+    if (rebindVbo) {
+        glBindBuffer(GL_ARRAY_BUFFER, R3D_MOD_RENDER.globalVbo);
+    }
 
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, position));
@@ -59,6 +61,20 @@ static void reconfigure_global_vao_attribs(void)
 
     glEnableVertexAttribArray(6);
     glVertexAttribPointer(6, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, weights));
+
+    if (configInstances) {
+        glVertexAttribDivisor(10, 1);
+        glVertexAttribDivisor(11, 1);
+        glVertexAttribDivisor(12, 1);
+        glVertexAttribDivisor(13, 1);
+        glVertexAttribDivisor(14, 1);
+
+        glVertexAttrib3f(10, 0.0f, 0.0f, 0.0f);
+        glVertexAttrib4f(11, 0.0f, 0.0f, 0.0f, 1.0f);
+        glVertexAttrib3f(12, 1.0f, 1.0f, 1.0f);
+        glVertexAttrib4f(13, 1.0f, 1.0f, 1.0f, 1.0f);
+        glVertexAttrib4f(14, 0.0f, 0.0f, 0.0f, 0.0f);
+    }
 }
 
 /*
@@ -93,7 +109,7 @@ static bool grow_global_vbo(int minCapacity)
 
     // Reconfigure the assignments on the new VBO
     glBindVertexArray(R3D_MOD_RENDER.globalVao);
-    reconfigure_global_vao_attribs();
+    configure_global_vao_attributes(true, false);
     glBindVertexArray(0);
 
     return true;
@@ -385,10 +401,19 @@ void load_shape_cube(r3d_render_shape_t* shape)
 
 static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT], R3D_InstanceFlags flags, int offset)
 {
+    r3d_render_instance_state_t* state = &R3D_MOD_RENDER.instanceState;
+
+    if (flags == state->flags && offset == state->offset &&
+        memcmp(buffers, state->buffers, R3D_INSTANCE_ATTRIBUTE_COUNT * sizeof(GLuint)) == 0) {
+        return;
+    }
+
+    memcpy(state->buffers, buffers, R3D_INSTANCE_ATTRIBUTE_COUNT * sizeof(GLuint));
+    state->flags = flags, state->offset = offset;
+
     if (BIT_TEST(flags, R3D_INSTANCE_POSITION)) {
         glBindBuffer(GL_ARRAY_BUFFER, buffers[0]);
         glEnableVertexAttribArray(10);
-        glVertexAttribDivisor(10, 1);
         glVertexAttribPointer(10, 3, GL_FLOAT, GL_FALSE, sizeof(Vector3), (void*)(offset * sizeof(Vector3)));
     }
     else {
@@ -398,7 +423,6 @@ static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT],
     if (BIT_TEST(flags, R3D_INSTANCE_ROTATION)) {
         glBindBuffer(GL_ARRAY_BUFFER, buffers[1]);
         glEnableVertexAttribArray(11);
-        glVertexAttribDivisor(11, 1);
         glVertexAttribPointer(11, 4, GL_FLOAT, GL_FALSE, sizeof(Quaternion), (void*)(offset * sizeof(Quaternion)));
     }
     else {
@@ -408,7 +432,6 @@ static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT],
     if (BIT_TEST(flags, R3D_INSTANCE_SCALE)) {
         glBindBuffer(GL_ARRAY_BUFFER, buffers[2]);
         glEnableVertexAttribArray(12);
-        glVertexAttribDivisor(12, 1);
         glVertexAttribPointer(12, 3, GL_FLOAT, GL_FALSE, sizeof(Vector3), (void*)(offset * sizeof(Vector3)));
     }
     else {
@@ -418,7 +441,6 @@ static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT],
     if (BIT_TEST(flags, R3D_INSTANCE_COLOR)) {
         glBindBuffer(GL_ARRAY_BUFFER, buffers[3]);
         glEnableVertexAttribArray(13);
-        glVertexAttribDivisor(13, 1);
         glVertexAttribPointer(13, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(Color), (void*)(offset * sizeof(Color)));
     }
     else {
@@ -428,7 +450,6 @@ static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT],
     if (BIT_TEST(flags, R3D_INSTANCE_CUSTOM)) {
         glBindBuffer(GL_ARRAY_BUFFER, buffers[4]);
         glEnableVertexAttribArray(14);
-        glVertexAttribDivisor(14, 1);
         glVertexAttribPointer(14, 4, GL_FLOAT, GL_FALSE, sizeof(Vector4), (void*)(offset * sizeof(Vector4)));
     }
     else {
@@ -438,6 +459,8 @@ static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT],
 
 static void disable_instances(R3D_InstanceFlags flags)
 {
+    memset(&R3D_MOD_RENDER.instanceState, 0, sizeof(R3D_MOD_RENDER.instanceState));
+
     if (BIT_TEST(flags, R3D_INSTANCE_POSITION)) {
         glDisableVertexAttribArray(10);
     }
@@ -873,34 +896,7 @@ bool r3d_render_init(void)
 
     /* --- Configuring vertex attributes --- */
 
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, position));
-
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, texcoord));
-
-    glEnableVertexAttribArray(2);
-    glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, normal));
-
-    glEnableVertexAttribArray(3);
-    glVertexAttribPointer(3, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, color));
-
-    glEnableVertexAttribArray(4);
-    glVertexAttribPointer(4, 4, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, tangent));
-
-    glEnableVertexAttribArray(5);
-    glVertexAttribIPointer(5, 4, GL_UNSIGNED_BYTE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, boneIds));
-
-    glEnableVertexAttribArray(6);
-    glVertexAttribPointer(6, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, weights));
-
-    // Default values ​​for instance attributes (disabled)
-    glVertexAttrib3f(10, 0.0f, 0.0f, 0.0f);
-    glVertexAttrib4f(11, 0.0f, 0.0f, 0.0f, 1.0f);
-    glVertexAttrib3f(12, 1.0f, 1.0f, 1.0f);
-    glVertexAttrib4f(13, 1.0f, 1.0f, 1.0f, 1.0f);
-    glVertexAttrib4f(14, 0.0f, 0.0f, 0.0f, 0.0f);
-
+    configure_global_vao_attributes(false, true);
     glBindVertexArray(0);
 
     return true;
@@ -1475,7 +1471,11 @@ void r3d_render_draw_instanced(const r3d_render_call_t* call)
         );
     }
 
-    disable_instances(group->instances.flags);
+    // Instance attributes (locations 10-14) are intentionally left enabled after
+    // the draw. This is safe as long as non-instanced vertex shaders
+    // never read those locations.
+
+    //disable_instances(group->instances.flags);
 }
 
 void r3d_render_draw_shape(r3d_render_shape_enum_t shape)

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -32,8 +32,9 @@ struct r3d_mod_render R3D_MOD_RENDER;
 // ========================================
 
 /*
- * Reconfigures all vertex attribute pointers on the global VAO after a VBO resize.
- * Must be called with the global VAO already bound.
+ * Sets up vertex attribute pointers on the global VAO (already bound).
+ * Pass rebindVbo=true after a VBO resize to update the stored buffer ID.
+ * Pass configInstances=true only at init to set divisors and default values.
  */
 static void configure_global_vao_attributes(bool rebindVbo, bool configInstances)
 {

--- a/src/modules/r3d_render.h
+++ b/src/modules/r3d_render.h
@@ -153,6 +153,18 @@ typedef enum {
 // ========================================
 
 /*
+ * Cached state of the per-instance vertex attribute bindings.
+ * Compared before each instanced draw call to avoid redundant
+ * GL attribute reconfiguration when consecutive draw calls share
+ * the same instance group.
+ */
+typedef struct {
+    GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT];
+    R3D_InstanceFlags flags;
+    int offset;
+} r3d_render_instance_state_t;
+
+/*
  * Interval [offset, offset+count) into the global VBO or EBO.
  */
 typedef struct {
@@ -292,6 +304,7 @@ extern struct r3d_mod_render {
     int freeVertexCapacity;                             //< Allocated capacity of the vertex free list array
     int freeElementCapacity;                            //< Allocated capacity of the element free list array
 
+    r3d_render_instance_state_t instanceState;          //< Cached instance binding configuration
     r3d_render_shape_t shapes[R3D_RENDER_SHAPE_COUNT];  //< Array of built-in shapes buffers
 
     r3d_render_cluster_t* clusters;                     //< Array of render clusters

--- a/src/r3d_instance.c
+++ b/src/r3d_instance.c
@@ -10,6 +10,7 @@
 #include <r3d_config.h>
 #include <raylib.h>
 #include <stddef.h>
+#include <string.h>
 #include <glad.h>
 
 #include "./common/r3d_helper.h"
@@ -56,6 +57,34 @@ R3D_InstanceBuffer R3D_LoadInstanceBuffer(int capacity, R3D_InstanceFlags flags)
 void R3D_UnloadInstanceBuffer(R3D_InstanceBuffer buffer)
 {
     glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, buffer.buffers);
+}
+
+void R3D_ResizeInstanceBuffer(R3D_InstanceBuffer* buffer, int newCapacity, bool keepData)
+{
+    if (newCapacity <= buffer->capacity) {
+        return;
+    }
+
+    GLuint newBuffers[R3D_INSTANCE_ATTRIBUTE_COUNT] = {0};
+    glGenBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+
+    for (int i = 0; i < R3D_INSTANCE_ATTRIBUTE_COUNT; i++) {
+        if (!BIT_TEST(buffer->flags, 1 << i)) continue;
+
+        int newSize = newCapacity * (int)INSTANCE_ATTRIBUTE_SIZE[i];
+        glBindBuffer(GL_COPY_WRITE_BUFFER, newBuffers[i]);
+        glBufferData(GL_COPY_WRITE_BUFFER, newSize, NULL, GL_DYNAMIC_DRAW);
+
+        if (keepData && buffer->capacity > 0) {
+            int oldSize = buffer->capacity * (int)INSTANCE_ATTRIBUTE_SIZE[i];
+            glBindBuffer(GL_COPY_READ_BUFFER, buffer->buffers[i]);
+            glCopyBufferSubData(GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER, 0, 0, oldSize);
+        }
+    }
+
+    glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, buffer->buffers);
+    memcpy(buffer->buffers, newBuffers, R3D_INSTANCE_ATTRIBUTE_COUNT * sizeof(GLuint));
+    buffer->capacity = newCapacity;
 }
 
 void R3D_UploadInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag, int offset, int count, void* data)


### PR DESCRIPTION
- Add `R3D_ResizeInstanceBuffer()` to grow instance attribute buffers, with optional data preservation via `glCopyBufferSubData`
- Cache the active instance attribute state (buffers, flags, offset) in the render module to skip redundant VAO reconfiguration when consecutive instanced draw calls share the same group
- Move instance attribute divisor setup (locations 10-14) to init via `configure_global_vao_attributes()`, removing the per-draw `glVertexAttribDivisor` calls