### PR TITLE
Add render priority support to materials

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@
   This "simply" requires changing the number of levels of `R3D_TARGET_DEPTH` and `R3D_TARGET_SELECTOR` from '0' to the maximum value in `r3d_target.c`,
   then implementing a shared Hi-Z screen-space ray tracing method for SSR/SSGI (it should be reusable).
 
-* [ ] **Add a render priority index to `R3D_Material`**
+* [x] **Add a render priority index to `R3D_Material`**
   Add a signed integer indicating render priority in materials, in order to control whether certain objects should be rendered before or after others.
   It should integrate easily with the existing material-based sorting.
 

--- a/include/r3d/r3d_material.h
+++ b/include/r3d/r3d_material.h
@@ -74,6 +74,7 @@
         .blendMode = R3D_BLEND_MIX,                     \
         .cullMode = R3D_CULL_BACK,                      \
         .unlit = false,                                 \
+        .priority = 0,                                  \
         .shader = 0,                                    \
     }
 
@@ -263,9 +264,9 @@ typedef struct R3D_Material {
     R3D_BillboardMode billboardMode;        ///< Billboard mode (default: DISABLED)
     R3D_BlendMode blendMode;                ///< Blend mode (default: MIX)
     R3D_CullMode cullMode;                  ///< Face culling mode (default: BACK)
-
     bool unlit;                             ///< If true, material does not participate in lighting (default: false)
 
+    int priority;                           ///< Render order priority; lower values are drawn first (default: 0)
     R3D_SurfaceShader* shader;              ///< Custom shader applied to the material (default: NULL)
 
 } R3D_Material;

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -696,33 +696,33 @@ static inline float calculate_max_distance_to_camera(const BoundingBox* aabb, co
     return maxDistSq;
 }
 
-static inline void sort_fill_material_data(r3d_render_sort_t* sortData, const r3d_render_call_t* call)
+static inline void sort_fill_state_data(r3d_render_sort_state_t* state, const r3d_render_call_t* call)
 {
-    memset(sortData, 0, sizeof(*sortData));
+    memset(state, 0, sizeof(*state));
 
     switch (call->type) {
     case R3D_RENDER_CALL_MESH:
-        sortData->material.priority = call->mesh.material.priority;
-        sortData->material.shader = (uintptr_t)call->mesh.material.shader;
-        sortData->material.shading = call->mesh.material.unlit;
-        sortData->material.albedo = call->mesh.material.albedo.texture.id;
-        sortData->material.normal = call->mesh.material.normal.texture.id;
-        sortData->material.orm = call->mesh.material.orm.texture.id;
-        sortData->material.emission = call->mesh.material.emission.texture.id;
-        sortData->material.stencil = r3d_hash_fnv1a_32(&call->mesh.material.stencil, sizeof(call->mesh.material.stencil));
-        sortData->material.depth = r3d_hash_fnv1a_32(&call->mesh.material.depth, sizeof(call->mesh.material.depth));
-        sortData->material.blend = call->mesh.material.blendMode;
-        sortData->material.cull = call->mesh.material.cullMode;
-        sortData->material.transparency = call->mesh.material.transparencyMode;
-        sortData->material.billboard = call->mesh.material.billboardMode;
+        state->priority = call->mesh.material.priority;
+        state->shader = (uintptr_t)call->mesh.material.shader;
+        state->shading = call->mesh.material.unlit;
+        state->albedo = call->mesh.material.albedo.texture.id;
+        state->normal = call->mesh.material.normal.texture.id;
+        state->orm = call->mesh.material.orm.texture.id;
+        state->emission = call->mesh.material.emission.texture.id;
+        state->stencil = r3d_hash_fnv1a_32(&call->mesh.material.stencil, sizeof(call->mesh.material.stencil));
+        state->depth = r3d_hash_fnv1a_32(&call->mesh.material.depth, sizeof(call->mesh.material.depth));
+        state->blend = call->mesh.material.blendMode;
+        state->cull = call->mesh.material.cullMode;
+        state->transparency = call->mesh.material.transparencyMode;
+        state->billboard = call->mesh.material.billboardMode;
         break;
 
     case R3D_RENDER_CALL_DECAL:
-        sortData->material.shader = (uintptr_t)call->decal.instance.shader;
-        sortData->material.albedo = call->decal.instance.albedo.texture.id;
-        sortData->material.normal = call->decal.instance.normal.texture.id;
-        sortData->material.orm = call->decal.instance.orm.texture.id;
-        sortData->material.emission = call->decal.instance.emission.texture.id;
+        state->shader = (uintptr_t)call->decal.instance.shader;
+        state->albedo = call->decal.instance.albedo.texture.id;
+        state->normal = call->decal.instance.normal.texture.id;
+        state->orm = call->decal.instance.orm.texture.id;
+        state->emission = call->decal.instance.emission.texture.id;
         break;
     }
 }
