### PR TITLE
Add mesh name support to `R3D_Model`

### DIFF
--- a/include/r3d/r3d_importer.h
+++ b/include/r3d/r3d_importer.h
@@ -32,9 +32,16 @@ typedef uint32_t R3D_ImportFlags;
 /**
  * @brief Keep a CPU-side copy of mesh data.
  *
- * When enabled, raw mesh data is preserved in RAM after model import.
+ * When enabled, raw mesh data is preserved in RAM after model import and stored in @c meshData.
  */
 #define R3D_IMPORT_MESH_DATA    (1 << 0)
+
+/**
+ * @brief Import and store mesh names from the model file.
+ *
+ * When enabled, mesh names are retrieved during import and stored in @c meshNames.
+ */
+#define R3D_IMPORT_MESH_NAMES   (1 << 1)
 
 /**
  * @brief Enable high-quality import processing.
@@ -45,7 +52,7 @@ typedef uint32_t R3D_ImportFlags;
  *
  * When disabled, a faster import preset is used, suitable for runtime.
  */
-#define R3D_IMPORT_QUALITY      (1 << 1)
+#define R3D_IMPORT_QUALITY      (1 << 2)
 
 // ========================================
 // STRUCTS TYPES

--- a/include/r3d/r3d_model.h
+++ b/include/r3d/r3d_model.h
@@ -149,6 +149,33 @@ R3DAPI R3D_Model R3D_LoadModelFromImporter(const R3D_Importer* importer);
  */
 R3DAPI void R3D_UnloadModel(R3D_Model model, bool unloadMaterials);
 
+/**
+ * @brief Returns the index of the mesh with the given name.
+ *
+ * @param model The model to search in.
+ * @param meshName The name of the mesh to look up.
+ * @return The mesh index, or -1 if not found or if @c meshNames is NULL.
+ */
+R3DAPI int R3D_GetModelMeshIndex(R3D_Model model, const char* meshName);
+
+/**
+ * @brief Returns a pointer to the mesh with the given name.
+ *
+ * @param model The model to search in.
+ * @param meshName The name of the mesh to look up.
+ * @return A pointer to the mesh, or NULL if not found or if @c meshNames is NULL.
+ */
+R3DAPI R3D_Mesh* R3D_GetModelMesh(R3D_Model model, const char* meshName);
+
+/**
+ * @brief Returns a pointer to the mesh data with the given name.
+ *
+ * @param model The model to search in.
+ * @param meshName The name of the mesh to look up.
+ * @return A pointer to the mesh data, or NULL if not found or if @c meshNames or @c meshData is NULL.
+ */
+R3DAPI R3D_MeshData* R3D_GetModelMeshData(R3D_Model model, const char* meshName);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/include/r3d/r3d_model.h
+++ b/include/r3d/r3d_model.h
@@ -21,6 +21,17 @@
  */
 
 // ========================================
+// ALIASES TYPES
+// ========================================
+
+/**
+ * @brief Fixed-length string type for mesh names.
+ *
+ * The size can be freely adjusted before compilation.
+ */
+typedef char R3D_MeshName[32];
+
+// ========================================
 // STRUCTS TYPES
 // ========================================
 
@@ -31,16 +42,18 @@
  */
 typedef struct R3D_Model {
 
-    R3D_Mesh* meshes;                   ///< Array of meshes composing the model.
-    R3D_MeshData* meshData;             ///< Array of meshes data in RAM (optional, can be NULL).
-    R3D_Material* materials;            ///< Array of materials used by the model.
-    int* meshMaterials;                 ///< Array of material indices, one per mesh.
+    R3D_Mesh* meshes;           ///< Array of meshes composing the model.
+    R3D_MeshData* meshData;     ///< Array of meshes data in RAM (optional, can be NULL).
+    R3D_MeshName* meshNames;    ///< Array of meshes names (optional, can be NULL).
 
-    int meshCount;                      ///< Number of meshes.
-    int materialCount;                  ///< Number of materials.
+    R3D_Material* materials;    ///< Array of materials used by the model.
+    int* meshMaterials;         ///< Array of material indices, one per mesh.
 
-    BoundingBox aabb;                   ///< Axis-Aligned Bounding Box encompassing the whole model.
-    R3D_Skeleton skeleton;              ///< Skeleton hierarchy and bind pose used for skinning (NULL if non-skinned).
+    int meshCount;              ///< Number of meshes.
+    int materialCount;          ///< Number of materials.
+
+    BoundingBox aabb;           ///< Axis-Aligned Bounding Box encompassing the whole model.
+    R3D_Skeleton skeleton;      ///< Skeleton hierarchy and bind pose used for skinning (NULL if non-skinned).
 
 } R3D_Model;
 

--- a/src/importer/r3d_importer_mesh.c
+++ b/src/importer/r3d_importer_mesh.c
@@ -254,6 +254,7 @@ static R3D_PrimitiveType get_primitive_type(unsigned int aiPrimitiveTypes)
 static bool load_mesh_internal(
     R3D_Mesh* outMesh,
     R3D_MeshData* outMeshData,
+    R3D_MeshName* outMeshName,
     const struct aiMesh* aiMesh,
     Matrix transform,
     bool hasBones)
