### PR TITLE
Optimize vertex layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,7 @@ add_library(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/src/r3d_skeleton.c"
     "${R3D_ROOT_PATH}/src/r3d_sky.c"
     "${R3D_ROOT_PATH}/src/r3d_utils.c"
+    "${R3D_ROOT_PATH}/src/r3d_vertex.c"
     "${R3D_ROOT_PATH}/src/r3d_visibility.c"
 )
 

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -10,6 +10,7 @@
 #define R3D_MESH_DATA_H
 
 #include "./r3d_platform.h"
+#include "./r3d_vertex.h"
 #include <raylib.h>
 #include <stdint.h>
 
@@ -38,20 +39,6 @@ typedef enum R3D_PrimitiveType {
 // ========================================
 // STRUCTS TYPES
 // ========================================
-
-/**
- * @brief Represents a vertex and all its attributes for a mesh.
- */
-typedef struct R3D_Vertex {
-    Vector3 position;       ///< The 3D position of the vertex in object space.
-    Vector2 texcoord;       ///< The 2D texture coordinates (UV) for mapping textures.
-    Vector3 normal;         ///< The normal vector used for lighting calculations.
-    Color color;            ///< Vertex color, in RGBA32.
-    Vector4 tangent;        ///< The tangent vector, used in normal mapping (often with a handedness in w).
-    uint8_t boneIds[4];     ///< Indices of up to 4 bones that influence this vertex (for skinning).
-    uint8_t weights[4];     ///< Corresponding bone weights (should sum to 255). Defines the influence of each bone.
-    uint8_t pad[4];         ///< Not used, reserved.
-} R3D_Vertex;
 
 /**
  * @brief Represents a mesh stored in CPU memory.

--- a/include/r3d/r3d_vertex.h
+++ b/include/r3d/r3d_vertex.h
@@ -1,0 +1,105 @@
+/* r3d_vertex.h -- R3D Vertex Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#ifndef R3D_VERTEX_H
+#define R3D_VERTEX_H
+
+#include "./r3d_platform.h"
+#include <raylib.h>
+#include <stdint.h>
+
+/**
+ * @defgroup Vertex
+ * @{
+ */
+
+// ========================================
+// STRUCTS TYPES
+// ========================================
+
+/**
+ * @brief Represents a vertex and all its attributes for a mesh.
+ */
+typedef struct R3D_Vertex {
+    Vector3 position;           ///< The 3D position of the vertex in object space.
+    uint16_t texcoord[2];       ///< The 2D texture coordinates (UV) for mapping textures.
+    int8_t normal[4];           ///< The normal vector used for lighting calculations.
+    int8_t tangent[4];          ///< The tangent vector, used in normal mapping (often with a handedness in w).
+    Color color;                ///< Vertex color, in RGBA32.
+    uint8_t boneIndices[4];     ///< Indices of up to 4 bones that influence this vertex (for skinning).
+    uint8_t boneWeights[4];     ///< Corresponding bone weights (should sum to 255). Defines the influence of each bone.
+} R3D_Vertex;
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Constructs a fully encoded @ref R3D_Vertex from unpacked attribute data.
+ * @param position Vertex position in object space.
+ * @param texcoord UV texture coordinates (float, any range).
+ * @param normal Unit normal vector.
+ * @param tangent Tangent vector with handedness in w (+1 or -1).
+ * @param color Vertex color in RGBA8.
+ * @return Encoded vertex ready for GPU upload.
+ */
+R3DAPI R3D_Vertex R3D_MakeVertex(Vector3 position, Vector2 texcoord, Vector3 normal, Vector4 tangent, Color color);
+
+/**
+ * @brief Encodes a UV coordinate pair from float32 to float16.
+ * @param dst Output buffer of 2 uint16_t (float16). Must not be NULL.
+ * @param src UV coordinates in float32. Supports any range (tiling included).
+ */
+R3DAPI void R3D_EncodeTexCoord(uint16_t* dst, Vector2 src);
+
+/**
+ * @brief Decodes a float16 UV coordinate pair back to float32.
+ * @param src Input buffer of 2 uint16_t (float16). Must not be NULL.
+ * @return Decoded UV coordinates in float32.
+ */
+R3DAPI Vector2 R3D_DecodeTexCoord(const uint16_t* src);
+
+/**
+ * @brief Encodes a unit normal vector from float32 to snorm8 (XYZ).
+ * @param dst Output buffer of 4 int8_t. W is set to 0. Must not be NULL.
+ * @param src Unit normal vector. Components must be in [-1, 1].
+ */
+R3DAPI void R3D_EncodeNormal(int8_t* dst, Vector3 src);
+
+/**
+ * @brief Decodes a snorm8 normal back to float32.
+ * @param src Input buffer of 4 int8_t (only XYZ are read). Must not be NULL.
+ * @return Decoded normal vector. Not guaranteed to be unit length.
+ */
+R3DAPI Vector3 R3D_DecodeNormal(const int8_t* src);
+
+/**
+ * @brief Encodes a tangent vector from float32 to snorm8, preserving handedness in W.
+ * @param dst Output buffer of 4 int8_t. Must not be NULL.
+ * @param src Tangent vector. XYZ must be in [-1, 1]; W encodes handedness (+1 or -1).
+ */
+R3DAPI void R3D_EncodeTangent(int8_t* dst, Vector4 src);
+
+/**
+ * @brief Decodes a snorm8 tangent back to float32.
+ * @param src Input buffer of 4 int8_t. Must not be NULL.
+ * @return Decoded tangent. W is exactly +1.0 or -1.0 (handedness).
+ */
+R3DAPI Vector4 R3D_DecodeTangent(const int8_t* src);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+/** @} */ // end of MeshData
+
+#endif // R3D_VERTEX_H

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -26,10 +26,10 @@
 layout(location = 0) in vec3 aPosition;
 layout(location = 1) in vec2 aTexCoord;
 layout(location = 2) in vec3 aNormal;
-layout(location = 3) in vec4 aColor;
-layout(location = 4) in vec4 aTangent;
-layout(location = 5) in ivec4 aBoneIDs;
-layout(location = 6) in vec4 aWeights;
+layout(location = 3) in vec4 aTangent;
+layout(location = 4) in vec4 aColor;
+layout(location = 5) in ivec4 aBoneIndices;
+layout(location = 6) in vec4 aBoneWeights;
 
 layout(location = 10) in vec3 iPosition;
 layout(location = 11) in vec4 iRotation;
@@ -181,7 +181,7 @@ void main()
 
 #if !defined(DECAL)
     if (uSkinning) {
-        mat4 sMatModel = SkinMatrix(aBoneIDs, aWeights);
+        mat4 sMatModel = SkinMatrix(aBoneIndices, aBoneWeights);
         mat3 sMatNormal = mat3(transpose(inverse(sMatModel)));
         localPosition = vec3(sMatModel * vec4(localPosition, 1.0));
         localNormal = sMatNormal * localNormal;

--- a/src/common/r3d_half.h
+++ b/src/common/r3d_half.h
@@ -17,7 +17,7 @@ typedef uint16_t r3d_half_t;
 
 /* === Float type 16 bits === */
 
-static inline uint16_t r3d_cvt_fhi(uint32_t ui)
+static inline uint16_t r3d_half_from_float_ui(uint32_t ui)
 {
     int32_t s = (ui >> 16) & 0x8000;
     int32_t em = ui & 0x7fffffff;
@@ -37,7 +37,7 @@ static inline uint16_t r3d_cvt_fhi(uint32_t ui)
     return (uint16_t)(s | h);
 }
 
-static inline uint32_t r3d_cvt_hfi(uint16_t h)
+static inline uint32_t r3d_half_to_float_ui(uint16_t h)
 {
     uint32_t s = (unsigned)(h & 0x8000) << 16;
     int32_t em = h & 0x7fff;
@@ -55,17 +55,17 @@ static inline uint32_t r3d_cvt_hfi(uint16_t h)
     return s | r;
 }
 
-static inline r3d_half_t r3d_cvt_fh(float i)
+static inline r3d_half_t r3d_half_from_float(float i)
 {
     union { float f; uint32_t i; } v;
     v.f = i;
-    return r3d_cvt_fhi(v.i);
+    return r3d_half_from_float_ui(v.i);
 }
 
-static inline float r3d_cvt_hf(r3d_half_t y)
+static inline float r3d_half_to_float(r3d_half_t y)
 {
     union { float f; uint32_t i; } v;
-    v.i = r3d_cvt_hfi(y);
+    v.i = r3d_half_to_float_ui(y);
     return v.f;
 }
 

--- a/src/importer/r3d_importer_mesh.c
+++ b/src/importer/r3d_importer_mesh.c
@@ -39,10 +39,10 @@ static inline void process_vertex_position(Vector3* position, const struct aiVec
     aabb->max = Vector3Max(aabb->max, gPosition);
 }
 
-static inline void process_vertex_texcoord(Vector2* texcoord, const struct aiMesh* aiMesh, int index)
+static inline void process_vertex_texcoord(uint16_t* texcoord, const struct aiMesh* aiMesh, int index)
 {
     if (aiMesh->mTextureCoords[0] && aiMesh->mNumUVComponents[0] >= 2) {
-        *texcoord = r3d_importer_cast_to_vector2(aiMesh->mTextureCoords[0][index]);
+        R3D_EncodeTexCoord(texcoord, r3d_importer_cast_to_vector2(aiMesh->mTextureCoords[0][index]));
     }
     // NOTE: Vertices are zero-initialized
     //else {
@@ -50,23 +50,24 @@ static inline void process_vertex_texcoord(Vector2* texcoord, const struct aiMes
     //}
 }
 
-static inline void process_vertex_normal(Vector3* normal, const struct aiMesh* aiMesh, int index, const Matrix* normalMatrix, bool hasBones)
+static inline void process_vertex_normal(int8_t* normal, const struct aiMesh* aiMesh, int index, const Matrix* normalMatrix, bool hasBones)
 {
     if (aiMesh->mNormals) {
-        *normal = r3d_importer_cast(aiMesh->mNormals[index]);
+        Vector3 vec = r3d_importer_cast(aiMesh->mNormals[index]);
         if (!hasBones) {
-            *normal = r3d_vector3_transform_linear(*normal, normalMatrix);
+            vec = r3d_vector3_transform_linear(vec, normalMatrix);
         }
+        R3D_EncodeNormal(normal, vec);
     }
     else {
-        *normal = (Vector3) {0.0f, 0.0f, 1.0f};
+        R3D_EncodeNormal(normal, (Vector3){0.0f, 0.0f, 1.0f});
     }
 }
 
 static inline void process_vertex_tangent(R3D_Vertex* vertex, const struct aiMesh* aiMesh, int index, const Matrix* normalMatrix, bool hasBones)
 {
     if (aiMesh->mNormals && aiMesh->mTangents && aiMesh->mBitangents) {
-        Vector3 normal = vertex->normal;
+        Vector3 normal = R3D_DecodeNormal(vertex->normal);
         Vector3 tangent = r3d_importer_cast(aiMesh->mTangents[index]);
         Vector3 bitangent = r3d_importer_cast(aiMesh->mBitangents[index]);
 
@@ -77,10 +78,10 @@ static inline void process_vertex_tangent(R3D_Vertex* vertex, const struct aiMes
 
         Vector3 reconstructedBitangent = Vector3CrossProduct(normal, tangent);
         float handedness = Vector3DotProduct(reconstructedBitangent, bitangent);
-        vertex->tangent = (Vector4) {tangent.x, tangent.y, tangent.z, copysignf(1.0f, handedness)};
+        R3D_EncodeTangent(vertex->tangent, (Vector4){tangent.x, tangent.y, tangent.z, copysignf(1.0f, handedness)});
     }
     else {
-        vertex->tangent = (Vector4) {1.0f, 0.0f, 0.0f, 1.0f};
+        R3D_EncodeTangent(vertex->tangent, (Vector4){1.0f, 0.0f, 0.0f, 1.0f});
     }
 }
 
@@ -115,13 +116,12 @@ static void process_indices(const struct aiMesh* aiMesh, R3D_MeshData* data)
 
 static inline bool assign_bone_weight(R3D_Vertex* vertex, uint32_t boneIndex, uint8_t weightValue)
 {
-    int emptySlot = -1;
-    int minWeightSlot = 0;
-    uint8_t minWeight = vertex->weights[0];
+    int emptySlot = -1, minWeightSlot = 0;
+    uint8_t minWeight = vertex->boneWeights[0];
 
     // Pass to find both empty slot and minimum weight
     for (int slot = 1; slot < MAX_BONE_WEIGHTS; slot++) {
-        uint8_t w = vertex->weights[slot];
+        uint8_t w = vertex->boneWeights[slot];
         if (w == 0 && emptySlot == -1) {
             emptySlot = slot;
         }
@@ -133,15 +133,15 @@ static inline bool assign_bone_weight(R3D_Vertex* vertex, uint32_t boneIndex, ui
 
     // Use empty slot if available
     if (emptySlot != -1) {
-        vertex->weights[emptySlot] = weightValue;
-        vertex->boneIds[emptySlot] = boneIndex;
+        vertex->boneIndices[emptySlot] = boneIndex;
+        vertex->boneWeights[emptySlot] = weightValue;
         return true;
     }
 
     // All slots occupied - replace if new weight is larger
     if (weightValue > minWeight) {
-        vertex->weights[minWeightSlot] = weightValue;
-        vertex->boneIds[minWeightSlot] = boneIndex;
+        vertex->boneIndices[minWeightSlot] = boneIndex;
+        vertex->boneWeights[minWeightSlot] = weightValue;
         return true;
     }
 
@@ -150,20 +150,20 @@ static inline bool assign_bone_weight(R3D_Vertex* vertex, uint32_t boneIndex, ui
 
 static void normalize_bone_weights(R3D_Vertex* vertex)
 {
-    uint32_t sum = (uint32_t)vertex->weights[0] + (uint32_t)vertex->weights[1] +
-                   (uint32_t)vertex->weights[2] + (uint32_t)vertex->weights[3];
+    uint32_t sum = (uint32_t)vertex->boneWeights[0] + (uint32_t)vertex->boneWeights[1] +
+                   (uint32_t)vertex->boneWeights[2] + (uint32_t)vertex->boneWeights[3];
 
     if (sum == 255) return;
 
     if (sum > 0) {
         uint32_t half = sum >> 1; // nearest rounding
-        vertex->weights[0] = (uint8_t)((vertex->weights[0] * 255 + half) / sum);
-        vertex->weights[1] = (uint8_t)((vertex->weights[1] * 255 + half) / sum);
-        vertex->weights[2] = (uint8_t)((vertex->weights[2] * 255 + half) / sum);
-        vertex->weights[3] = (uint8_t)((vertex->weights[3] * 255 + half) / sum);
+        vertex->boneWeights[0] = (uint8_t)((vertex->boneWeights[0] * 255 + half) / sum);
+        vertex->boneWeights[1] = (uint8_t)((vertex->boneWeights[1] * 255 + half) / sum);
+        vertex->boneWeights[2] = (uint8_t)((vertex->boneWeights[2] * 255 + half) / sum);
+        vertex->boneWeights[3] = (uint8_t)((vertex->boneWeights[3] * 255 + half) / sum);
     }
     else {
-        vertex->weights[0] = 255;
+        vertex->boneWeights[0] = 255;
     }
 }
 
@@ -172,15 +172,15 @@ static bool process_bones(const struct aiMesh* aiMesh, R3D_MeshData* data, int v
     if (aiMesh->mNumBones == 0) {
         // No bones - initialize default weights
         for (int i = 0; i < vertexCount; i++) {
-            data->vertices[i].weights[0] = 255;
+            data->vertices[i].boneWeights[0] = 255;
         }
         return true;
     }
 
     // Check if the mesh has too many bones
-    if (aiMesh->mNumBones > MAX_OF(*data->vertices->boneIds) + 1) {
+    if (aiMesh->mNumBones > MAX_OF(*data->vertices->boneIndices) + 1) {
         R3D_TRACELOG(LOG_WARNING, "Mesh has %u bones, max %d supported",
-            aiMesh->mNumBones, MAX_OF(*data->vertices->boneIds) + 1);
+            aiMesh->mNumBones, MAX_OF(*data->vertices->boneIndices) + 1);
         return false;
     }
 
@@ -295,8 +295,8 @@ static bool load_mesh_internal(
     for (int i = 0; i < vertexCount; i++) {
         R3D_Vertex* vertex = &data.vertices[i];
         process_vertex_position(&vertex->position, &aiMesh->mVertices[i], &transform, hasBones, &aabb);
-        process_vertex_texcoord(&vertex->texcoord, aiMesh, i);
-        process_vertex_normal(&vertex->normal, aiMesh, i, &normalMatrix, hasBones);
+        process_vertex_texcoord(vertex->texcoord, aiMesh, i);
+        process_vertex_normal(vertex->normal, aiMesh, i, &normalMatrix, hasBones);
         process_vertex_tangent(vertex, aiMesh, i, &normalMatrix, hasBones);
         process_vertex_color(&vertex->color, aiMesh, i);
     }

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -46,22 +46,22 @@ static void configure_global_vao_attributes(bool rebindVbo, bool configInstances
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, position));
 
     glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, texcoord));
+    glVertexAttribPointer(1, 2, GL_HALF_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, texcoord));
 
     glEnableVertexAttribArray(2);
-    glVertexAttribPointer(2, 3, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, normal));
+    glVertexAttribPointer(2, 3, GL_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, normal));
 
     glEnableVertexAttribArray(3);
-    glVertexAttribPointer(3, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, color));
+    glVertexAttribPointer(3, 4, GL_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, tangent));
 
     glEnableVertexAttribArray(4);
-    glVertexAttribPointer(4, 4, GL_FLOAT, GL_FALSE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, tangent));
+    glVertexAttribPointer(4, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, color));
 
     glEnableVertexAttribArray(5);