@@ -745,7 +745,7 @@ static void sort_fill_cache_front_to_back(r3d_render_list_enum_t list)
             &call->mesh.instance.aabb, &group->transform
         );
         
-        sort_fill_material_data(sortData, call);
+        sort_fill_state_data(&sortData->state, call);
     }
 }
 
@@ -768,7 +768,7 @@ static void sort_fill_cache_back_to_front(r3d_render_list_enum_t list)
         );
 
         // For back-to-front (transparency), we don't sort by material.
-        //sort_fill_material_data(sortData, call);
+        //sort_fill_state_data(sortData, call);
     }
 }
 
@@ -784,7 +784,7 @@ static void sort_fill_cache_by_material(r3d_render_list_enum_t list)
 
         sortData->distance = 0.0f;
 
-        sort_fill_material_data(sortData, call);
+        sort_fill_state_data(&sortData->state, call);
     }
 }
 
@@ -801,13 +801,13 @@ static inline int compare_f32(float a, float b)
 static inline int compare_material(const r3d_render_sort_t* a, const r3d_render_sort_t* b)
 {
     // User priority first (signed)
-    if (a->material.priority != b->material.priority) {
-        return compare_i32(a->material.priority, b->material.priority);
+    if (a->state.priority != b->state.priority) {
+        return compare_i32(a->state.priority, b->state.priority);
     }
 
     // Remaining fields via memcmp (must be all unsigned, zero-padded)
-    size_t n = sizeof(a->material) - offsetof(typeof(a->material), shader);
-    return memcmp(&a->material.shader, &b->material.shader, n);
+    size_t n = sizeof(a->state) - offsetof(r3d_render_sort_state_t, shader);
+    return memcmp(&a->state.shader, &b->state.shader, n);
 }
 
 static int compare_front_to_back(const void* a, const void* b)
@@ -826,7 +826,7 @@ static int compare_back_to_front(const void* a, const void* b)
     const r3d_render_sort_t* aEntry = &R3D_MOD_RENDER.sortCache[*(const int*)(a)];
     const r3d_render_sort_t* bEntry = &R3D_MOD_RENDER.sortCache[*(const int*)(b)];
 
-    int cmp = compare_i32(aEntry->material.priority, bEntry->material.priority);
+    int cmp = compare_i32(aEntry->state.priority, bEntry->state.priority);
     if (cmp != 0) return cmp;
 
     return compare_f32(bEntry->distance, aEntry->distance);

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -767,8 +767,11 @@ static void sort_fill_cache_back_to_front(r3d_render_list_enum_t list)
             &call->mesh.instance.aabb, &group->transform
         );
 
-        // For back-to-front (transparency), we don't sort by material.
-        //sort_fill_state_data(sortData, call);
+        // For back-to-front sorting we just need the priority for the meshes
+        memset(&sortData->state, 0, sizeof(sortData->state));
+        if (call->type == R3D_RENDER_CALL_MESH) {
+            sortData->state.priority = call->mesh.material.priority;
+        }
     }
 }
 