@@ -314,8 +315,13 @@ static bool load_mesh_internal(
     R3D_PrimitiveType ptype = get_primitive_type(aiMesh->mPrimitiveTypes);
     *outMesh = R3D_LoadMesh(ptype, data, &aabb);
 
-    if (outMeshData == NULL) R3D_UnloadMeshData(data);
-    else *outMeshData = data;
+    if (outMeshData != NULL) *outMeshData = data;
+    else R3D_UnloadMeshData(data);
+
+    if (outMeshName != NULL && aiMesh->mName.length > 0) {
+        strncpy(*outMeshName, aiMesh->mName.data, sizeof(R3D_MeshName) - 1);
+        *outMeshName[sizeof(R3D_MeshName) - 1] = '\0';
+    }
 
     return true;
 }
@@ -334,7 +340,10 @@ static bool load_recursive(const R3D_Importer* importer, R3D_Model* model, const
         uint32_t meshIndex = node->mMeshes[i];
         const struct aiMesh* mesh = r3d_importer_get_mesh(importer, meshIndex);
 
-        if (!load_mesh_internal(&model->meshes[meshIndex], model->meshData ? &model->meshData[meshIndex] : NULL, mesh, globalTransform, mesh->mNumBones > 0)) {
+        R3D_MeshData* meshData = model->meshData ? &model->meshData[meshIndex] : NULL;
+        R3D_MeshName* meshName = model->meshNames ? &model->meshNames[meshIndex] : NULL;
+
+        if (!load_mesh_internal(&model->meshes[meshIndex], meshData, meshName, mesh, globalTransform, mesh->mNumBones > 0)) {
             R3D_TRACELOG(LOG_ERROR, "Unable to load mesh [%u]; The model will be invalid", meshIndex);
             return false;
         }
@@ -364,6 +373,8 @@ bool r3d_importer_load_meshes(const R3D_Importer* importer, R3D_Model* model)
     }
 
     bool keepMeshData = BIT_TEST(importer->flags, R3D_IMPORT_MESH_DATA);
+    bool keepMeshNames = BIT_TEST(importer->flags, R3D_IMPORT_MESH_NAMES);
+
     const struct aiScene* scene = r3d_importer_get_scene(importer);
 
     // Allocate space for meshes
@@ -371,7 +382,8 @@ bool r3d_importer_load_meshes(const R3D_Importer* importer, R3D_Model* model)
     model->meshes = RL_CALLOC(model->meshCount, sizeof(*model->meshes));
     model->meshMaterials = RL_CALLOC(model->meshCount, sizeof(*model->meshMaterials));
     if (keepMeshData) model->meshData = RL_CALLOC(model->meshCount, sizeof(*model->meshData));
-    if (!model->meshes || !model->meshMaterials || (keepMeshData && !model->meshData)) {
+    if (keepMeshNames) model->meshNames = RL_CALLOC(model->meshCount, sizeof(*model->meshNames));
+    if (!model->meshes || !model->meshMaterials || (keepMeshData && !model->meshData) || (keepMeshNames && !model->meshNames)) {
         R3D_TRACELOG(LOG_ERROR, "Unable to allocate memory for meshes");
         goto cleanup_and_fail;
     }

--- a/src/r3d_model.c
+++ b/src/r3d_model.c
@@ -170,3 +170,27 @@ void R3D_UnloadModel(R3D_Model model, bool unloadMaterials)
     RL_FREE(model.meshData);
     RL_FREE(model.meshes);
 }
+
+int R3D_GetModelMeshIndex(R3D_Model model, const char* meshName)
+{
+    if (model.meshNames == NULL) return -1;
+    for (int i = 0; i < model.meshCount; i++) {
+        if (strncmp(model.meshNames[i], meshName, sizeof(R3D_MeshName)) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+R3D_Mesh* R3D_GetModelMesh(R3D_Model model, const char* meshName)
+{
+    int index = R3D_GetModelMeshIndex(model, meshName);
+    return index >= 0 ? &model.meshes[index] : NULL;
+}
+
+R3D_MeshData* R3D_GetModelMeshData(R3D_Model model, const char* meshName)
+{
+    if (model.meshData == NULL) return NULL;
+    int index = R3D_GetModelMeshIndex(model, meshName);
+    return index >= 0 ? &model.meshData[index] : NULL;
+}


### PR DESCRIPTION
Introduces optional mesh name storage on import, controlled by the new `R3D_IMPORT_MESH_NAMES` flag.
When enabled, names are stored in the `meshNames` field of `R3D_Model` as a `R3D_MeshName[]` array.

Also adds three lookup helpers:
- `R3D_GetModelMeshIndex` find a mesh index by name
- `R3D_GetModelMesh` get a mesh pointer by name
- `R3D_GetModelMeshData` get mesh data pointer by name

All helpers return NULL/-1 if `meshNames` is not populated.