-    glVertexAttribIPointer(5, 4, GL_UNSIGNED_BYTE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, boneIds));
+    glVertexAttribIPointer(5, 4, GL_UNSIGNED_BYTE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, boneIndices));
 
     glEnableVertexAttribArray(6);
-    glVertexAttribPointer(6, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, weights));
+    glVertexAttribPointer(6, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(R3D_Vertex), (void*)offsetof(R3D_Vertex, boneWeights));
 
     if (configInstances) {
         glVertexAttribDivisor(10, 1);
@@ -329,70 +329,79 @@ void load_shape_dummy(r3d_render_shape_t* shape)
 
 void load_shape_quad(r3d_render_shape_t* shape)
 {
-    static const R3D_Vertex VERTICES[] = {
-        {{-0.5f, 0.5f, 0}, {0, 1}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{-0.5f,-0.5f, 0}, {0, 0}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{ 0.5f, 0.5f, 0}, {1, 1}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{ 0.5f,-0.5f, 0}, {1, 0}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
+    const R3D_Vertex vertices[] = {
+        R3D_MakeVertex((Vector3){-0.5f,  0.5f, 0}, (Vector2){0, 1}, (Vector3){0, 0, 1}, (Vector4){1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){-0.5f, -0.5f, 0}, (Vector2){0, 0}, (Vector3){0, 0, 1}, (Vector4){1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f,  0.5f, 0}, (Vector2){1, 1}, (Vector3){0, 0, 1}, (Vector4){1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f, -0.5f, 0}, (Vector2){1, 0}, (Vector3){0, 0, 1}, (Vector4){1, 0, 0, 1}, WHITE),
     };
-    static const uint32_t INDICES[] = {0, 1, 2, 1, 3, 2};
 
-    r3d_render_alloc_vertices(ARRAY_SIZE(VERTICES), &shape->vertices.offset);
+    static const uint32_t INDICES[] = {
+        0, 1, 2,
+        1, 3, 2
+    };
+
+    r3d_render_alloc_vertices(ARRAY_SIZE(vertices), &shape->vertices.offset);
     r3d_render_alloc_elements(ARRAY_SIZE(INDICES), &shape->elements.offset);
 
-    r3d_render_upload_vertices(shape->vertices.offset, VERTICES, ARRAY_SIZE(VERTICES));
+    r3d_render_upload_vertices(shape->vertices.offset, vertices, ARRAY_SIZE(vertices));
     r3d_render_upload_elements(shape->elements.offset, INDICES, ARRAY_SIZE(INDICES));
 
-    shape->vertices.count = ARRAY_SIZE(VERTICES);
+    shape->vertices.count = ARRAY_SIZE(vertices);
     shape->elements.count = ARRAY_SIZE(INDICES);
 }
 
 void load_shape_cube(r3d_render_shape_t* shape)
 {
-    static const R3D_Vertex VERTICES[] = {
+    const R3D_Vertex vertices[] = {
         // Front (Z+)
-        {{-0.5f, 0.5f, 0.5f}, {0, 1}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{-0.5f,-0.5f, 0.5f}, {0, 0}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{ 0.5f, 0.5f, 0.5f}, {1, 1}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{ 0.5f,-0.5f, 0.5f}, {1, 0}, {0, 0, 1}, {255, 255, 255, 255}, {1, 0, 0, 1}},
+        R3D_MakeVertex((Vector3){-0.5f,  0.5f,  0.5f}, (Vector2){0, 1}, (Vector3){ 0, 0, 1}, (Vector4){ 1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){-0.5f, -0.5f,  0.5f}, (Vector2){0, 0}, (Vector3){ 0, 0, 1}, (Vector4){ 1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f,  0.5f,  0.5f}, (Vector2){1, 1}, (Vector3){ 0, 0, 1}, (Vector4){ 1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f, -0.5f,  0.5f}, (Vector2){1, 0}, (Vector3){ 0, 0, 1}, (Vector4){ 1, 0, 0, 1}, WHITE),
         // Back (Z-)
-        {{-0.5f, 0.5f,-0.5f}, {1, 1}, {0, 0,-1}, {255, 255, 255, 255}, {-1, 0, 0, 1}},
-        {{-0.5f,-0.5f,-0.5f}, {1, 0}, {0, 0,-1}, {255, 255, 255, 255}, {-1, 0, 0, 1}},
-        {{ 0.5f, 0.5f,-0.5f}, {0, 1}, {0, 0,-1}, {255, 255, 255, 255}, {-1, 0, 0, 1}},
-        {{ 0.5f,-0.5f,-0.5f}, {0, 0}, {0, 0,-1}, {255, 255, 255, 255}, {-1, 0, 0, 1}},
+        R3D_MakeVertex((Vector3){-0.5f,  0.5f, -0.5f}, (Vector2){1, 1}, (Vector3){ 0, 0,-1}, (Vector4){-1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){-0.5f, -0.5f, -0.5f}, (Vector2){1, 0}, (Vector3){ 0, 0,-1}, (Vector4){-1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f,  0.5f, -0.5f}, (Vector2){0, 1}, (Vector3){ 0, 0,-1}, (Vector4){-1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f, -0.5f, -0.5f}, (Vector2){0, 0}, (Vector3){ 0, 0,-1}, (Vector4){-1, 0, 0, 1}, WHITE),
         // Left (X-)
-        {{-0.5f, 0.5f,-0.5f}, {0, 1}, {-1, 0, 0}, {255, 255, 255, 255}, {0, 0,-1, 1}},
-        {{-0.5f,-0.5f,-0.5f}, {0, 0}, {-1, 0, 0}, {255, 255, 255, 255}, {0, 0,-1, 1}},
-        {{-0.5f, 0.5f, 0.5f}, {1, 1}, {-1, 0, 0}, {255, 255, 255, 255}, {0, 0,-1, 1}},
-        {{-0.5f,-0.5f, 0.5f}, {1, 0}, {-1, 0, 0}, {255, 255, 255, 255}, {0, 0,-1, 1}},
+        R3D_MakeVertex((Vector3){-0.5f,  0.5f, -0.5f}, (Vector2){0, 1}, (Vector3){-1, 0, 0}, (Vector4){ 0, 0,-1, 1}, WHITE),
+        R3D_MakeVertex((Vector3){-0.5f, -0.5f, -0.5f}, (Vector2){0, 0}, (Vector3){-1, 0, 0}, (Vector4){ 0, 0,-1, 1}, WHITE),
+        R3D_MakeVertex((Vector3){-0.5f,  0.5f,  0.5f}, (Vector2){1, 1}, (Vector3){-1, 0, 0}, (Vector4){ 0, 0,-1, 1}, WHITE),
+        R3D_MakeVertex((Vector3){-0.5f, -0.5f,  0.5f}, (Vector2){1, 0}, (Vector3){-1, 0, 0}, (Vector4){ 0, 0,-1, 1}, WHITE),
         // Right (X+)
-        {{ 0.5f, 0.5f, 0.5f}, {0, 1}, {1, 0, 0}, {255, 255, 255, 255}, {0, 0, 1, 1}},
-        {{ 0.5f,-0.5f, 0.5f}, {0, 0}, {1, 0, 0}, {255, 255, 255, 255}, {0, 0, 1, 1}},
-        {{ 0.5f, 0.5f,-0.5f}, {1, 1}, {1, 0, 0}, {255, 255, 255, 255}, {0, 0, 1, 1}},
-        {{ 0.5f,-0.5f,-0.5f}, {1, 0}, {1, 0, 0}, {255, 255, 255, 255}, {0, 0, 1, 1}},
+        R3D_MakeVertex((Vector3){ 0.5f,  0.5f,  0.5f}, (Vector2){0, 1}, (Vector3){ 1, 0, 0}, (Vector4){ 0, 0, 1, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f, -0.5f,  0.5f}, (Vector2){0, 0}, (Vector3){ 1, 0, 0}, (Vector4){ 0, 0, 1, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f,  0.5f, -0.5f}, (Vector2){1, 1}, (Vector3){ 1, 0, 0}, (Vector4){ 0, 0, 1, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f, -0.5f, -0.5f}, (Vector2){1, 0}, (Vector3){ 1, 0, 0}, (Vector4){ 0, 0, 1, 1}, WHITE),
         // Top (Y+)
-        {{-0.5f, 0.5f,-0.5f}, {0, 0}, {0, 1, 0}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{-0.5f, 0.5f, 0.5f}, {0, 1}, {0, 1, 0}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{ 0.5f, 0.5f,-0.5f}, {1, 0}, {0, 1, 0}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{ 0.5f, 0.5f, 0.5f}, {1, 1}, {0, 1, 0}, {255, 255, 255, 255}, {1, 0, 0, 1}},
+        R3D_MakeVertex((Vector3){-0.5f,  0.5f, -0.5f}, (Vector2){0, 0}, (Vector3){ 0, 1, 0}, (Vector4){ 1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){-0.5f,  0.5f,  0.5f}, (Vector2){0, 1}, (Vector3){ 0, 1, 0}, (Vector4){ 1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f,  0.5f, -0.5f}, (Vector2){1, 0}, (Vector3){ 0, 1, 0}, (Vector4){ 1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f,  0.5f,  0.5f}, (Vector2){1, 1}, (Vector3){ 0, 1, 0}, (Vector4){ 1, 0, 0, 1}, WHITE),
         // Bottom (Y-)
-        {{-0.5f,-0.5f, 0.5f}, {0, 0}, {0,-1, 0}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{-0.5f,-0.5f,-0.5f}, {0, 1}, {0,-1, 0}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{ 0.5f,-0.5f, 0.5f}, {1, 0}, {0,-1, 0}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-        {{ 0.5f,-0.5f,-0.5f}, {1, 1}, {0,-1, 0}, {255, 255, 255, 255}, {1, 0, 0, 1}},
-    };
-    static const uint32_t INDICES[] = {
-        0,1,2, 2,1,3,   6,5,4, 7,5,6,   8,9,10, 10,9,11,
-        12,13,14, 14,13,15,   16,17,18, 18,17,19,   20,21,22, 22,21,23
+        R3D_MakeVertex((Vector3){-0.5f, -0.5f,  0.5f}, (Vector2){0, 0}, (Vector3){ 0,-1, 0}, (Vector4){ 1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){-0.5f, -0.5f, -0.5f}, (Vector2){0, 1}, (Vector3){ 0,-1, 0}, (Vector4){ 1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f, -0.5f,  0.5f}, (Vector2){1, 0}, (Vector3){ 0,-1, 0}, (Vector4){ 1, 0, 0, 1}, WHITE),
+        R3D_MakeVertex((Vector3){ 0.5f, -0.5f, -0.5f}, (Vector2){1, 1}, (Vector3){ 0,-1, 0}, (Vector4){ 1, 0, 0, 1}, WHITE),
     };
 
-    r3d_render_alloc_vertices(ARRAY_SIZE(VERTICES), &shape->vertices.offset);
+    static const uint32_t INDICES[] = {
+        0,1,2, 2,1,3,
+        6,5,4, 7,5,6,
+        8,9,10, 10,9,11,
+        12,13,14, 14,13,15,
+        16,17,18, 18,17,19,
+        20,21,22, 22,21,23
+    };
+
+    r3d_render_alloc_vertices(ARRAY_SIZE(vertices), &shape->vertices.offset);
     r3d_render_alloc_elements(ARRAY_SIZE(INDICES), &shape->elements.offset);
 
-    r3d_render_upload_vertices(shape->vertices.offset, VERTICES, ARRAY_SIZE(VERTICES));
+    r3d_render_upload_vertices(shape->vertices.offset, vertices, ARRAY_SIZE(vertices));
     r3d_render_upload_elements(shape->elements.offset, INDICES, ARRAY_SIZE(INDICES));
 
-    shape->vertices.count = ARRAY_SIZE(VERTICES);
+    shape->vertices.count = ARRAY_SIZE(vertices);
     shape->elements.count = ARRAY_SIZE(INDICES);
 }
 

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -7,14 +7,14 @@
  */
 
 #include <r3d/r3d_mesh_data.h>
+#include <r3d/r3d_vertex.h>
 #include <r3d_config.h>
 #include <raymath.h>
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>
 
-#include "./common/r3d_helper.h"
-#include "common/r3d_math.h"
+#include "./common/r3d_math.h"
 
 // ========================================
 // INTERNAL FUNCTIONS
@@ -103,15 +103,13 @@ R3D_MeshData R3D_GenMeshDataQuad(float width, float length, int resX, int resZ, 
             float u = x * invResX;
             float localX = (u - 0.5f) * width;
 
-            vertex->position = (Vector3){
+            Vector3 position = {
                 localX * tangent.x + localY * bitangent.x,
                 localX * tangent.y + localY * bitangent.y,
                 localX * tangent.z + localY * bitangent.z
             };
-            vertex->texcoord = (Vector2){u, v};
-            vertex->normal = normal;
-            vertex->color = WHITE;
-            vertex->tangent = tangent4;
+
+            *vertex = R3D_MakeVertex(position, (Vector2){u, v}, normal, tangent4, WHITE);
         }
     }
 
@@ -169,13 +167,13 @@ R3D_MeshData R3D_GenMeshDataPlane(float width, float length, int resX, int resZ)
             float posX = -halfWidth + x * stepX;
             float uvX = x * invResX;
 
-            *vertex = (R3D_Vertex){
-                .position = {posX, 0.0f, posZ},
-                .texcoord = {uvX, uvZ},
-                .normal = {0.0f, 1.0f, 0.0f},
-                .color = WHITE,
-                .tangent = {1.0f, 0.0f, 0.0f, 1.0f}
-            };
+            *vertex = R3D_MakeVertex(
+                (Vector3){posX, 0.0f, posZ},
+                (Vector2){uvX, uvZ},
+                (Vector3){0.0f, 1.0f, 0.0f},
+                (Vector4){1.0f, 0.0f, 0.0f, 1.0f},
+                WHITE
+            );
         }
     }
 
@@ -220,13 +218,13 @@ R3D_MeshData R3D_GenMeshDataPoly(int sides, float radius, Vector3 frontDir)
     Vector4 tangent4 = {tangent.x, tangent.y, tangent.z, 1.0f};
     float angleStep = 2.0f * PI / sides;
 
-    meshData.vertices[0] = (R3D_Vertex){
-        .position = {0.0f, 0.0f, 0.0f},
-        .texcoord = {0.5f, 0.5f},
-        .normal = normal,
-        .color = WHITE,
-        .tangent = tangent4
-    };
+    meshData.vertices[0] = R3D_MakeVertex(
+        (Vector3){0.0f, 0.0f, 0.0f},
+        (Vector2){0.5f, 0.5f},
+        normal,
+        tangent4,
+        WHITE
+    );
 
     R3D_Vertex* vertex = &meshData.vertices[1];
     uint32_t* index = meshData.indices;
@@ -240,19 +238,18 @@ R3D_MeshData R3D_GenMeshDataPoly(int sides, float radius, Vector3 frontDir)
         float localX = radius * cosAngle;
         float localY = radius * sinAngle;
 
-        vertex->position = (Vector3){
+        Vector3 position = {
             localX * tangent.x + localY * bitangent.x,
             localX * tangent.y + localY * bitangent.y,
             localX * tangent.z + localY * bitangent.z
         };
 
-        vertex->texcoord = (Vector2){
+        Vector2 texcoord = {
             0.5f + 0.5f * cosAngle,
             0.5f + 0.5f * sinAngle
         };
-        vertex->normal = normal;
-        vertex->color = WHITE;
-        vertex->tangent = tangent4;
+
+        *vertex = R3D_MakeVertex(position, texcoord, normal, tangent4, WHITE);
 
         *index++ = 0;
         *index++ = i + 1;
@@ -286,40 +283,40 @@ R3D_MeshData R3D_GenMeshDataCube(float width, float height, float length)
     R3D_Vertex* v = meshData.vertices;
 
     // Back face (+Z)
-    *v++ = (R3D_Vertex){{-halfW, -halfH, halfL}, uvs[0], {0.0f, 0.0f, 1.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{halfW, -halfH, halfL}, uvs[1], {0.0f, 0.0f, 1.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{halfW, halfH, halfL}, uvs[2], {0.0f, 0.0f, 1.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{-halfW, halfH, halfL}, uvs[3], {0.0f, 0.0f, 1.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
+    *v++ = R3D_MakeVertex((Vector3){-halfW, -halfH, halfL}, uvs[0], (Vector3){0.0f, 0.0f, 1.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){halfW, -halfH, halfL}, uvs[1], (Vector3){0.0f, 0.0f, 1.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){halfW, halfH, halfL}, uvs[2], (Vector3){0.0f, 0.0f, 1.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){-halfW, halfH, halfL}, uvs[3], (Vector3){0.0f, 0.0f, 1.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
 
     // Front face (-Z)
-    *v++ = (R3D_Vertex){{halfW, -halfH, -halfL}, uvs[0], {0.0f, 0.0f, -1.0f}, WHITE, {-1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{-halfW, -halfH, -halfL}, uvs[1], {0.0f, 0.0f, -1.0f}, WHITE, {-1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{-halfW, halfH, -halfL}, uvs[2], {0.0f, 0.0f, -1.0f}, WHITE, {-1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{halfW, halfH, -halfL}, uvs[3], {0.0f, 0.0f, -1.0f}, WHITE, {-1.0f, 0.0f, 0.0f, 1.0f}};
+    *v++ = R3D_MakeVertex((Vector3){halfW, -halfH, -halfL}, uvs[0], (Vector3){0.0f, 0.0f, -1.0f}, (Vector4){-1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){-halfW, -halfH, -halfL}, uvs[1], (Vector3){0.0f, 0.0f, -1.0f}, (Vector4){-1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){-halfW, halfH, -halfL}, uvs[2], (Vector3){0.0f, 0.0f, -1.0f}, (Vector4){-1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){halfW, halfH, -halfL}, uvs[3], (Vector3){0.0f, 0.0f, -1.0f}, (Vector4){-1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
 
     // Right face (+X)
-    *v++ = (R3D_Vertex){{halfW, -halfH, halfL}, uvs[0], {1.0f, 0.0f, 0.0f}, WHITE, {0.0f, 0.0f, -1.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{halfW, -halfH, -halfL}, uvs[1], {1.0f, 0.0f, 0.0f}, WHITE, {0.0f, 0.0f, -1.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{halfW, halfH, -halfL}, uvs[2], {1.0f, 0.0f, 0.0f}, WHITE, {0.0f, 0.0f, -1.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{halfW, halfH, halfL}, uvs[3], {1.0f, 0.0f, 0.0f}, WHITE, {0.0f, 0.0f, -1.0f, 1.0f}};
+    *v++ = R3D_MakeVertex((Vector3){halfW, -halfH, halfL}, uvs[0], (Vector3){1.0f, 0.0f, 0.0f}, (Vector4){0.0f, 0.0f, -1.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){halfW, -halfH, -halfL}, uvs[1], (Vector3){1.0f, 0.0f, 0.0f}, (Vector4){0.0f, 0.0f, -1.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){halfW, halfH, -halfL}, uvs[2], (Vector3){1.0f, 0.0f, 0.0f}, (Vector4){0.0f, 0.0f, -1.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){halfW, halfH, halfL}, uvs[3], (Vector3){1.0f, 0.0f, 0.0f}, (Vector4){0.0f, 0.0f, -1.0f, 1.0f}, WHITE);
 
     // Left face (-X)
-    *v++ = (R3D_Vertex){{-halfW, -halfH, -halfL}, uvs[0], {-1.0f, 0.0f, 0.0f}, WHITE, {0.0f, 0.0f, 1.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{-halfW, -halfH, halfL}, uvs[1], {-1.0f, 0.0f, 0.0f}, WHITE, {0.0f, 0.0f, 1.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{-halfW, halfH, halfL}, uvs[2], {-1.0f, 0.0f, 0.0f}, WHITE, {0.0f, 0.0f, 1.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{-halfW, halfH, -halfL}, uvs[3], {-1.0f, 0.0f, 0.0f}, WHITE, {0.0f, 0.0f, 1.0f, 1.0f}};
+    *v++ = R3D_MakeVertex((Vector3){-halfW, -halfH, -halfL}, uvs[0], (Vector3){-1.0f, 0.0f, 0.0f}, (Vector4){0.0f, 0.0f, 1.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){-halfW, -halfH, halfL}, uvs[1], (Vector3){-1.0f, 0.0f, 0.0f}, (Vector4){0.0f, 0.0f, 1.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){-halfW, halfH, halfL}, uvs[2], (Vector3){-1.0f, 0.0f, 0.0f}, (Vector4){0.0f, 0.0f, 1.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){-halfW, halfH, -halfL}, uvs[3], (Vector3){-1.0f, 0.0f, 0.0f}, (Vector4){0.0f, 0.0f, 1.0f, 1.0f}, WHITE);
 
     // Top face (+Y)
-    *v++ = (R3D_Vertex){{-halfW, halfH, halfL}, uvs[0], {0.0f, 1.0f, 0.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{halfW, halfH, halfL}, uvs[1], {0.0f, 1.0f, 0.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{halfW, halfH, -halfL}, uvs[2], {0.0f, 1.0f, 0.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{-halfW, halfH, -halfL}, uvs[3], {0.0f, 1.0f, 0.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
+    *v++ = R3D_MakeVertex((Vector3){-halfW, halfH, halfL}, uvs[0], (Vector3){0.0f, 1.0f, 0.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){halfW, halfH, halfL}, uvs[1], (Vector3){0.0f, 1.0f, 0.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){halfW, halfH, -halfL}, uvs[2], (Vector3){0.0f, 1.0f, 0.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){-halfW, halfH, -halfL}, uvs[3], (Vector3){0.0f, 1.0f, 0.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
 
     // Bottom face (-Y)
-    *v++ = (R3D_Vertex){{-halfW, -halfH, -halfL}, uvs[0], {0.0f, -1.0f, 0.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{halfW, -halfH, -halfL}, uvs[1], {0.0f, -1.0f, 0.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{halfW, -halfH, halfL}, uvs[2], {0.0f, -1.0f, 0.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
-    *v++ = (R3D_Vertex){{-halfW, -halfH, halfL}, uvs[3], {0.0f, -1.0f, 0.0f}, WHITE, {1.0f, 0.0f, 0.0f, 1.0f}};
+    *v++ = R3D_MakeVertex((Vector3){-halfW, -halfH, -halfL}, uvs[0], (Vector3){0.0f, -1.0f, 0.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){halfW, -halfH, -halfL}, uvs[1], (Vector3){0.0f, -1.0f, 0.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){halfW, -halfH, halfL}, uvs[2], (Vector3){0.0f, -1.0f, 0.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
+    *v++ = R3D_MakeVertex((Vector3){-halfW, -halfH, halfL}, uvs[3], (Vector3){0.0f, -1.0f, 0.0f}, (Vector4){1.0f, 0.0f, 0.0f, 1.0f}, WHITE);
 
     // Indices
     uint32_t* index = meshData.indices;
@@ -364,16 +361,13 @@ static void gen_cube_face(
             float ut = u * invU;
             float localU = (ut - 0.5f) * uSize;
 
-            vertex->position = (Vector3){
+            Vector3 position = {
                 origin.x + localU * uAxis.x + localV * vAxis.x,
                 origin.y + localU * uAxis.y + localV * vAxis.y,
                 origin.z + localU * uAxis.z + localV * vAxis.z
             };
 
-            vertex->texcoord = (Vector2){ut, vt};
-            vertex->normal   = normal;
-            vertex->color    = WHITE;
-            vertex->tangent  = tangent4;
+            *vertex = R3D_MakeVertex(position, (Vector2){ut, vt}, normal, tangent4, WHITE);
 
             vertex++;
             (*vertexOffset)++;
@@ -551,10 +545,11 @@ R3D_MeshData R3D_GenMeshDataSlope(float width, float height, float length, Vecto
         if (keptInFace == 4) {
             int baseV = vertexCount;
             for (int i = 0; i < 4; i++) {
-                v[vertexCount++] = (R3D_Vertex){
-                    corners[ci[i]], uvs[i], faceNormals[f], WHITE,
-                    {faceTangents[f].x, faceTangents[f].y, faceTangents[f].z, 1.0f}
-                };
+                v[vertexCount++] = R3D_MakeVertex(
+                    corners[ci[i]], uvs[i], faceNormals[f],
+                    (Vector4){faceTangents[f].x, faceTangents[f].y, faceTangents[f].z, 1.0f},
+                    WHITE
+                );
             }
             idx[indexCount++] = baseV; idx[indexCount++] = baseV+2; idx[indexCount++] = baseV+1;
             idx[indexCount++] = baseV+2; idx[indexCount++] = baseV; idx[indexCount++] = baseV+3;
@@ -611,10 +606,11 @@ R3D_MeshData R3D_GenMeshDataSlope(float width, float height, float length, Vecto
         if (polyCount >= 3) {
             int baseV = vertexCount;
             for (int i = 0; i < polyCount; i++) {
-                v[vertexCount++] = (R3D_Vertex){
-                    polygon[i], polyUVs[i], faceNormals[f], WHITE,
-                    {faceTangents[f].x, faceTangents[f].y, faceTangents[f].z, 1.0f}
-                };
+                v[vertexCount++] = R3D_MakeVertex(
+                    polygon[i], polyUVs[i], faceNormals[f],
+                    (Vector4){faceTangents[f].x, faceTangents[f].y, faceTangents[f].z, 1.0f},
+                    WHITE
+                );
             }
             for (int i = 1; i < polyCount - 1; i++) {
                 idx[indexCount++] = baseV;
@@ -685,10 +681,11 @@ R3D_MeshData R3D_GenMeshDataSlope(float width, float height, float length, Vecto
                 (projV - uvMin.y) / rangeV
             };
             
-            v[vertexCount++] = (R3D_Vertex){
-                cutPolygon[i], uv, cutNormal, WHITE,
-                {u.x, u.y, u.z, 1.0f}
-            };
+            v[vertexCount++] = R3D_MakeVertex(
+                cutPolygon[i], uv, cutNormal,
+                (Vector4){u.x, u.y, u.z, 1.0f},
+                WHITE
+            );
         }
 
         for (int i = 1; i < cutCount - 1; i++) {
@@ -742,11 +739,13 @@ R3D_MeshData R3D_GenMeshDataSphere(float radius, int rings, int slices)
             float x = ringRadius * cosTheta;
             float z = ringRadius * -sinTheta;
 
-            vertex->position = (Vector3){x, y, z};
-            vertex->texcoord = (Vector2){slice * invSlices, v};
-            vertex->normal = (Vector3){x * invRadius, y * invRadius, z * invRadius};
-            vertex->color = WHITE;
-            vertex->tangent = (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f};
+            *vertex = R3D_MakeVertex(
+                (Vector3){x, y, z},
+                (Vector2){slice * invSlices, v},
+                (Vector3){x * invRadius, y * invRadius, z * invRadius},
+                (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f},
+                WHITE
+            );
         }
     }
 
@@ -813,22 +812,24 @@ R3D_MeshData R3D_GenMeshDataHemiSphere(float radius, int rings, int slices)
             float x = ringRadius * cosTheta;
             float z = ringRadius * -sinTheta;
 
-            vertex->position = (Vector3){x, y, z};
-            vertex->texcoord = (Vector2){slice * invSlices, v};
-            vertex->normal = (Vector3){x * invRadius, y * invRadius, z * invRadius};
-            vertex->color = WHITE;
-            vertex->tangent = (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f};
+            *vertex = R3D_MakeVertex(
+                (Vector3){x, y, z},
+                (Vector2){slice * invSlices, v},
+                (Vector3){x * invRadius, y * invRadius, z * invRadius},
+                (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f},
+                WHITE
+            );
         }
     }
 
     uint32_t baseCenterIdx = hemisphereVertCount;
-    *vertex++ = (R3D_Vertex){
-        .position = {0.0f, 0.0f, 0.0f},
-        .texcoord = {0.5f, 0.5f},
-        .normal = {0.0f, -1.0f, 0.0f},
-        .color = WHITE,
-        .tangent = {1.0f, 0.0f, 0.0f, 1.0f}
-    };
+    *vertex++ = R3D_MakeVertex(
+        (Vector3){0.0f, 0.0f, 0.0f},
+        (Vector2){0.5f, 0.5f},
+        (Vector3){0.0f, -1.0f, 0.0f},
+        (Vector4){1.0f, 0.0f, 0.0f, 1.0f},
+        WHITE
+    );
 
     for (int slice = 0; slice <= slices; slice++, vertex++)
     {
@@ -839,11 +840,13 @@ R3D_MeshData R3D_GenMeshDataHemiSphere(float radius, int rings, int slices)
         float x = radius * cosTheta;
         float z = radius * -sinTheta;
 
-        vertex->position = (Vector3){x, 0.0f, z};
-        vertex->texcoord = (Vector2){0.5f + 0.5f * cosTheta, 0.5f - 0.5f * sinTheta};
-        vertex->normal = (Vector3){0.0f, -1.0f, 0.0f};
-        vertex->color = WHITE;
-        vertex->tangent = (Vector4){1.0f, 0.0f, 0.0f, 1.0f};
+        *vertex = R3D_MakeVertex(
+            (Vector3){x, 0.0f, z},
+            (Vector2){0.5f + 0.5f * cosTheta, 0.5f - 0.5f * sinTheta},
+            (Vector3){0.0f, -1.0f, 0.0f},
+            (Vector4){1.0f, 0.0f, 0.0f, 1.0f},
+            WHITE
+        );
     }
 
     uint32_t* index = meshData.indices;
@@ -934,11 +937,13 @@ R3D_MeshData R3D_GenMeshDataCylinderEx(float bottomRadius, float topRadius, floa
             float cosTheta = cosf(theta);
             float sinTheta = sinf(theta);
 
-            vertex->position = (Vector3){radius * cosTheta, y, -radius * sinTheta};
-            vertex->texcoord = (Vector2){slice * invSlices, t};
-            vertex->normal = (Vector3){normalR * cosTheta, normalY, -normalR * sinTheta};
-            vertex->color = WHITE;
-            vertex->tangent = (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f};
+            *vertex = R3D_MakeVertex(
+                (Vector3){radius * cosTheta, y, -radius * sinTheta},
+                (Vector2){slice * invSlices, t},
+                (Vector3){normalR * cosTheta, normalY, -normalR * sinTheta},
+                (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f},
+                WHITE
+            );
         }
     }
 
@@ -949,13 +954,13 @@ R3D_MeshData R3D_GenMeshDataCylinderEx(float bottomRadius, float topRadius, floa
     {
         bottomCapStart = (uint32_t)bodyVertCount;
 
-        *vertex++ = (R3D_Vertex){
-            .position = {0.0f, -halfHeight, 0.0f },
-            .texcoord = {0.5f, 0.5f },
-            .normal = {0.0f, -1.0f, 0.0f },
-            .color = WHITE,
-            .tangent = {1.0f, 0.0f, 0.0f, 1.0f }
-        };
+        *vertex++ = R3D_MakeVertex(
+            (Vector3){0.0f, -halfHeight, 0.0f},
+            (Vector2){0.5f, 0.5f},
+            (Vector3){0.0f, -1.0f, 0.0f},
+            (Vector4){1.0f, 0.0f, 0.0f, 1.0f},
+            WHITE
+        );
 
         for (int slice = 0; slice < slices; slice++, vertex++)
         {
@@ -963,11 +968,13 @@ R3D_MeshData R3D_GenMeshDataCylinderEx(float bottomRadius, float topRadius, floa
             float cosTheta = cosf(theta);
             float sinTheta = sinf(theta);
 
-            vertex->position = (Vector3){bottomRadius * cosTheta, -halfHeight, -bottomRadius * sinTheta};
-            vertex->texcoord = (Vector2){0.5f + 0.5f * cosTheta, 0.5f - 0.5f * sinTheta};
-            vertex->normal = (Vector3){0.0f, -1.0f, 0.0f};
-            vertex->color = WHITE;
-            vertex->tangent = (Vector4){1.0f, 0.0f, 0.0f, 1.0f};
+            *vertex = R3D_MakeVertex(
+                (Vector3){bottomRadius * cosTheta, -halfHeight, -bottomRadius * sinTheta},
+                (Vector2){0.5f + 0.5f * cosTheta, 0.5f - 0.5f * sinTheta},
+                (Vector3){0.0f, -1.0f, 0.0f},
+                (Vector4){1.0f, 0.0f, 0.0f, 1.0f},
+                WHITE
+            );
         }
     }
 
@@ -977,13 +984,13 @@ R3D_MeshData R3D_GenMeshDataCylinderEx(float bottomRadius, float topRadius, floa
             ? bottomCapStart + 1 + (uint32_t)slices
             : (uint32_t)bodyVertCount;
 
-        *vertex++ = (R3D_Vertex){
-            .position = {0.0f, halfHeight, 0.0f},
-            .texcoord = {0.5f, 0.5f},
-            .normal = {0.0f, 1.0f, 0.0f},
-            .color = WHITE,
-            .tangent = {1.0f, 0.0f, 0.0f, 1.0f}
-        };
+        *vertex++ = R3D_MakeVertex(
+            (Vector3){0.0f, halfHeight, 0.0f},
+            (Vector2){0.5f, 0.5f},
+            (Vector3){0.0f, 1.0f, 0.0f},
+            (Vector4){1.0f, 0.0f, 0.0f, 1.0f},
+            WHITE
+        );
 
         for (int slice = 0; slice < slices; slice++, vertex++)
         {
@@ -991,11 +998,13 @@ R3D_MeshData R3D_GenMeshDataCylinderEx(float bottomRadius, float topRadius, floa
             float cosTheta = cosf(theta);
             float sinTheta = sinf(theta);
 
-            vertex->position = (Vector3){topRadius * cosTheta, halfHeight, -topRadius * sinTheta};
-            vertex->texcoord = (Vector2){0.5f + 0.5f * cosTheta, 0.5f - 0.5f * sinTheta};
-            vertex->normal = (Vector3){0.0f, 1.0f, 0.0f};
-            vertex->color = WHITE;
-            vertex->tangent = (Vector4){1.0f, 0.0f, 0.0f, 1.0f};
+            *vertex = R3D_MakeVertex(
+                (Vector3){topRadius * cosTheta, halfHeight, -topRadius * sinTheta},
+                (Vector2){0.5f + 0.5f * cosTheta, 0.5f - 0.5f * sinTheta},
+                (Vector3){0.0f, 1.0f, 0.0f},
+                (Vector4){1.0f, 0.0f, 0.0f, 1.0f},
+                WHITE
+            );
         }
     }
 
@@ -1078,12 +1087,13 @@ R3D_MeshData R3D_GenMeshDataCapsule(float radius, float height, int rings, int s
             float x = ringRadius * cosTheta;
             float z = ringRadius * sinTheta;
 
-            vertex->position = (Vector3){x, y, z};
-            vertex->texcoord = (Vector2){slice * invSlices, v};
-
-            vertex->normal = (Vector3){cosPhi * cosTheta, sinPhi, cosPhi * sinTheta};
-            vertex->color = WHITE;
-            vertex->tangent = (Vector4){-sinTheta, 0.0f, cosTheta, 1.0f};
+            *vertex = R3D_MakeVertex(
+                (Vector3){x, y, z},
+                (Vector2){slice * invSlices, v},
+                (Vector3){cosPhi * cosTheta, sinPhi, cosPhi * sinTheta},
+                (Vector4){-sinTheta, 0.0f, cosTheta, 1.0f},
+                WHITE
+            );
         }
     }
 
@@ -1097,11 +1107,13 @@ R3D_MeshData R3D_GenMeshDataCapsule(float radius, float height, int rings, int s
         float x = radius * cosTheta;
         float z = radius * sinTheta;
 
-        vertex->position = (Vector3){x, -halfHeight, z};
-        vertex->texcoord = (Vector2){slice * invSlices, v};
-        vertex->normal = (Vector3){cosTheta, 0.0f, sinTheta};
-        vertex->color = WHITE;
-        vertex->tangent = (Vector4){-sinTheta, 0.0f, cosTheta, 1.0f};
+        *vertex = R3D_MakeVertex(
+            (Vector3){x, -halfHeight, z},
+            (Vector2){slice * invSlices, v},
+            (Vector3){cosTheta, 0.0f, sinTheta},
+            (Vector4){-sinTheta, 0.0f, cosTheta, 1.0f},
+            WHITE
+        );
     }
 
     for (int ring = 1; ring <= rings; ring++)
@@ -1122,11 +1134,13 @@ R3D_MeshData R3D_GenMeshDataCapsule(float radius, float height, int rings, int s
             float x = ringRadius * cosTheta;
             float z = ringRadius * sinTheta;
 
-            vertex->position = (Vector3){x, y, z};
-            vertex->texcoord = (Vector2){slice * invSlices, v};
-            vertex->normal = (Vector3){cosPhi * cosTheta, sinPhi, cosPhi * sinTheta};
-            vertex->color = WHITE;
-            vertex->tangent = (Vector4){-sinTheta, 0.0f, cosTheta, 1.0f};
+            *vertex = R3D_MakeVertex(
+                (Vector3){x, y, z},
+                (Vector2){slice * invSlices, v},
+                (Vector3){cosPhi * cosTheta, sinPhi, cosPhi * sinTheta},
+                (Vector4){-sinTheta, 0.0f, cosTheta, 1.0f},
+                WHITE
+            );
         }
     }
 
@@ -1194,15 +1208,19 @@ R3D_MeshData R3D_GenMeshDataTorus(float radius, float size, int radSeg, int side
                 -sinTheta * cosPhi
             };
 
-            vertex->position = (Vector3){
+            Vector3 position = {
                 ringCenterX + size * normal.x,
                 size * normal.y,
                 ringCenterZ + size * normal.z
             };
-            vertex->texcoord = (Vector2){u, side * invSides};
-            vertex->normal = normal;
-            vertex->color = WHITE;
-            vertex->tangent = (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f};
+
+            *vertex = R3D_MakeVertex(
+                position,
+                (Vector2){u, side * invSides},
+                normal,
+                (Vector4){-sinTheta, 0.0f, -cosTheta, 1.0f},
+                WHITE
+            );
         }
     }
 
@@ -1314,15 +1332,19 @@ R3D_MeshData R3D_GenMeshDataKnot(float radius, float size, int radSeg, int sides
                 normal.z * cosPhi + binormal.z * sinPhi
             };
 
-            vertex->position = (Vector3){
+            Vector3 position = {
                 knotCenter.x + size * surfaceNormal.x,
                 knotCenter.y + size * surfaceNormal.y,
                 knotCenter.z + size * surfaceNormal.z
             };
-            vertex->texcoord = (Vector2){u, side * invSides};
-            vertex->normal = surfaceNormal;
-            vertex->color = WHITE;
-            vertex->tangent = (Vector4){tangent.x, tangent.y, tangent.z, 1.0f};
+
+            *vertex = R3D_MakeVertex(
+                position,
+                (Vector2){u, side * invSides},
+                surfaceNormal,
+                (Vector4){tangent.x, tangent.y, tangent.z, 1.0f},
+                WHITE
+            );
         }
     }
 
@@ -1404,13 +1426,13 @@ R3D_MeshData R3D_GenMeshDataHeightmap(Image heightmap, Vector3 size)
             Vector3 normal = Vector3Normalize((Vector3) {-gradX, 1.0f, -gradZ});
             Vector3 tangent = Vector3Normalize((Vector3) {1.0f, gradX, 0.0f});
 
-            meshData.vertices[vertexIndex] = (R3D_Vertex){
-                .position = {posX, posY, posZ},
-                .texcoord = {x * stepU, z * stepV},
-                .normal = normal,
-                .color = WHITE,
-                .tangent = (Vector4) {tangent.x, tangent.y, tangent.z, 1.0f}
-            };
+            meshData.vertices[vertexIndex] = R3D_MakeVertex(
+                (Vector3){posX, posY, posZ},
+                (Vector2){x * stepU, z * stepV},
+                normal,
+                (Vector4){tangent.x, tangent.y, tangent.z, 1.0f},
+                WHITE
+            );
             vertexIndex++;
         }
     }
@@ -1528,10 +1550,10 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
                         {texUVs[2].x + texUVs[2].width, texUVs[2].y}
                     };
 
-                    vertices[vertexCount + 0] = (R3D_Vertex){{posX - halfW, cubeSize.y, posZ - halfL}, uvs[0], normals[2], {255, 255, 255, 255}, tangents[2]};
-                    vertices[vertexCount + 1] = (R3D_Vertex){{posX - halfW, cubeSize.y, posZ + halfL}, uvs[1], normals[2], {255, 255, 255, 255}, tangents[2]};
-                    vertices[vertexCount + 2] = (R3D_Vertex){{posX + halfW, cubeSize.y, posZ + halfL}, uvs[2], normals[2], {255, 255, 255, 255}, tangents[2]};
-                    vertices[vertexCount + 3] = (R3D_Vertex){{posX + halfW, cubeSize.y, posZ - halfL}, uvs[3], normals[2], {255, 255, 255, 255}, tangents[2]};
+                    vertices[vertexCount + 0] = R3D_MakeVertex((Vector3){posX - halfW, cubeSize.y, posZ - halfL}, uvs[0], normals[2], tangents[2], WHITE);
+                    vertices[vertexCount + 1] = R3D_MakeVertex((Vector3){posX - halfW, cubeSize.y, posZ + halfL}, uvs[1], normals[2], tangents[2], WHITE);
+                    vertices[vertexCount + 2] = R3D_MakeVertex((Vector3){posX + halfW, cubeSize.y, posZ + halfL}, uvs[2], normals[2], tangents[2], WHITE);
+                    vertices[vertexCount + 3] = R3D_MakeVertex((Vector3){posX + halfW, cubeSize.y, posZ - halfL}, uvs[3], normals[2], tangents[2], WHITE);
 
                     indices[indexCount + 0] = vertexCount + 0;
                     indices[indexCount + 1] = vertexCount + 1;
@@ -1554,10 +1576,10 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
                         {texUVs[3].x, texUVs[3].y}
                     };
 
-                    vertices[vertexCount + 0] = (R3D_Vertex){{posX - halfW, 0.0f, posZ - halfL}, uvs[0], normals[3], {255, 255, 255, 255}, tangents[3]};
-                    vertices[vertexCount + 1] = (R3D_Vertex){{posX + halfW, 0.0f, posZ + halfL}, uvs[1], normals[3], {255, 255, 255, 255}, tangents[3]};
-                    vertices[vertexCount + 2] = (R3D_Vertex){{posX - halfW, 0.0f, posZ + halfL}, uvs[2], normals[3], {255, 255, 255, 255}, tangents[3]};
-                    vertices[vertexCount + 3] = (R3D_Vertex){{posX + halfW, 0.0f, posZ - halfL}, uvs[3], normals[3], {255, 255, 255, 255}, tangents[3]};
+                    vertices[vertexCount + 0] = R3D_MakeVertex((Vector3){posX - halfW, 0.0f, posZ - halfL}, uvs[0], normals[3], tangents[3], WHITE);
+                    vertices[vertexCount + 1] = R3D_MakeVertex((Vector3){posX + halfW, 0.0f, posZ + halfL}, uvs[1], normals[3], tangents[3], WHITE);
+                    vertices[vertexCount + 2] = R3D_MakeVertex((Vector3){posX - halfW, 0.0f, posZ + halfL}, uvs[2], normals[3], tangents[3], WHITE);
+                    vertices[vertexCount + 3] = R3D_MakeVertex((Vector3){posX + halfW, 0.0f, posZ - halfL}, uvs[3], normals[3], tangents[3], WHITE);
 
                     indices[indexCount + 0] = vertexCount + 0;
                     indices[indexCount + 1] = vertexCount + 1;
@@ -1582,10 +1604,10 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
                         {texUVs[5].x + texUVs[5].width, texUVs[5].y + texUVs[5].height}
                     };
 
-                    vertices[vertexCount + 0] = (R3D_Vertex){{posX - halfW, cubeSize.y, posZ + halfL}, uvs[0], normals[5], {255, 255, 255, 255}, tangents[5]};
-                    vertices[vertexCount + 1] = (R3D_Vertex){{posX - halfW, 0.0f, posZ + halfL}, uvs[1], normals[5], {255, 255, 255, 255}, tangents[5]};
-                    vertices[vertexCount + 2] = (R3D_Vertex){{posX + halfW, cubeSize.y, posZ + halfL}, uvs[2], normals[5], {255, 255, 255, 255}, tangents[5]};
-                    vertices[vertexCount + 3] = (R3D_Vertex){{posX + halfW, 0.0f, posZ + halfL}, uvs[3], normals[5], {255, 255, 255, 255}, tangents[5]};
+                    vertices[vertexCount + 0] = R3D_MakeVertex((Vector3){posX - halfW, cubeSize.y, posZ + halfL}, uvs[0], normals[5], tangents[5], WHITE);
+                    vertices[vertexCount + 1] = R3D_MakeVertex((Vector3){posX - halfW, 0.0f, posZ + halfL}, uvs[1], normals[5], tangents[5], WHITE);
+                    vertices[vertexCount + 2] = R3D_MakeVertex((Vector3){posX + halfW, cubeSize.y, posZ + halfL}, uvs[2], normals[5], tangents[5], WHITE);
+                    vertices[vertexCount + 3] = R3D_MakeVertex((Vector3){posX + halfW, 0.0f, posZ + halfL}, uvs[3], normals[5], tangents[5], WHITE);
 
                     indices[indexCount + 0] = vertexCount + 0;
                     indices[indexCount + 1] = vertexCount + 1;
@@ -1608,10 +1630,10 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
                         {texUVs[4].x, texUVs[4].y}
                     };
 
-                    vertices[vertexCount + 0] = (R3D_Vertex){{posX + halfW, cubeSize.y, posZ - halfL}, uvs[0], normals[4], {255, 255, 255, 255}, tangents[4]};
-                    vertices[vertexCount + 1] = (R3D_Vertex){{posX - halfW, 0.0f, posZ - halfL}, uvs[1], normals[4], {255, 255, 255, 255}, tangents[4]};
-                    vertices[vertexCount + 2] = (R3D_Vertex){{posX + halfW, 0.0f, posZ - halfL}, uvs[2], normals[4], {255, 255, 255, 255}, tangents[4]};
-                    vertices[vertexCount + 3] = (R3D_Vertex){{posX - halfW, cubeSize.y, posZ - halfL}, uvs[3], normals[4], {255, 255, 255, 255}, tangents[4]};
+                    vertices[vertexCount + 0] = R3D_MakeVertex((Vector3){posX + halfW, cubeSize.y, posZ - halfL}, uvs[0], normals[4], tangents[4], WHITE);
+                    vertices[vertexCount + 1] = R3D_MakeVertex((Vector3){posX - halfW, 0.0f, posZ - halfL}, uvs[1], normals[4], tangents[4], WHITE);
+                    vertices[vertexCount + 2] = R3D_MakeVertex((Vector3){posX + halfW, 0.0f, posZ - halfL}, uvs[2], normals[4], tangents[4], WHITE);
+                    vertices[vertexCount + 3] = R3D_MakeVertex((Vector3){posX - halfW, cubeSize.y, posZ - halfL}, uvs[3], normals[4], tangents[4], WHITE);
 
                     indices[indexCount + 0] = vertexCount + 0;
                     indices[indexCount + 1] = vertexCount + 2;
@@ -1634,10 +1656,10 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
                         {texUVs[0].x + texUVs[0].width, texUVs[0].y + texUVs[0].height}
                     };
 
-                    vertices[vertexCount + 0] = (R3D_Vertex){{posX + halfW, cubeSize.y, posZ + halfL}, uvs[0], normals[0], {255, 255, 255, 255}, tangents[0]};
-                    vertices[vertexCount + 1] = (R3D_Vertex){{posX + halfW, 0.0f, posZ + halfL}, uvs[1], normals[0], {255, 255, 255, 255}, tangents[0]};
-                    vertices[vertexCount + 2] = (R3D_Vertex){{posX + halfW, cubeSize.y, posZ - halfL}, uvs[2], normals[0], {255, 255, 255, 255}, tangents[0]};
-                    vertices[vertexCount + 3] = (R3D_Vertex){{posX + halfW, 0.0f, posZ - halfL}, uvs[3], normals[0], {255, 255, 255, 255}, tangents[0]};
+                    vertices[vertexCount + 0] = R3D_MakeVertex((Vector3){posX + halfW, cubeSize.y, posZ + halfL}, uvs[0], normals[0], tangents[0], WHITE);
+                    vertices[vertexCount + 1] = R3D_MakeVertex((Vector3){posX + halfW, 0.0f, posZ + halfL}, uvs[1], normals[0], tangents[0], WHITE);
+                    vertices[vertexCount + 2] = R3D_MakeVertex((Vector3){posX + halfW, cubeSize.y, posZ - halfL}, uvs[2], normals[0], tangents[0], WHITE);
+                    vertices[vertexCount + 3] = R3D_MakeVertex((Vector3){posX + halfW, 0.0f, posZ - halfL}, uvs[3], normals[0], tangents[0], WHITE);
 
                     indices[indexCount + 0] = vertexCount + 0;
                     indices[indexCount + 1] = vertexCount + 1;
@@ -1660,10 +1682,10 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
                         {texUVs[1].x, texUVs[1].y + texUVs[1].height}
                     };
 
-                    vertices[vertexCount + 0] = (R3D_Vertex){{posX - halfW, cubeSize.y, posZ - halfL}, uvs[0], normals[1], {255, 255, 255, 255}, tangents[1]};
-                    vertices[vertexCount + 1] = (R3D_Vertex){{posX - halfW, 0.0f, posZ + halfL}, uvs[1], normals[1], {255, 255, 255, 255}, tangents[1]};
-                    vertices[vertexCount + 2] = (R3D_Vertex){{posX - halfW, cubeSize.y, posZ + halfL}, uvs[2], normals[1], {255, 255, 255, 255}, tangents[1]};
-                    vertices[vertexCount + 3] = (R3D_Vertex){{posX - halfW, 0.0f, posZ - halfL}, uvs[3], normals[1], {255, 255, 255, 255}, tangents[1]};
+                    vertices[vertexCount + 0] = R3D_MakeVertex((Vector3){posX - halfW, cubeSize.y, posZ - halfL}, uvs[0], normals[1], tangents[1], WHITE);
+                    vertices[vertexCount + 1] = R3D_MakeVertex((Vector3){posX - halfW, 0.0f, posZ + halfL}, uvs[1], normals[1], tangents[1], WHITE);
+                    vertices[vertexCount + 2] = R3D_MakeVertex((Vector3){posX - halfW, cubeSize.y, posZ + halfL}, uvs[2], normals[1], tangents[1], WHITE);
+                    vertices[vertexCount + 3] = R3D_MakeVertex((Vector3){posX - halfW, 0.0f, posZ - halfL}, uvs[3], normals[1], tangents[1], WHITE);
 
                     indices[indexCount + 0] = vertexCount + 0;
                     indices[indexCount + 1] = vertexCount + 1;
@@ -1686,10 +1708,10 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
                     {texUVs[2].x + texUVs[2].width, texUVs[2].y}
                 };
 
-                vertices[vertexCount + 0] = (R3D_Vertex){{posX - halfW, cubeSize.y, posZ - halfL}, uvs_top[0], normals[3], {255, 255, 255, 255}, tangents[3]};
-                vertices[vertexCount + 1] = (R3D_Vertex){{posX + halfW, cubeSize.y, posZ + halfL}, uvs_top[1], normals[3], {255, 255, 255, 255}, tangents[3]};
-                vertices[vertexCount + 2] = (R3D_Vertex){{posX - halfW, cubeSize.y, posZ + halfL}, uvs_top[2], normals[3], {255, 255, 255, 255}, tangents[3]};
-                vertices[vertexCount + 3] = (R3D_Vertex){{posX + halfW, cubeSize.y, posZ - halfL}, uvs_top[3], normals[3], {255, 255, 255, 255}, tangents[3]};
+                vertices[vertexCount + 0] = R3D_MakeVertex((Vector3){posX - halfW, cubeSize.y, posZ - halfL}, uvs_top[0], normals[3], tangents[3], WHITE);
+                vertices[vertexCount + 1] = R3D_MakeVertex((Vector3){posX + halfW, cubeSize.y, posZ + halfL}, uvs_top[1], normals[3], tangents[3], WHITE);
+                vertices[vertexCount + 2] = R3D_MakeVertex((Vector3){posX - halfW, cubeSize.y, posZ + halfL}, uvs_top[2], normals[3], tangents[3], WHITE);
+                vertices[vertexCount + 3] = R3D_MakeVertex((Vector3){posX + halfW, cubeSize.y, posZ - halfL}, uvs_top[3], normals[3], tangents[3], WHITE);
 
                 indices[indexCount + 0] = vertexCount + 0;
                 indices[indexCount + 1] = vertexCount + 1;
@@ -1709,10 +1731,10 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
                     {texUVs[3].x, texUVs[3].y}
                 };
 
-                vertices[vertexCount + 0] = (R3D_Vertex){{posX - halfW, 0.0f, posZ - halfL}, uvs_bottom[0], normals[2], {255, 255, 255, 255}, tangents[2]};
-                vertices[vertexCount + 1] = (R3D_Vertex){{posX - halfW, 0.0f, posZ + halfL}, uvs_bottom[1], normals[2], {255, 255, 255, 255}, tangents[2]};
-                vertices[vertexCount + 2] = (R3D_Vertex){{posX + halfW, 0.0f, posZ + halfL}, uvs_bottom[2], normals[2], {255, 255, 255, 255}, tangents[2]};
-                vertices[vertexCount + 3] = (R3D_Vertex){{posX + halfW, 0.0f, posZ - halfL}, uvs_bottom[3], normals[2], {255, 255, 255, 255}, tangents[2]};
+                vertices[vertexCount + 0] = R3D_MakeVertex((Vector3){posX - halfW, 0.0f, posZ - halfL}, uvs_bottom[0], normals[2], tangents[2], WHITE);
+                vertices[vertexCount + 1] = R3D_MakeVertex((Vector3){posX - halfW, 0.0f, posZ + halfL}, uvs_bottom[1], normals[2], tangents[2], WHITE);
+                vertices[vertexCount + 2] = R3D_MakeVertex((Vector3){posX + halfW, 0.0f, posZ + halfL}, uvs_bottom[2], normals[2], tangents[2], WHITE);
+                vertices[vertexCount + 3] = R3D_MakeVertex((Vector3){posX + halfW, 0.0f, posZ - halfL}, uvs_bottom[3], normals[2], tangents[2], WHITE);
 
                 indices[indexCount + 0] = vertexCount + 0;
                 indices[indexCount + 1] = vertexCount + 1;
@@ -1729,6 +1751,9 @@ R3D_MeshData R3D_GenMeshDataCubicmap(Image cubicmap, Vector3 cubeSize)
 
     // Cleaning
     UnloadImageColors(pixels);
+
+    meshData.vertexCount = vertexCount;
+    meshData.indexCount = indexCount;
 
     return meshData;
 }
@@ -1861,13 +1886,17 @@ void R3D_TransformMeshData(R3D_MeshData* meshData, Matrix transform)
 
     Matrix matNormal = r3d_matrix_normal(&transform);
 
-    for (int i = 0; i < meshData->vertexCount; i++) {
-        R3D_Vertex* vertex = &meshData->vertices[i];
-        vertex->position = r3d_vector3_transform(vertex->position, &transform);
-        vertex->normal = r3d_vector3_transform_normal(vertex->normal, &matNormal);
-        Vector3 tangent = {vertex->tangent.x, vertex->tangent.y, vertex->tangent.z};
-        tangent = Vector3Normalize(r3d_vector3_transform_normal(tangent, &transform));
-        vertex->tangent = (Vector4) {tangent.x, tangent.y, tangent.z, vertex->tangent.w};
+    for (int i = 0; i < meshData->vertexCount; i++)
+    {
+        R3D_Vertex* v = &meshData->vertices[i];
+        v->position = r3d_vector3_transform(v->position, &transform);
+
+        Vector3 normal = R3D_DecodeNormal((int8_t*)v->normal);
+        R3D_EncodeNormal((int8_t*)v->normal, r3d_vector3_transform_normal(normal, &matNormal));
+
+        Vector4 tangent = R3D_DecodeTangent((int8_t*)v->tangent);
+        Vector3 t = Vector3Normalize(r3d_vector3_transform_normal((Vector3){tangent.x, tangent.y, tangent.z}, &matNormal));
+        R3D_EncodeTangent((int8_t*)v->tangent, (Vector4){t.x, t.y, t.z, tangent.w});
     }
 }
 
@@ -1888,20 +1917,16 @@ void R3D_RotateMeshData(R3D_MeshData* meshData, Quaternion rotation)
 
     for (int i = 0; i < meshData->vertexCount; i++)
     {
-        meshData->vertices[i].position = Vector3RotateByQuaternion(meshData->vertices[i].position, rotation);
-        meshData->vertices[i].normal = Vector3RotateByQuaternion(meshData->vertices[i].normal, rotation);
+        R3D_Vertex* v = &meshData->vertices[i];
 
-        // Preserve w component for handedness
-        Vector3 tangentVec = (Vector3) {
-            meshData->vertices[i].tangent.x, 
-            meshData->vertices[i].tangent.y, 
-            meshData->vertices[i].tangent.z
-        };
-        tangentVec = Vector3RotateByQuaternion(tangentVec, rotation);
+        v->position = Vector3RotateByQuaternion(v->position, rotation);
 
-        meshData->vertices[i].tangent.x = tangentVec.x;
-        meshData->vertices[i].tangent.y = tangentVec.y;
-        meshData->vertices[i].tangent.z = tangentVec.z;
+        Vector3 normal = R3D_DecodeNormal((int8_t*)v->normal);
+        R3D_EncodeNormal((int8_t*)v->normal, Vector3RotateByQuaternion(normal, rotation));
+
+        Vector4 tangent = R3D_DecodeTangent((int8_t*)v->tangent);
+        Vector3 t = Vector3RotateByQuaternion((Vector3){tangent.x, tangent.y, tangent.z}, rotation);
+        R3D_EncodeTangent((int8_t*)v->tangent, (Vector4){t.x, t.y, t.z, tangent.w});
     }
 }
 
@@ -1909,35 +1934,30 @@ void R3D_ScaleMeshData(R3D_MeshData* meshData, Vector3 scale)
 {
     if (meshData == NULL || meshData->vertices == NULL) return;
 
-    if (scale.x != scale.y || scale.y != scale.z) {
-        Vector3 invScale = {
-            scale.x != 0.0f ? 1.0f / scale.x : 0.0f,
-            scale.y != 0.0f ? 1.0f / scale.y : 0.0f,
-            scale.z != 0.0f ? 1.0f / scale.z : 0.0f
-        };
-        for (int i = 0; i < meshData->vertexCount; i++) {
-            R3D_Vertex* v = &meshData->vertices[i];
-            v->position.x *= scale.x;
-            v->position.y *= scale.y;
-            v->position.z *= scale.z;
-            v->normal.x *= invScale.x;
-            v->normal.y *= invScale.y;
-            v->normal.z *= invScale.z;
-            v->normal = Vector3Normalize(v->normal);
-            v->tangent.x *= scale.x;
-            v->tangent.y *= scale.y;
-            v->tangent.z *= scale.z;
-            float w = v->tangent.w;
-            Vector3 t = Vector3Normalize((Vector3){v->tangent.x, v->tangent.y, v->tangent.z});
-            v->tangent = (Vector4) {t.x, t.y, t.z, w};
-        }
-    }
-    else {
-        for (int i = 0; i < meshData->vertexCount; i++) {
-            R3D_Vertex* v = &meshData->vertices[i];
-            v->position.x *= scale.x;
-            v->position.y *= scale.y;
-            v->position.z *= scale.z;
+    bool uniform = (scale.x == scale.y && scale.y == scale.z);
+
+    Vector3 invScale = {
+        scale.x != 0.0f ? 1.0f / scale.x : 0.0f,
+        scale.y != 0.0f ? 1.0f / scale.y : 0.0f,
+        scale.z != 0.0f ? 1.0f / scale.z : 0.0f
+    };
+
+    for (int i = 0; i < meshData->vertexCount; i++)
+    {
+        R3D_Vertex* v = &meshData->vertices[i];
+
+        v->position.x *= scale.x;
+        v->position.y *= scale.y;
+        v->position.z *= scale.z;
+
+        if (!uniform) {
+            Vector3 normal = R3D_DecodeNormal((int8_t*)v->normal);
+            normal = Vector3Normalize((Vector3){ normal.x * invScale.x, normal.y * invScale.y, normal.z * invScale.z });
+            R3D_EncodeNormal((int8_t*)v->normal, normal);
+
+            Vector4 tangent = R3D_DecodeTangent((int8_t*)v->tangent);
+            Vector3 t = Vector3Normalize((Vector3){ tangent.x * scale.x, tangent.y * scale.y, tangent.z * scale.z });
+            R3D_EncodeTangent((int8_t*)v->tangent, (Vector4){t.x, t.y, t.z, tangent.w});
         }
     }
 }
@@ -1956,7 +1976,7 @@ void R3D_GenMeshDataUVsPlanar(R3D_MeshData* meshData, Vector2 uvScale, Vector3 a
         Vector3 pos = meshData->vertices[i].position;
         float u = Vector3DotProduct(pos, tangent) * uvScale.x;
         float v = Vector3DotProduct(pos, bitangent) * uvScale.y;
-        meshData->vertices[i].texcoord = (Vector2) {u, v};
+        R3D_EncodeTexCoord(meshData->vertices[i].texcoord, (Vector2){u, v});
     }
 }
 
@@ -1968,7 +1988,7 @@ void R3D_GenMeshDataUVsSpherical(R3D_MeshData* meshData)
         Vector3 pos = Vector3Normalize(meshData->vertices[i].position);
         float u = 0.5f + atan2f(pos.z, pos.x) / (2.0f * PI);
         float v = 0.5f - asinf(pos.y) * (1.0f / PI);
-        meshData->vertices[i].texcoord = (Vector2) {u, v};
+        R3D_EncodeTexCoord(meshData->vertices[i].texcoord, (Vector2){u, v});
     }
 }
 
@@ -1980,11 +2000,11 @@ void R3D_GenMeshDataUVsCylindrical(R3D_MeshData* meshData)
         Vector3 pos = meshData->vertices[i].position;
         float u = 0.5f + atan2f(pos.z, pos.x) / (2.0f * PI);
         float v = pos.y;
-        meshData->vertices[i].texcoord = (Vector2) {u, v};
+        R3D_EncodeTexCoord(meshData->vertices[i].texcoord, (Vector2){u, v});
     }
 }
 
-static void accumulate_face_normal(R3D_MeshData* meshData, uint32_t i0, uint32_t i1, uint32_t i2)
+static void accumulate_face_normal(Vector3* normals, R3D_MeshData* meshData, uint32_t i0, uint32_t i1, uint32_t i2)
 {
     Vector3 v0 = meshData->vertices[i0].position;
     Vector3 v1 = meshData->vertices[i1].position;
@@ -1995,9 +2015,9 @@ static void accumulate_face_normal(R3D_MeshData* meshData, uint32_t i0, uint32_t
         Vector3Subtract(v2, v0)
     );
 
-    meshData->vertices[i0].normal = Vector3Add(meshData->vertices[i0].normal, faceNormal);
-    meshData->vertices[i1].normal = Vector3Add(meshData->vertices[i1].normal, faceNormal);
-    meshData->vertices[i2].normal = Vector3Add(meshData->vertices[i2].normal, faceNormal);
+    normals[i0] = Vector3Add(normals[i0], faceNormal);
+    normals[i1] = Vector3Add(normals[i1], faceNormal);
+    normals[i2] = Vector3Add(normals[i2], faceNormal);
 }
 
 void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType type)
@@ -2009,39 +2029,39 @@ void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType type)
     if (type == R3D_PRIMITIVE_POINTS ||  type == R3D_PRIMITIVE_LINES ||
         type == R3D_PRIMITIVE_LINE_STRIP ||  type == R3D_PRIMITIVE_LINE_LOOP) {
         for (int i = 0; i < meshData->vertexCount; i++) {
-            meshData->vertices[i].normal = (Vector3) {0.0f, 0.0f, 1.0f};
+            R3D_EncodeNormal((int8_t*)meshData->vertices[i].normal, (Vector3){0.0f, 0.0f, 1.0f});
         }
         return;
     }
 
-    for (int i = 0; i < meshData->vertexCount; i++) {
-        meshData->vertices[i].normal = (Vector3) {0};
-    }
+    // Accumulate in float to avoid precision loss
+    Vector3* normals = RL_CALLOC(meshData->vertexCount, sizeof(Vector3));
+    if (normals == NULL) return;
 
     int count = meshData->indexCount > 0 ? meshData->indexCount : meshData->vertexCount;
 
     switch (type) {
-    case R3D_PRIMITIVE_TRIANGLES: {
+    case R3D_PRIMITIVE_TRIANGLES:
         for (int i = 0; i + 2 < count; i += 3) {
-            accumulate_face_normal(meshData,
+            accumulate_face_normal(normals, meshData,
                 get_index(meshData, i),
                 get_index(meshData, i + 1),
                 get_index(meshData, i + 2)
             );
         }
-    } break;
-    case R3D_PRIMITIVE_TRIANGLE_STRIP: {
+        break;
+    case R3D_PRIMITIVE_TRIANGLE_STRIP:
         for (int i = 0; i + 2 < count; i++) {
             uint32_t i0 = get_index(meshData, i % 2 == 0 ? i     : i + 1);
             uint32_t i1 = get_index(meshData, i % 2 == 0 ? i + 1 : i    );
             uint32_t i2 = get_index(meshData, i + 2);
-            accumulate_face_normal(meshData, i0, i1, i2);
+            accumulate_face_normal(normals, meshData, i0, i1, i2);
         }
-    } break;
+        break;
     case R3D_PRIMITIVE_TRIANGLE_FAN: {
         uint32_t center = get_index(meshData, 0);
         for (int i = 1; i + 1 < count; i++) {
-            accumulate_face_normal(meshData,
+            accumulate_face_normal(normals, meshData,
                 center,
                 get_index(meshData, i),
                 get_index(meshData, i + 1)
@@ -2053,19 +2073,21 @@ void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType type)
     }
 
     for (int i = 0; i < meshData->vertexCount; i++) {
-        meshData->vertices[i].normal = Vector3Normalize(meshData->vertices[i].normal);
+        R3D_EncodeNormal((int8_t*)meshData->vertices[i].normal, Vector3Normalize(normals[i]));
     }
+
+    RL_FREE(normals);
 }
 
-static void process_triangle_tangents(R3D_MeshData* meshData, Vector3* bitangents, uint32_t i0, uint32_t i1, uint32_t i2)
+static void process_triangle_tangents(Vector3* tangents, Vector3* bitangents, R3D_MeshData* meshData, uint32_t i0, uint32_t i1, uint32_t i2)
 {
     Vector3 v0 = meshData->vertices[i0].position;
     Vector3 v1 = meshData->vertices[i1].position;
     Vector3 v2 = meshData->vertices[i2].position;
 
-    Vector2 uv0 = meshData->vertices[i0].texcoord;
-    Vector2 uv1 = meshData->vertices[i1].texcoord;
-    Vector2 uv2 = meshData->vertices[i2].texcoord;
+    Vector2 uv0 = R3D_DecodeTexCoord(meshData->vertices[i0].texcoord);
+    Vector2 uv1 = R3D_DecodeTexCoord(meshData->vertices[i1].texcoord);
+    Vector2 uv2 = R3D_DecodeTexCoord(meshData->vertices[i2].texcoord);
 
     Vector3 edge1 = Vector3Subtract(v1, v0);
     Vector3 edge2 = Vector3Subtract(v2, v0);
@@ -2090,18 +2112,9 @@ static void process_triangle_tangents(R3D_MeshData* meshData, Vector3* bitangent
         invDet * (-deltaUV2.x * edge1.z + deltaUV1.x * edge2.z)
     };
 
-    meshData->vertices[i0].tangent.x += tangent.x;
-    meshData->vertices[i0].tangent.y += tangent.y;
-    meshData->vertices[i0].tangent.z += tangent.z;
-
-    meshData->vertices[i1].tangent.x += tangent.x;
-    meshData->vertices[i1].tangent.y += tangent.y;
-    meshData->vertices[i1].tangent.z += tangent.z;
-
-    meshData->vertices[i2].tangent.x += tangent.x;
-    meshData->vertices[i2].tangent.y += tangent.y;
-    meshData->vertices[i2].tangent.z += tangent.z;
-
+    tangents[i0] = Vector3Add(tangents[i0], tangent);
+    tangents[i1] = Vector3Add(tangents[i1], tangent);
+    tangents[i2] = Vector3Add(tangents[i2], tangent);
     bitangents[i0] = Vector3Add(bitangents[i0], bitangent);
     bitangents[i1] = Vector3Add(bitangents[i1], bitangent);
     bitangents[i2] = Vector3Add(bitangents[i2], bitangent);
@@ -2116,47 +2129,44 @@ void R3D_GenMeshDataTangents(R3D_MeshData* meshData, R3D_PrimitiveType type)
     if (type == R3D_PRIMITIVE_POINTS || type == R3D_PRIMITIVE_LINES ||
         type == R3D_PRIMITIVE_LINE_STRIP || type == R3D_PRIMITIVE_LINE_LOOP) {
         for (int i = 0; i < meshData->vertexCount; i++) {
-            meshData->vertices[i].tangent = (Vector4){ 1.0f, 0.0f, 0.0f, 1.0f };
+            R3D_EncodeTangent((int8_t*)meshData->vertices[i].tangent, (Vector4){ 1.0f, 0.0f, 0.0f, 1.0f });
         }
         return;
     }
 
+    Vector3* tangents = RL_CALLOC(meshData->vertexCount, sizeof(Vector3));
     Vector3* bitangents = RL_CALLOC(meshData->vertexCount, sizeof(Vector3));
-    if (bitangents == NULL) {
+    if (tangents == NULL || bitangents == NULL) {
         R3D_TRACELOG(LOG_ERROR, "Failed to allocate memory for tangent calculation");
+        RL_FREE(tangents);
+        RL_FREE(bitangents);
         return;
-    }
-
-    for (int i = 0; i < meshData->vertexCount; i++) {
-        meshData->vertices[i].tangent = (Vector4) {0};
     }
 
     int count = meshData->indexCount > 0 ? meshData->indexCount : meshData->vertexCount;
 
     switch (type) {
-    case R3D_PRIMITIVE_TRIANGLES: {
+    case R3D_PRIMITIVE_TRIANGLES:
         for (int i = 0; i + 2 < count; i += 3) {
-            process_triangle_tangents(
-                meshData, bitangents,
+            process_triangle_tangents(tangents, bitangents, meshData,
                 get_index(meshData, i),
                 get_index(meshData, i + 1),
                 get_index(meshData, i + 2)
             );
         }
-    } break;
-    case R3D_PRIMITIVE_TRIANGLE_STRIP: {
+        break;
+    case R3D_PRIMITIVE_TRIANGLE_STRIP:
         for (int i = 0; i + 2 < count; i++) {
             uint32_t i0 = get_index(meshData, i % 2 == 0 ? i     : i + 1);
             uint32_t i1 = get_index(meshData, i % 2 == 0 ? i + 1 : i    );
             uint32_t i2 = get_index(meshData, i + 2);
-            process_triangle_tangents(meshData, bitangents, i0, i1, i2);
+            process_triangle_tangents(tangents, bitangents, meshData, i0, i1, i2);
         }
-    } break;
+        break;
     case R3D_PRIMITIVE_TRIANGLE_FAN: {
         uint32_t center = get_index(meshData, 0);
         for (int i = 1; i + 1 < count; i++) {
-            process_triangle_tangents(
-                meshData, bitangents,
+            process_triangle_tangents(tangents, bitangents, meshData,
                 center,
                 get_index(meshData, i),
                 get_index(meshData, i + 1)
@@ -2170,29 +2180,25 @@ void R3D_GenMeshDataTangents(R3D_MeshData* meshData, R3D_PrimitiveType type)
     // Orthogonalization (Gram-Schmidt) and handedness calculation
     for (int i = 0; i < meshData->vertexCount; i++)
     {
-        Vector3 n = meshData->vertices[i].normal;
-        Vector3 t = {
-            meshData->vertices[i].tangent.x,
-            meshData->vertices[i].tangent.y,
-            meshData->vertices[i].tangent.z
-        };
+        Vector3 n = R3D_DecodeNormal((int8_t*)meshData->vertices[i].normal);
+        Vector3 t = tangents[i];
 
         // Gram-Schmidt orthogonalization
         t = Vector3Subtract(t, Vector3Scale(n, Vector3DotProduct(n, t)));
         float tLength = Vector3Length(t);
         if (tLength > 1e-6f) {
             t = Vector3Scale(t, 1.0f / tLength);
-        }
-        else {
+        } else {
             // Fallback: generate an arbitrary tangent perpendicular to the normal
-            t = fabsf(n.x) < 0.9f ? (Vector3) {1.0f, 0.0f, 0.0f } : (Vector3) {0.0f, 1.0f, 0.0f };
+            t = fabsf(n.x) < 0.9f ? (Vector3){1.0f, 0.0f, 0.0f} : (Vector3){0.0f, 1.0f, 0.0f};
             t = Vector3Normalize(Vector3Subtract(t, Vector3Scale(n, Vector3DotProduct(n, t))));
         }
 
-        float handedness = (Vector3DotProduct(Vector3CrossProduct(n, t), bitangents[i]) < 0.0f) ? -1.0f : 1.0f;
-        meshData->vertices[i].tangent = (Vector4) {t.x, t.y, t.z, handedness };
+        float handedness = Vector3DotProduct(Vector3CrossProduct(n, t), bitangents[i]) < 0.0f ? -1.0f : 1.0f;
+        R3D_EncodeTangent((int8_t*)meshData->vertices[i].tangent, (Vector4){t.x, t.y, t.z, handedness});
     }
 
+    RL_FREE(tangents);
     RL_FREE(bitangents);
 }
 

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -1388,12 +1388,6 @@ R3D_MeshData R3D_GenMeshDataHeightmap(Image heightmap, Vector3 size)
         return meshData;
     }
 
-    if (!meshData.vertices || !meshData.indices) {
-        if (meshData.vertices) RL_FREE(meshData.vertices);
-        if (meshData.indices) RL_FREE(meshData.indices);
-        return meshData;
-    }
-
     const float halfSizeX = size.x * 0.5f;
     const float halfSizeZ = size.z * 0.5f;
     const float stepX     = size.x / (mapWidth - 1);
@@ -1869,7 +1863,7 @@ R3D_MeshData R3D_MergeMeshData(R3D_MeshData a, R3D_MeshData b)
 
 void R3D_AppendMeshData(R3D_MeshData* meshData, R3D_Vertex* vertices, int vertexCount, uint32_t* indices, int indexCount)
 {
-    R3D_ReserveMeshData(meshData, vertexCount, indexCount);
+    R3D_ReserveMeshData(meshData, meshData->vertexCount + vertexCount, meshData->indexCount + indexCount);
 
     for (int i = 0; i < vertexCount; i++) {
         meshData->vertices[meshData->vertexCount++] = vertices[i];
@@ -2239,6 +2233,8 @@ bool alloc_mesh(R3D_MeshData* meshData, int vertexCount, int indexCount)
 
     meshData->vertexCount = vertexCount;
     meshData->indexCount = indexCount;
+    meshData->vertexCapacity = vertexCount;
+    meshData->indexCapacity = indexCount;
 
     return true;
 }

--- a/src/r3d_vertex.c
+++ b/src/r3d_vertex.c
@@ -1,0 +1,76 @@
+/* r3d_vertex.c -- R3D Vertex Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#include <r3d/r3d_vertex.h>
+#include <math.h>
+
+#include "./common/r3d_half.h"
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+R3D_Vertex R3D_MakeVertex(Vector3 position, Vector2 texcoord, Vector3 normal, Vector4 tangent, Color color)
+{
+    R3D_Vertex v = {0};
+    v.position = position;
+    R3D_EncodeTexCoord(v.texcoord, texcoord);
+    R3D_EncodeNormal((int8_t*)v.normal, normal);
+    R3D_EncodeTangent((int8_t*)v.tangent, tangent);
+    v.color = color;
+    return v;
+}
+
+void R3D_EncodeTexCoord(uint16_t* dst, Vector2 src)
+{
+    dst[0] = r3d_half_from_float(src.x);
+    dst[1] = r3d_half_from_float(src.y);
+}
+
+Vector2 R3D_DecodeTexCoord(const uint16_t* src)
+{
+    Vector2 result;
+    result.x = r3d_half_from_float(src[0]);
+    result.y = r3d_half_from_float(src[1]);
+    return result;
+}
+
+void R3D_EncodeNormal(int8_t* dst, Vector3 src)
+{
+    dst[0] = (int8_t)roundf(src.x * 127.0f);
+    dst[1] = (int8_t)roundf(src.y * 127.0f);
+    dst[2] = (int8_t)roundf(src.z * 127.0f);
+    dst[3] = 0;
+}
+
+Vector3 R3D_DecodeNormal(const int8_t* src)
+{
+    return (Vector3){
+        src[0] / 127.0f,
+        src[1] / 127.0f,
+        src[2] / 127.0f
+    };
+}
+
+void R3D_EncodeTangent(int8_t* dst, Vector4 src)
+{
+    dst[0] = (int8_t)roundf(src.x * 127.0f);
+    dst[1] = (int8_t)roundf(src.y * 127.0f);
+    dst[2] = (int8_t)roundf(src.z * 127.0f);
+    dst[3] = (src.w >= 0.0f) ? 127 : -127;
+}
+
+Vector4 R3D_DecodeTangent(const int8_t* src)
+{
+    return (Vector4){
+        src[0] / 127.0f,
+        src[1] / 127.0f,
+        src[2] / 127.0f,
+        (src[3] >= 0) ? 1.0f : -1.0f
+    };
+}


### PR DESCRIPTION
Reduces `R3D_Vertex` from 64 _(and even previously 86)_ to 36 bytes by compressing attributes.

### Internal changes

- `texcoord` changed from `Vector2` (float32x2) to `uint16_t[2]` (float16x2)
- `normal` changed from `Vector3` (float32x3) to `int8_t[4]` (snorm8 XYZ, W=0)
- `tangent` changed from `Vector4` (float32x4) to `int8_t[4]` (snorm8 XYZ, W=handedness +/-127)
- `R3D_GenMeshDataNormals` and `R3D_GenMeshDataTangents` updated to accumulate in temporary float32 buffers before encoding
- VAO attribute configuration updated: `GL_HALF_FLOAT` for texcoords, `GL_BYTE` normalized for normals and tangents

### API changes

New public functions added to `r3d_vertex.h`:

```c
R3D_Vertex R3D_MakeVertex(Vector3 position, Vector2 texcoord, Vector3 normal, Vector4 tangent, Color color);

void R3D_EncodeTexCoord(uint16_t* dst, Vector2 src);
Vector2 R3D_DecodeTexCoord(const uint16_t* src);

void R3D_EncodeNormal(int8_t* dst, Vector3 src);
Vector3 R3D_DecodeNormal(const int8_t* src);

void R3D_EncodeTangent(int8_t* dst, Vector4 src);
Vector4 R3D_DecodeTangent(const int8_t* src);
```

### Breaking changes

Direct field access on `R3D_Vertex.texcoord`, `.normal`, and `.tangent` is no longer valid for reading or writing float values. Any external code constructing vertices manually must be updated to use `R3D_MakeVertex()` or the individual encode/decode functions.