@@ -783,7 +786,6 @@ static void sort_fill_cache_by_material(r3d_render_list_enum_t list)
         r3d_render_sort_t* sortData = &R3D_MOD_RENDER.sortCache[callIndex];
 
         sortData->distance = 0.0f;
-
         sort_fill_state_data(&sortData->state, call);
     }
 }

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -702,6 +702,7 @@ static inline void sort_fill_material_data(r3d_render_sort_t* sortData, const r3
 
     switch (call->type) {
     case R3D_RENDER_CALL_MESH:
+        sortData->material.priority = call->mesh.material.priority;
         sortData->material.shader = (uintptr_t)call->mesh.material.shader;
         sortData->material.shading = call->mesh.material.unlit;
         sortData->material.albedo = call->mesh.material.albedo.texture.id;
@@ -787,48 +788,56 @@ static void sort_fill_cache_by_material(r3d_render_list_enum_t list)
     }
 }
 
-static int compare_front_to_back(const void* a, const void* b)
+static inline int compare_i32(int32_t a, int32_t b)
 {
-    int indexA = *(int*)a;
-    int indexB = *(int*)b;
+    return (a > b) - (a < b);
+}
 
-    int materialCmp = memcmp(
-        &R3D_MOD_RENDER.sortCache[indexA].material,
-        &R3D_MOD_RENDER.sortCache[indexB].material,
-        sizeof(R3D_MOD_RENDER.sortCache[0].material)
-    );
+static inline int compare_f32(float a, float b)
+{
+    return (a > b) - (a < b);
+}
 
-    if (materialCmp != 0) {
-        return materialCmp;
+static inline int compare_material(const r3d_render_sort_t* a, const r3d_render_sort_t* b)
+{
+    // User priority first (signed)
+    if (a->material.priority != b->material.priority) {
+        return compare_i32(a->material.priority, b->material.priority);
     }
 
-    float distA = R3D_MOD_RENDER.sortCache[indexA].distance;
-    float distB = R3D_MOD_RENDER.sortCache[indexB].distance;
+    // Remaining fields via memcmp (must be all unsigned, zero-padded)
+    size_t n = sizeof(a->material) - offsetof(typeof(a->material), shader);
+    return memcmp(&a->material.shader, &b->material.shader, n);
+}
 
-    return (distA > distB) - (distA < distB);
+static int compare_front_to_back(const void* a, const void* b)
+{
+    const r3d_render_sort_t* aEntry = &R3D_MOD_RENDER.sortCache[*(const int*)(a)];
+    const r3d_render_sort_t* bEntry = &R3D_MOD_RENDER.sortCache[*(const int*)(b)];
+
+    int cmp = compare_material(aEntry, bEntry);
+    if (cmp != 0) return cmp;
+
+    return compare_f32(aEntry->distance, bEntry->distance);
 }
 
 static int compare_back_to_front(const void* a, const void* b)
 {
-    int indexA = *(int*)a;
-    int indexB = *(int*)b;
+    const r3d_render_sort_t* aEntry = &R3D_MOD_RENDER.sortCache[*(const int*)(a)];
+    const r3d_render_sort_t* bEntry = &R3D_MOD_RENDER.sortCache[*(const int*)(b)];
 
-    float distA = R3D_MOD_RENDER.sortCache[indexA].distance;
-    float distB = R3D_MOD_RENDER.sortCache[indexB].distance;
+    int cmp = compare_i32(aEntry->material.priority, bEntry->material.priority);
+    if (cmp != 0) return cmp;
 
-    return (distA < distB) - (distA > distB);
+    return compare_f32(bEntry->distance, aEntry->distance);
 }
 
 static int compare_materials_only(const void* a, const void* b)
 {
-    int indexA = *(int*)a;
-    int indexB = *(int*)b;
+    const r3d_render_sort_t* aEntry = &R3D_MOD_RENDER.sortCache[*(const int*)(a)];
+    const r3d_render_sort_t* bEntry = &R3D_MOD_RENDER.sortCache[*(const int*)(b)];
 
-    return memcmp(
-        &R3D_MOD_RENDER.sortCache[indexA].material,
-        &R3D_MOD_RENDER.sortCache[indexB].material,
-        sizeof(R3D_MOD_RENDER.sortCache[0].material)
-    );
+    return compare_material(aEntry, bEntry);
 }
 
 // ========================================
@@ -1402,20 +1411,20 @@ void r3d_render_sort_list(r3d_render_list_enum_t list, Vector3 viewPosition, r3d
 {
     G_sortViewPosition = viewPosition;
 
-    int (*compare_func)(const void *a, const void *b) = NULL;
+    int (*compareFunc)(const void *a, const void *b) = NULL;
     r3d_render_list_t* drawList = &R3D_MOD_RENDER.list[list];
 
     switch (mode) {
     case R3D_RENDER_SORT_FRONT_TO_BACK:
-        compare_func = compare_front_to_back;
+        compareFunc = compare_front_to_back;
         sort_fill_cache_front_to_back(list);
         break;
     case R3D_RENDER_SORT_BACK_TO_FRONT:
-        compare_func = compare_back_to_front;
+        compareFunc = compare_back_to_front;
         sort_fill_cache_back_to_front(list);
         break;
     case R3D_RENDER_SORT_MATERIAL_ONLY:
-        compare_func = compare_materials_only;
+        compareFunc = compare_materials_only;
         sort_fill_cache_by_material(list);
         break;
     }
@@ -1424,7 +1433,7 @@ void r3d_render_sort_list(r3d_render_list_enum_t list, Vector3 viewPosition, r3d
         drawList->calls,
         drawList->numCalls,
         sizeof(*drawList->calls),
-        compare_func
+        compareFunc
     );
 }
 

--- a/src/modules/r3d_render.h
+++ b/src/modules/r3d_render.h
@@ -259,25 +259,32 @@ typedef struct {
 } r3d_render_list_t;
 
 /*
- * Data stored by draw call in the sort cache.
+ * Sort key derived from a rendering state.
+ * Fields are declared in priority order: the first differing field
+ * encountered during comparison determines the sort result.
  */
 typedef struct {
+    int32_t priority;       ///< User-defined render order (signed, lower = first)
+    uintptr_t shader;       ///< Shader program pointer
+    uint32_t shading;       ///< Shading mode (lit/unlit)
+    uint32_t albedo;        ///< Albedo texture ID
+    uint32_t normal;        ///< Normal map texture ID
+    uint32_t orm;           ///< ORM texture ID
+    uint32_t emission;      ///< Emission texture ID
+    uint32_t stencil;       ///< Hashed stencil state
+    uint32_t depth;         ///< Hashed depth state
+    uint8_t blend;          ///< Blend mode
+    uint8_t cull;           ///< Cull mode
+    uint8_t transparency;   ///< Transparency mode
+    uint8_t billboard;      ///< Billboard mode
+} r3d_render_sort_state_t;
+
+/*
+ * Data stored per draw call in the sort cache.
+ */
+typedef struct {
+    r3d_render_sort_state_t state;
     float distance;
-    struct {
-        int32_t priority;
-        uintptr_t shader;
-        uint32_t shading;
-        uint32_t albedo;
-        uint32_t normal;
-        uint32_t orm;
-        uint32_t emission;
-        uint32_t stencil;
-        uint32_t depth;
-        uint8_t blend;
-        uint8_t cull;
-        uint8_t transparency;
-        uint8_t billboard;
-    } material;
 } r3d_render_sort_t;
 
 // ========================================

--- a/src/modules/r3d_render.h
+++ b/src/modules/r3d_render.h
@@ -264,6 +264,7 @@ typedef struct {
 typedef struct {
     float distance;
     struct {
+        int32_t priority;
         uintptr_t shader;
         uint32_t shading;
         uint32_t albedo;


### PR DESCRIPTION
A signed `priority` field has been added to `R3D_Material`, allowing to explicitly control draw order. Lower values are drawn first. Negative values are supported.

The internal sort comparators have been updated accordingly. Priority is always evaluated first, before any other criterion like material state changes or distance from camera.