### PR TITLE
Replace SSIL-VB with SSDO and rework SSAO

### DIFF
--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -225,30 +225,27 @@ typedef struct R3D_EnvSSAO {
     float power;            ///< Exponential falloff for sharper darkening (default: 1.0)
     float maxRadius;        ///< Fraction of screen height beyond which the sampling radius is clamped (default: 0.2)
     float radius;           ///< Sampling radius in world space (default: 1.0)
-    float bias;             ///< Depth bias to prevent self-shadowing (default: 0.03)
+    float bias;             ///< Depth bias to prevent self-occlusion artifacts, in world-space units (default: 0.03)
     bool enabled;           ///< Enable/disable SSAO effect (default: false)
 } R3D_EnvSSAO;
 
 /**
  * @brief Screen Space Indirect Lighting (SSIL) settings.
  *
- * Approximates indirect lighting by gathering light from nearby visible
- * surfaces in screen space.
- *
- * With a small radius, SSIL behaves like an extension of SSAO,
- * producing a very subtle local blending of light and surface hues.
- * With a larger radius, it becomes a better complement to SSGI,
- * reinforcing indirect lighting over a wider area.
+ * Extends the SSAO algorithm with a global illumination component: occluding
+ * surfaces not only darken the fragment (ambient occlusion) but also transfer
+ * their color to it (indirect light bounce). A larger radius than SSAO is
+ * generally preferable to capture meaningful indirect lighting contributions.
  */
 typedef struct R3D_EnvSSIL {
-    int sampleCount;        ///< Number of samples to compute SSAO (default: 16)
-    float giIntensity;      ///< Base lighting strength multiplier (default: 1.0)
-    float aoIntensity;      ///< Base occlusion strength multiplier (default: 1.0)
-    float aoPower;          ///< Exponential falloff for sharper darkening (default: 1.0)
+    int sampleCount;        ///< Number of samples to compute SSIL (default: 16)
+    float giIntensity;      ///< Indirect light strength multiplier (default: 1.0)
+    float aoIntensity;      ///< Ambient occlusion strength multiplier (default: 1.0)
+    float aoPower;          ///< Exponential falloff for sharper occlusion darkening (default: 1.0)
     float maxRadius;        ///< Fraction of screen height beyond which the sampling radius is clamped (default: 0.2)
     float radius;           ///< Sampling radius in world space (default: 4.0)
-    float bias;             ///< Depth bias to prevent self-shadowing (default: 0.03)
-    bool enabled;           ///< Enable/disable SSAO effect (default: false)
+    float bias;             ///< Depth bias to prevent self-occlusion artifacts, in world-space units (default: 0.03)
+    bool enabled;           ///< Enable/disable SSIL effect (default: false)
 } R3D_EnvSSIL;
 
 /**

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -67,21 +67,21 @@
         },                                              \
         .ssao = {                                       \
             .sampleCount = 16,                          \
-            .intensity = 0.5f,                          \
-            .power = 1.5f,                              \
+            .intensity = 1.0f,                          \
+            .power = 1.0f,                              \
             .maxRadius = 0.2f,                          \
-            .radius = 0.5f,                             \
-            .bias = 0.02f,                              \
+            .radius = 1.0f,                             \
+            .bias = 0.03f,                              \
             .enabled = false,                           \
         },                                              \
         .ssil = {                                       \
             .sampleCount = 16,                          \
-            .giIntensity = 4.0f,                        \
-            .aoIntensity = 0.5f,                        \
-            .aoPower = 1.5f,                            \
+            .giIntensity = 1.0f,                        \
+            .aoIntensity = 1.0f,                        \
+            .aoPower = 1.0f,                            \
             .maxRadius = 0.2f,                          \
             .radius = 4.0f,                             \
-            .bias = 0.02f,                              \
+            .bias = 0.03f,                              \
             .enabled = false,                           \
         },                                              \
         .ssgi = {                                       \
@@ -222,10 +222,10 @@ typedef struct R3D_EnvAmbient {
 typedef struct R3D_EnvSSAO {
     int sampleCount;        ///< Number of samples to compute SSAO (default: 16)
     float intensity;        ///< Base occlusion strength multiplier (default: 1.0)
-    float power;            ///< Exponential falloff for sharper darkening (default: 1.5)
+    float power;            ///< Exponential falloff for sharper darkening (default: 1.0)
     float maxRadius;        ///< Fraction of screen height beyond which the sampling radius is clamped (default: 0.2)
-    float radius;           ///< Sampling radius in world space (default: 0.25)
-    float bias;             ///< Depth bias to prevent self-shadowing, good value is ~2% of the radius (default: 0.007)
+    float radius;           ///< Sampling radius in world space (default: 1.0)
+    float bias;             ///< Depth bias to prevent self-shadowing (default: 0.03)
     bool enabled;           ///< Enable/disable SSAO effect (default: false)
 } R3D_EnvSSAO;
 
@@ -242,12 +242,12 @@ typedef struct R3D_EnvSSAO {
  */
 typedef struct R3D_EnvSSIL {
     int sampleCount;        ///< Number of samples to compute SSAO (default: 16)
-    float giIntensity;      ///< 
+    float giIntensity;      ///< Base lighting strength multiplier (default: 1.0)
     float aoIntensity;      ///< Base occlusion strength multiplier (default: 1.0)
-    float aoPower;          ///< Exponential falloff for sharper darkening (default: 1.5)
+    float aoPower;          ///< Exponential falloff for sharper darkening (default: 1.0)
     float maxRadius;        ///< Fraction of screen height beyond which the sampling radius is clamped (default: 0.2)
-    float radius;           ///< Sampling radius in world space (default: 0.25)
-    float bias;             ///< Depth bias to prevent self-shadowing, good value is ~2% of the radius (default: 0.007)
+    float radius;           ///< Sampling radius in world space (default: 4.0)
+    float bias;             ///< Depth bias to prevent self-shadowing (default: 0.03)
     bool enabled;           ///< Enable/disable SSAO effect (default: false)
 } R3D_EnvSSIL;
 

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -69,6 +69,7 @@
             .sampleCount = 16,                          \
             .intensity = 0.5f,                          \
             .power = 1.5f,                              \
+            .maxRadius = 0.2f,                          \
             .radius = 0.5f,                             \
             .bias = 0.02f,                              \
             .enabled = false,                           \
@@ -222,6 +223,7 @@ typedef struct R3D_EnvSSAO {
     int sampleCount;        ///< Number of samples to compute SSAO (default: 16)
     float intensity;        ///< Base occlusion strength multiplier (default: 1.0)
     float power;            ///< Exponential falloff for sharper darkening (default: 1.5)
+    float maxRadius;        ///< Fraction of screen height beyond which the sampling radius is clamped (default: 0.2)
     float radius;           ///< Sampling radius in world space (default: 0.25)
     float bias;             ///< Depth bias to prevent self-shadowing, good value is ~2% of the radius (default: 0.007)
     bool enabled;           ///< Enable/disable SSAO effect (default: false)

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -75,13 +75,13 @@
             .enabled = false,                           \
         },                                              \
         .ssil = {                                       \
-            .sampleCount = 2,                           \
-            .sliceCount = 4,                            \
-            .radius = 2.0f,                             \
-            .thickness = 1.0f,                          \
-            .intensity = 1.0f,                          \
-            .aoPower = 1.0f,                            \
-            .denoiseSteps = 4,                          \
+            .sampleCount = 16,                          \
+            .giIntensity = 4.0f,                        \
+            .aoIntensity = 0.5f,                        \
+            .aoPower = 1.5f,                            \
+            .maxRadius = 0.2f,                          \
+            .radius = 4.0f,                             \
+            .bias = 0.02f,                              \
             .enabled = false,                           \
         },                                              \
         .ssgi = {                                       \
@@ -241,14 +241,14 @@ typedef struct R3D_EnvSSAO {
  * reinforcing indirect lighting over a wider area.
  */
 typedef struct R3D_EnvSSIL {
-    int sampleCount;        ///< Number of samples to compute indirect lighting (default: 2)
-    int sliceCount;         ///< Number of depth slices for accumulation (default: 4)
-    float radius;           ///< Maximum distance to gather light from (default: 2.0)
-    float thickness;        ///< Thickness threshold for occluders (default: 1.0)
-    float intensity;        ///< IL intensity multiplier (default: 1.0)
-    float aoPower;          ///< AO exponent/power (default: 1.0)
-    int denoiseSteps;       ///< Number of denoiser iterations (default: 4)
-    bool enabled;           ///< Enable/disable SSIL effect (default: false)
+    int sampleCount;        ///< Number of samples to compute SSAO (default: 16)
+    float giIntensity;      ///< 
+    float aoIntensity;      ///< Base occlusion strength multiplier (default: 1.0)
+    float aoPower;          ///< Exponential falloff for sharper darkening (default: 1.5)
+    float maxRadius;        ///< Fraction of screen height beyond which the sampling radius is clamped (default: 0.2)
+    float radius;           ///< Sampling radius in world space (default: 0.25)
+    float bias;             ///< Depth bias to prevent self-shadowing, good value is ~2% of the radius (default: 0.007)
+    bool enabled;           ///< Enable/disable SSAO effect (default: false)
 } R3D_EnvSSIL;
 
 /**

--- a/shaders/deferred/ambient.frag
+++ b/shaders/deferred/ambient.frag
@@ -36,8 +36,8 @@ uniform samplerCubeArray uPrefilterTex;
 uniform sampler2D uBrdfLutTex;
 
 uniform float uSsaoPower;
-uniform float uSsilIntensity;
 uniform float uSsilAoPower;
+uniform float uSsilIntensity;
 uniform float uSsgiIntensity;
 
 /* === Blocks === */

--- a/shaders/prepare/ssao.frag
+++ b/shaders/prepare/ssao.frag
@@ -113,7 +113,7 @@ void main()
     aoSum /= (temp * temp);
 
     // Attenuate intensity proportionally when ssRadius was clamped, preventing over-darkening at close range
-    float ao = max(0.0, 1.0 - (aoSum / float(uSampleCount)) * uIntensity * radiusScale);
+    float ao = max(0.0, 1.0 - aoSum * uIntensity * (2.0 / float(uSampleCount)) * radiusScale);
 
     // 1-pixel bilateral filter using derivatives (almost free)
     if (abs(dFdx(depth)) < 0.2) ao -= dFdx(ao) * (float(pixelCoord.x & 1) - 0.5);

--- a/shaders/prepare/ssao.frag
+++ b/shaders/prepare/ssao.frag
@@ -29,6 +29,7 @@ uniform int uSampleCount;
 uniform float uRadius;
 uniform float uBias;
 uniform float uIntensity;
+uniform float uMaxSSRadius;
 
 /* === Constants === */
 
@@ -78,7 +79,10 @@ void main()
     vec3 normal = V_GetViewNormal(uNormalTex, pixelCoord);
 
     float projScale = abs(uView.proj[1][1]) * textureSize(uDepthTex, 0).y * 0.5;
-    float ssRadius = projScale * uRadius / max(depth, 0.1);
+    float ssRadiusRaw = projScale * uRadius / max(depth, 0.1);
+    float ssRadius = min(ssRadiusRaw, uMaxSSRadius);
+
+    float radiusScale = ssRadius / max(ssRadiusRaw, 1e-4);
     float radiusSq = uRadius * uRadius;
 
     // Here we use an IGN instead of the hash from the HPG12 AlchemyAO paper.
@@ -107,13 +111,13 @@ void main()
 
     float temp = radiusSq * uRadius;
     aoSum /= (temp * temp);
-    
-    float A = max(0.0, 1.0 - aoSum * uIntensity * (4.0 / float(uSampleCount)));
+
+    // Attenuate intensity proportionally when ssRadius was clamped, preventing over-darkening at close range
+    float ao = max(0.0, 1.0 - aoSum * uIntensity * (4.0 / float(uSampleCount)) * radiusScale);
 
     // 1-pixel bilateral filter using derivatives (almost free)
-	if (abs(dFdx(depth)) < 0.2) A -= dFdx(A) * (float(pixelCoord.x & 1) - 0.5);
-    if (abs(dFdy(depth)) < 0.2) A -= dFdy(A) * (float(pixelCoord.y & 1) - 0.5);
+    if (abs(dFdx(depth)) < 0.2) ao -= dFdx(ao) * (float(pixelCoord.x & 1) - 0.5);
+    if (abs(dFdy(depth)) < 0.2) ao -= dFdy(ao) * (float(pixelCoord.y & 1) - 0.5);
 
-    // SAO tends to over-darken near surfaces; smoothly fade it out
-    FragOcclusion = mix(A, 1.0, 1.0 - clamp(0.5 * depth, 0.0, 1.0));
+    FragOcclusion = ao;
 }

--- a/shaders/prepare/ssao.frag
+++ b/shaders/prepare/ssao.frag
@@ -113,7 +113,7 @@ void main()
     aoSum /= (temp * temp);
 
     // Attenuate intensity proportionally when ssRadius was clamped, preventing over-darkening at close range
-    float ao = max(0.0, 1.0 - aoSum * uIntensity * (4.0 / float(uSampleCount)) * radiusScale);
+    float ao = max(0.0, 1.0 - (aoSum / float(uSampleCount)) * uIntensity * radiusScale);
 
     // 1-pixel bilateral filter using derivatives (almost free)
     if (abs(dFdx(depth)) < 0.2) ao -= dFdx(ao) * (float(pixelCoord.x & 1) - 0.5);

--- a/shaders/prepare/ssil.frag
+++ b/shaders/prepare/ssil.frag
@@ -125,8 +125,8 @@ void main()
     giSum *= normFactor;
 
     // Attenuate intensity proportionally when ssRadius was clamped, preventing over-darkening at close range
-    float ao = max(0.0, 1.0 - aoSum * uAoIntensity * (4.0 / float(uSampleCount)) * radiusScale);
-    vec3  gi = giSum * (4.0 / float(uSampleCount)) * radiusScale;
+    float ao = max(0.0, 1.0 - (aoSum / float(uSampleCount)) * uAoIntensity * radiusScale);
+    vec3  gi = (giSum / float(uSampleCount)) * radiusScale;
 
     // 1-pixel bilateral filter using derivatives (almost free)
 	if (abs(dFdx(depth)) < 0.2) ao -= dFdx(ao) * (float(pixelCoord.x & 1) - 0.5);

--- a/shaders/prepare/ssil.frag
+++ b/shaders/prepare/ssil.frag
@@ -6,7 +6,7 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-// Based on Screen Space Directional Occlusion by Tobias Ritschel et al
+// Based on Screen Space Directional Occlusion by Tobias Ritschel et al.
 // SEE: https://web.archive.org/web/20140725130649/https://people.mpi-inf.mpg.de/~ritschel/Papers/SSDO.pdf
 
 // And on Scalable Ambient Obscurance method by Morgan McGuire et al.

--- a/shaders/prepare/ssil.frag
+++ b/shaders/prepare/ssil.frag
@@ -126,7 +126,7 @@ void main()
 
     // Attenuate intensity proportionally when ssRadius was clamped, preventing over-darkening at close range
     float ao = max(0.0, 1.0 - (aoSum / float(uSampleCount)) * uAoIntensity * radiusScale);
-    vec3  gi = (giSum / float(uSampleCount)) * radiusScale;
+    vec3  gi = giSum * (16.0 / float(uSampleCount)) * radiusScale;
 
     // 1-pixel bilateral filter using derivatives (almost free)
 	if (abs(dFdx(depth)) < 0.2) ao -= dFdx(ao) * (float(pixelCoord.x & 1) - 0.5);

--- a/shaders/prepare/ssil.frag
+++ b/shaders/prepare/ssil.frag
@@ -125,7 +125,7 @@ void main()
     giSum *= normFactor;
 
     // Attenuate intensity proportionally when ssRadius was clamped, preventing over-darkening at close range
-    float ao = max(0.0, 1.0 - (aoSum / float(uSampleCount)) * uAoIntensity * radiusScale);
+    float ao = max(0.0, 1.0 - aoSum * uAoIntensity * (2.0 / float(uSampleCount)) * radiusScale);
     vec3  gi = giSum * (16.0 / float(uSampleCount)) * radiusScale;
 
     // 1-pixel bilateral filter using derivatives (almost free)

--- a/shaders/prepare/ssil.frag
+++ b/shaders/prepare/ssil.frag
@@ -1,4 +1,4 @@
-/* ssil.frag -- Screen space indirect lihgting with visibility mask
+/* ssil.frag -- Screen Space Directional Occlusion (SSDO)
  *
  * Copyright (c) 2025-2026 Le Juez Victor
  *
@@ -6,11 +6,11 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-// Original version adapted from "Screen Space Indirect Lighting with Visibility Bitmask" by Olivier Therrien, et al.
-// https://cdrinmatane.github.io/posts/cgspotlight-slides/
+// Based on Screen Space Directional Occlusion by Tobias Ritschel et al
+// SEE: https://web.archive.org/web/20140725130649/https://people.mpi-inf.mpg.de/~ritschel/Papers/SSDO.pdf
 
-// This is version is adapted from the Cyberealty's blog post (big thanks for for this discovery!):
-// https://cybereality.com/screen-space-indirect-lighting-with-visibility-bitmask-improvement-to-gtao-ssao-real-time-ambient-occlusion-algorithm-glsl-shader-implementation/
+// And on Scalable Ambient Obscurance method by Morgan McGuire et al.
+// SEE: https://research.nvidia.com/publication/2012-06_scalable-ambient-obscurance
 
 #version 330 core
 
@@ -19,143 +19,118 @@
 #include "../include/blocks/view.glsl"
 #include "../include/math.glsl"
 
-/* === Varyings == */
+/* === Varyings === */
 
 noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
 uniform sampler2D uDiffuseTex;
-uniform sampler2D uHistoryTex;
 uniform sampler2D uNormalTex;
 uniform sampler2D uDepthTex;
 
-uniform float uSampleCount;
-uniform float uSliceCount;
+uniform int uSampleCount;
 uniform float uRadius;
-uniform float uThickness;
+uniform float uBias;
+uniform float uAoIntensity;
+uniform float uMaxSSRadius;
+
+/* === Constants === */
+
+// Number of spiral turns for each sample count, ensuring coprime relationship.
+// Each entry ROTATIONS[i] is chosen such that GCD(i+1, ROTATIONS[i]) = 1,
+// preventing sample alignment artifacts in the spiral pattern.
+// Indexed by (sampleCount - 1). Supports 1 to 98 samples.
+const int ROTATIONS[98] = int[98](
+    1, 1, 2, 3, 2, 5, 2, 3, 2,
+    3, 3, 5, 5, 3, 4, 7, 5, 5, 7,
+    9, 8, 5, 5, 7, 7, 7, 8, 5, 8,
+    11, 12, 7, 10, 13, 8, 11, 8, 7, 14,
+    11, 11, 13, 12, 13, 19, 17, 13, 11, 18,
+    19, 11, 11, 14, 17, 21, 15, 16, 17, 18,
+    13, 17, 11, 17, 19, 18, 25, 18, 19, 19,
+    29, 21, 19, 27, 31, 29, 21, 18, 17, 29,
+    31, 31, 23, 18, 25, 26, 25, 23, 19, 34,
+    19, 27, 21, 25, 39, 29, 17, 21, 27
+);
 
 /* === Fragments === */
 
-layout(location = 0) out vec4 FragColor;
+out vec4 FragColor;
 
-/* === Helper Functions === */
+/* === Helper functions === */
 
-uint BitCount(uint value)
+vec2 TapLocation(int i, float numSpiralTurns, float spin, out float rNorm)
 {
-    // https://graphics.stanford.edu/%7Eseander/bithacks.html
-    value = value - ((value >> 1u) & 0x55555555u);
-    value = (value & 0x33333333u) + ((value >> 2u) & 0x33333333u);
-    return ((value + (value >> 4u) & 0xF0F0F0Fu) * 0x1010101u) >> 24u;
+    float alpha = (float(i) + 0.5) / float(uSampleCount);
+    float angle = alpha * (numSpiralTurns * M_TAU) + spin;
+
+    rNorm = alpha;
+    return vec2(cos(angle), sin(angle));
 }
 
-const uint SECTOR_COUNT = 32u;
-uint UpdateSectors(float minHorizon, float maxHorizon)
-{
-    uint b = uint(ceil((maxHorizon - minHorizon) * float(SECTOR_COUNT))); // Horizon angle
-    uint a = uint(minHorizon * float(SECTOR_COUNT)); // Start bit
-    uint mask = b > 0u ? ((1u << b) - 1u) : 0u;
-    return mask << a;
-}
-
-vec3 SampleLight(vec2 texCoord)
-{
-    vec3 indirect = texture(uHistoryTex, texCoord).rgb;
-    vec3 direct = texture(uDiffuseTex, texCoord).rgb;
-    float edgeMask = float(!V_OffScreen(texCoord));
-    return (direct + indirect) * edgeMask;
-}
-
-float FastAcos(float x)
-{
-    // Lagrange polynomial approximation, maximum error around 0.18 rad
-    return (-0.69813170079773212 * x * x - 0.87266462599716477) * x + 1.5707963267948966;
-}
-
-vec2 FastAcos(vec2 x)
-{
-    // Lagrange polynomial approximation, maximum error around 0.18 rad
-    return (-0.69813170079773212 * x * x - 0.87266462599716477) * x + 1.5707963267948966;
-}
-
-/* === Program === */
+/* === Main program === */
 
 void main()
 {
-    vec3 position = V_GetViewPosition(uDepthTex, ivec2(gl_FragCoord.xy));
-    vec3 normal = V_GetViewNormal(uNormalTex, ivec2(gl_FragCoord.xy));
-    vec3 camera = normalize(-position);
+    FragColor = vec4(vec3(0.0), 1.0);
 
-    vec2 screenSize = vec2(textureSize(uDiffuseTex, 0));
-    vec2 aspect = screenSize.yx / screenSize.x;
-    float jitter = M_HashIGN(gl_FragCoord.xy);
+    ivec2 pixelCoord = ivec2(gl_FragCoord.xy);
+    float depth = texture(uDepthTex, vTexCoord).r;
+    if (depth >= uView.far) return;
 
-    float sliceRotation = M_TAU / uSliceCount;
-    float jitterRotation = M_TAU * jitter;
+    vec3 position = V_GetViewPosition(vTexCoord, depth);
+    vec3 normal = V_GetViewNormal(uNormalTex, pixelCoord);
 
-    float sampleScale = uRadius * uView.proj[0][0] / -position.z;
-    float sampleOffset = 0.01;
+    float projScale = abs(uView.proj[1][1]) * textureSize(uDepthTex, 0).y * 0.5;
+    float ssRadiusRaw = projScale * uRadius / max(depth, 0.1);
+    float ssRadius = min(ssRadiusRaw, uMaxSSRadius);
 
-    // Indirect + visiblity accumulator
-    vec4 indirect = vec4(0.0);
+    float radiusScale = ssRadius / max(ssRadiusRaw, 1e-4);
+    float radiusSq = uRadius * uRadius;
 
-    // Iterate over angular slices around the hemisphere
-    for (int slice = 0; slice < uSliceCount; slice++)
+    // Here we use an IGN instead of the hash from the HPG12 AlchemyAO paper.
+    // The result is much more pleasing and blurs much better.
+
+    float spin = M_TAU * M_HashR2(gl_FragCoord.xy);
+    int numSpiralTurns = ROTATIONS[clamp(uSampleCount - 1, 0, 97)];
+
+    float aoSum = 0.0;
+    vec3 giSum = vec3(0.0);
+
+    for (int i = 0; i < uSampleCount; ++i)
     {
-        float phi = jitterRotation + sliceRotation * float(slice);
-        vec2 omega = vec2(cos(phi), sin(phi));
+        float rNorm;
+        vec2 unitDir = TapLocation(i, float(numSpiralTurns), spin, rNorm);
+        ivec2 pixelOffset = pixelCoord + ivec2(unitDir * ssRadius * rNorm);
 
-        vec3 direction = vec3(omega.x, omega.y, 0.0);
-        vec3 orthoDirection = direction - dot(direction, camera) * camera;  // Project onto plane perpendicular to view
-        vec3 axis = cross(direction, camera);
+        vec3 samplePos = V_GetViewPosition(uDepthTex, pixelOffset);
+        vec3 v = samplePos - position;
 
-        // Project surface normal onto the sampling plane
-        vec3 projNormal = normal - axis * dot(normal, axis);
-        float projLength = length(projNormal);
+        float vv = dot(v, v);
+        float vn = dot(v, normal);
 
-        // Compute signed angle offset from camera direction
-        float signN = sign(dot(orthoDirection, projNormal));
-        float cosN = clamp(dot(projNormal, camera) / projLength, 0.0, 1.0);
-        float n = signN * FastAcos(cosN);
+        const float epsilon = 0.02;
+        float f = max(radiusSq - vv, 0.0);
+        float w = f * f * f * max((vn - uBias) / (epsilon + vv), 0.0);
 
-        // Occlusion accumulator for this slice
-        uint occlusion = 0u;
-
-        // Trace radial samples outward along this slice
-        for (int currentSample = 0; currentSample < uSampleCount; currentSample++)
-        {
-            float sampleStep = (float(currentSample) + jitter) / uSampleCount + sampleOffset;
-            vec2 sampleUV = vTexCoord - sampleStep * sampleScale * omega * aspect;
-
-            vec3 samplePosition = V_GetViewPosition(uDepthTex, sampleUV);
-            vec3 sampleNormal = V_GetViewNormal(uNormalTex, sampleUV);
-            vec3 sampleLight = SampleLight(sampleUV);
-
-            vec3 sampleDistance = samplePosition - position;
-            vec3 sampleHorizon = sampleDistance / length(sampleDistance);
-
-            // Compute horizon angles: front (actual position) and back (with thickness offset)
-            vec3 backSample = normalize(sampleDistance - camera * uThickness);
-            vec2 frontBackHorizon = vec2(dot(sampleHorizon, camera), dot(backSample, camera));
-            frontBackHorizon = FastAcos(clamp(frontBackHorizon, -1.0, 1.0));
-            frontBackHorizon = clamp((frontBackHorizon + n + M_HPI) / M_PI, 0.0, 1.0);
-
-            // Mark visible sectors for this sample
-            uint sampleBitmask = UpdateSectors(frontBackHorizon.x, frontBackHorizon.y);
-
-            // Weight lighting by newly visible sectors (those not already occluded) and by geometric terms (surface angles)
-            float newlyVisible = 1.0 - float(BitCount(sampleBitmask & ~occlusion)) / float(SECTOR_COUNT);
-            float eNdotL = max(dot(sampleNormal, -sampleHorizon), 0.0); // emitter
-            float rNdotL = max(dot(normal, sampleHorizon), 0.0); // receiver
-            indirect.rgb += sampleLight * newlyVisible * eNdotL * rNdotL;
-
-            // Accumulate occlusion across samples
-            occlusion |= sampleBitmask;
-        }
-
-        indirect.a += 1.0 - float(BitCount(occlusion)) / float(SECTOR_COUNT);
+        aoSum += w;
+        giSum += texelFetch(uDiffuseTex, pixelOffset, 0).rgb * w;
     }
 
-    FragColor = indirect / uSliceCount;
-    FragColor.a = min(FragColor.a, 1.0);
+    float temp = radiusSq * uRadius;
+    float normFactor = 1.0 / (temp * temp);
+
+    aoSum *= normFactor;
+    giSum *= normFactor;
+
+    // Attenuate intensity proportionally when ssRadius was clamped, preventing over-darkening at close range
+    float ao = max(0.0, 1.0 - aoSum * uAoIntensity * (4.0 / float(uSampleCount)) * radiusScale);
+    vec3  gi = giSum * (4.0 / float(uSampleCount)) * radiusScale;
+
+    // 1-pixel bilateral filter using derivatives (almost free)
+	if (abs(dFdx(depth)) < 0.2) ao -= dFdx(ao) * (float(pixelCoord.x & 1) - 0.5);
+    if (abs(dFdy(depth)) < 0.2) ao -= dFdy(ao) * (float(pixelCoord.y & 1) - 0.5);
+
+    FragColor = vec4(gi, ao);
 }

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -379,14 +379,14 @@ bool r3d_shader_load_prepare_ssil(r3d_shader_custom_t* custom)
     SET_UNIFORM_BUFFER(ssil, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
     GET_LOCATION(ssil, uSampleCount);
-    GET_LOCATION(ssil, uSliceCount);
     GET_LOCATION(ssil, uRadius);
-    GET_LOCATION(ssil, uThickness);
+    GET_LOCATION(ssil, uBias);
+    GET_LOCATION(ssil, uAoIntensity);
+    GET_LOCATION(ssil, uMaxSSRadius);
 
     USE_SHADER(ssil);
 
     SET_SAMPLER(ssil, uDiffuseTex, R3D_SHADER_SAMPLER_BUFFER_DIFFUSE);
-    SET_SAMPLER(ssil, uHistoryTex, R3D_SHADER_SAMPLER_BUFFER_SSIL);
     SET_SAMPLER(ssil, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
     SET_SAMPLER(ssil, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 
@@ -1250,8 +1250,8 @@ bool r3d_shader_load_deferred_ambient(r3d_shader_custom_t* custom)
     SET_UNIFORM_BUFFER(ambient, EnvBlock, R3D_SHADER_BLOCK_SLOT_ENV);
 
     GET_LOCATION(ambient, uSsaoPower);
-    GET_LOCATION(ambient, uSsilIntensity);
     GET_LOCATION(ambient, uSsilAoPower);
+    GET_LOCATION(ambient, uSsilIntensity);
     GET_LOCATION(ambient, uSsgiIntensity);
 
     USE_SHADER(ambient);

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -333,6 +333,7 @@ bool r3d_shader_load_prepare_ssao(r3d_shader_custom_t* custom)
     GET_LOCATION(ssao, uRadius);
     GET_LOCATION(ssao, uBias);
     GET_LOCATION(ssao, uIntensity);
+    GET_LOCATION(ssao, uMaxSSRadius);
 
     USE_SHADER(ssao);
 

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -620,6 +620,7 @@ typedef struct {
     r3d_shader_uniform_float_t uRadius;
     r3d_shader_uniform_float_t uBias;
     r3d_shader_uniform_float_t uIntensity;
+    r3d_shader_uniform_float_t uMaxSSRadius;
 } r3d_shader_prepare_ssao_t;
 
 typedef struct {

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -640,13 +640,13 @@ typedef struct {
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uDiffuseTex;
-    r3d_shader_uniform_sampler_t uHistoryTex;
     r3d_shader_uniform_sampler_t uNormalTex;
     r3d_shader_uniform_sampler_t uDepthTex;
-    r3d_shader_uniform_float_t uSampleCount;
-    r3d_shader_uniform_float_t uSliceCount;
+    r3d_shader_uniform_int_t uSampleCount;
     r3d_shader_uniform_float_t uRadius;
-    r3d_shader_uniform_float_t uThickness;
+    r3d_shader_uniform_float_t uBias;
+    r3d_shader_uniform_float_t uAoIntensity;
+    r3d_shader_uniform_float_t uMaxSSRadius;
 } r3d_shader_prepare_ssil_t;
 
 typedef struct {
@@ -999,8 +999,8 @@ typedef struct {
     r3d_shader_uniform_sampler_t uPrefilterTex;
     r3d_shader_uniform_sampler_t uBrdfLutTex;
     r3d_shader_uniform_float_t uSsaoPower;
-    r3d_shader_uniform_float_t uSsilIntensity;
     r3d_shader_uniform_float_t uSsilAoPower;
+    r3d_shader_uniform_float_t uSsilIntensity;
     r3d_shader_uniform_float_t uSsgiIntensity;
 } r3d_shader_deferred_ambient_t;
 

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -87,7 +87,6 @@ static const target_config_t TARGET_CONFIG[] = {
     [R3D_TARGET_SSAO_1]      = { FORMAT_R8,      0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSIL_0]      = { FORMAT_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSIL_1]      = { FORMAT_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
-    [R3D_TARGET_SSIL_2]      = { FORMAT_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSGI_0]      = { FORMAT_RGB16F,  0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSGI_1]      = { FORMAT_RGB16F,  0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSGI_2]      = { FORMAT_RGB16F,  0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -36,7 +36,6 @@ typedef enum {
     R3D_TARGET_SSAO_1,          //< Half - Mip 1 - R8
     R3D_TARGET_SSIL_0,          //< Half - Mip 1 - RGBA16F
     R3D_TARGET_SSIL_1,          //< Half - Mip 1 - RGBA16F
-    R3D_TARGET_SSIL_2,          //< Half - Mip 1 - RGBA16F
     R3D_TARGET_SSGI_0,          //< Half - Mip 1 - RGB16F
     R3D_TARGET_SSGI_1,          //< Half - Mip 1 - RGB16F
     R3D_TARGET_SSGI_2,          //< Half - Mip 1 - RGB16F

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1702,36 +1702,30 @@ r3d_target_t pass_prepare_ssil(void)
     r3d_target_t src = R3D_TARGET_SSIL_0;
     r3d_target_t dst = R3D_TARGET_SSIL_1;
 
-    int steps = 4;//R3D.environment.ssil.denoiseSteps;
+    R3D_SHADER_USE(prepare.atrousWavelet);
 
-    if (steps > 0)
+    R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
+    R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
+
+    R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvNormalSharp, 20.0f);
+    R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvDepthSharp, 200.0f);
+
+    int stepWidth[] = {4, 2, 1};
+
+    for (int i = 0; i < ARRAY_SIZE(stepWidth); i++)
     {
-        R3D_SHADER_USE(prepare.atrousWavelet);
+        float invStepWidth2 = 1.0f / (stepWidth[i]*stepWidth[i]);
 
-        R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
-        R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
+        R3D_TARGET_BIND(false, dst);
+        R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uSourceTex, r3d_target_get(src));
+        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvStepWidth2, invStepWidth2);
+        R3D_SHADER_SET_INT(prepare.atrousWavelet, uStepWidth, stepWidth[i]);
+        R3D_RENDER_SCREEN();
 
-        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvNormalSharp, 50.0f);
-        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvDepthSharp, 150.0f);
-
-        int stepWidth[] = {8, 4, 2, 1};
-        steps = MIN(steps, ARRAY_SIZE(stepWidth));
-
-        for (int i = 0; i < steps; i++)
-        {
-            float invStepWidth2 = 1.0f / (stepWidth[i]*stepWidth[i]);
-
-            R3D_TARGET_BIND(false, dst);
-            R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uSourceTex, r3d_target_get(src));
-            R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvStepWidth2, invStepWidth2);
-            R3D_SHADER_SET_INT(prepare.atrousWavelet, uStepWidth, stepWidth[i]);
-            R3D_RENDER_SCREEN();
-
-            SWAP(r3d_target_t, src, dst);
-        }
+        SWAP(r3d_target_t, src, dst);
     }
 
-    return dst;
+    return src;
 }
 
 r3d_target_t pass_prepare_ssgi(void)

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1658,16 +1658,6 @@ r3d_target_t pass_prepare_ssao(void)
 
 r3d_target_t pass_prepare_ssil(void)
 {
-    /* --- Check if we need history --- */
-
-    static r3d_target_t SSIL_HISTORY  = R3D_TARGET_SSIL_0;
-    static r3d_target_t SSIL_RAW      = R3D_TARGET_SSIL_1;
-    static r3d_target_t SSIL_FILTERED = R3D_TARGET_SSIL_2;
-
-    if (r3d_target_get_or_null(SSIL_HISTORY) == 0) {
-        R3D_TARGET_CLEAR(false, SSIL_HISTORY);
-    }
-
     /* --- Setup OpenGL pipeline --- */
 
     r3d_driver_disable(GL_STENCIL_TEST);
@@ -1686,29 +1676,33 @@ r3d_target_t pass_prepare_ssil(void)
 
     R3D_RENDER_SCREEN();
 
-    /* --- Calculate SSIL (RAW) --- */
+    /* --- Calculate SSIL --- */
 
-    R3D_TARGET_BIND(false, SSIL_RAW);
+    R3D_TARGET_BIND(false, R3D_TARGET_SSIL_0);
     R3D_SHADER_USE(prepare.ssil);
 
+    R3D_SHADER_SET_INT(prepare.ssil, uSampleCount, R3D.environment.ssil.sampleCount);
+    R3D_SHADER_SET_FLOAT(prepare.ssil, uRadius,  R3D.environment.ssil.radius);
+    R3D_SHADER_SET_FLOAT(prepare.ssil, uBias, R3D.environment.ssil.bias);
+    R3D_SHADER_SET_FLOAT(prepare.ssil, uAoIntensity, R3D.environment.ssil.aoIntensity);
+
+    int wSsil = 0, hSsil = 0;
+    r3d_target_get_resolution(&wSsil, &hSsil, R3D_TARGET_SSIL_0, 0);
+    float maxScreenRadius = (float)MIN(wSsil, hSsil) * R3D.environment.ssil.maxRadius;
+    R3D_SHADER_SET_FLOAT(prepare.ssil, uMaxSSRadius, maxScreenRadius);
+
     R3D_SHADER_BIND_SAMPLER(prepare.ssil, uDiffuseTex, r3d_target_get_level(R3D_TARGET_DIFFUSE, 1));
-    R3D_SHADER_BIND_SAMPLER(prepare.ssil, uHistoryTex, R3D_TEXTURE_SELECT(r3d_target_get_or_null(SSIL_HISTORY), BLACK));
     R3D_SHADER_BIND_SAMPLER(prepare.ssil, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
     R3D_SHADER_BIND_SAMPLER(prepare.ssil, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
 
-    R3D_SHADER_SET_FLOAT(prepare.ssil, uSampleCount, (float)R3D.environment.ssil.sampleCount);
-    R3D_SHADER_SET_FLOAT(prepare.ssil, uSliceCount, (float)R3D.environment.ssil.sliceCount);
-    R3D_SHADER_SET_FLOAT(prepare.ssil, uRadius, R3D.environment.ssil.radius);
-    R3D_SHADER_SET_FLOAT(prepare.ssil, uThickness, R3D.environment.ssil.thickness);
-
     R3D_RENDER_SCREEN();
 
-    /* --- Atrous denoise: RAW -> FILTERED --- */
+    /* --- Denoise SSIL --- */
 
-    r3d_target_t* src = &SSIL_RAW;
-    r3d_target_t* dst = &SSIL_FILTERED;
+    r3d_target_t src = R3D_TARGET_SSIL_0;
+    r3d_target_t dst = R3D_TARGET_SSIL_1;
 
-    int steps = R3D.environment.ssil.denoiseSteps;
+    int steps = 4;//R3D.environment.ssil.denoiseSteps;
 
     if (steps > 0)
     {
@@ -1717,27 +1711,27 @@ r3d_target_t pass_prepare_ssil(void)
         R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
         R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
 
-        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvNormalSharp, 25.0f);
-        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvDepthSharp, 50.0f);
+        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvNormalSharp, 50.0f);
+        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvDepthSharp, 150.0f);
+
+        int stepWidth[] = {8, 4, 2, 1};
+        steps = MIN(steps, ARRAY_SIZE(stepWidth));
 
         for (int i = 0; i < steps; i++)
         {
-            int stepWidth = 1 << ((steps - 1) - i);
-            float invStepWidth2 = 1.0f / (stepWidth*stepWidth);
+            float invStepWidth2 = 1.0f / (stepWidth[i]*stepWidth[i]);
 
-            R3D_TARGET_BIND(false, *dst);
-            R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uSourceTex, r3d_target_get(*src));
+            R3D_TARGET_BIND(false, dst);
+            R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uSourceTex, r3d_target_get(src));
             R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvStepWidth2, invStepWidth2);
-            R3D_SHADER_SET_INT(prepare.atrousWavelet, uStepWidth, stepWidth);
+            R3D_SHADER_SET_INT(prepare.atrousWavelet, uStepWidth, stepWidth[i]);
             R3D_RENDER_SCREEN();
 
-            SWAP(r3d_target_t, *src, *dst);
+            SWAP(r3d_target_t, src, dst);
         }
     }
 
-    SWAP(r3d_target_t, SSIL_HISTORY, *src);
-
-    return SSIL_HISTORY;
+    return dst;
 }
 
 r3d_target_t pass_prepare_ssgi(void)
@@ -2021,8 +2015,8 @@ void pass_deferred_ambient(r3d_target_t ssaoSource, r3d_target_t ssilSource, r3d
     R3D_SHADER_BIND_SAMPLER(deferred.ambient, uOrmTex, r3d_target_get_level(R3D_TARGET_ORM, 0));
 
     R3D_SHADER_SET_FLOAT(deferred.ambient, uSsaoPower, R3D.environment.ssao.power);
-    R3D_SHADER_SET_FLOAT(deferred.ambient, uSsilIntensity, R3D.environment.ssil.intensity);
     R3D_SHADER_SET_FLOAT(deferred.ambient, uSsilAoPower, R3D.environment.ssil.aoPower);
+    R3D_SHADER_SET_FLOAT(deferred.ambient, uSsilIntensity, R3D.environment.ssil.giIntensity);
     R3D_SHADER_SET_FLOAT(deferred.ambient, uSsgiIntensity, R3D.environment.ssgi.intensity);
 
     R3D_RENDER_SCREEN();

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1628,6 +1628,11 @@ r3d_target_t pass_prepare_ssao(void)
     R3D_SHADER_SET_FLOAT(prepare.ssao, uBias, R3D.environment.ssao.bias);
     R3D_SHADER_SET_FLOAT(prepare.ssao, uIntensity, R3D.environment.ssao.intensity);
 
+    int wSsao = 0, hSsao = 0;
+    r3d_target_get_resolution(&wSsao, &hSsao, R3D_TARGET_SSAO_0, 0);
+    float maxScreenRadius = (float)MIN(wSsao, hSsao) * R3D.environment.ssao.maxRadius;
+    R3D_SHADER_SET_FLOAT(prepare.ssao, uMaxSSRadius, maxScreenRadius);
+
     R3D_SHADER_BIND_SAMPLER(prepare.ssao, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
     R3D_SHADER_BIND_SAMPLER(prepare.ssao, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
 


### PR DESCRIPTION
### Motivation:
SSIL-VB (Olivier Therrien et al.) would have required temporal accumulation and reprojection to produce convincing results. Without that, its horizon-based bitmask approach tends to give weak indirect lighting and is tricky to tune, while still being fairly expensive per frame.

SSDO, built on top of SAO, fits much better into our pipeline. It reuses what we already have (estimator and sampling), doesn't need any temporal data, and delivers both indirect lighting and occlusion in a single pass. On top of that, its parameters are much easier to tweak.

Overall, it just looks better by default in our case and runs at a much lower cost.

### SSIL:
- Replace the SSIL-VB implementation (horizon-based with visibility bitmask) with a
  Screen Space Directional Occlusion approach (Ritschel et al. 2009) built on top of
  the existing SAO estimator (McGuire et al. 2012). The same spiral sampling and
  weight function are reused; the GI component is accumulated in the same pass by
  multiplying each sample's SAO weight by its diffuse color, keeping the overhead
  minimal. AO and GI are output separately (vec4: rgb=indirect, a=occlusion).
- GI and AO intensities are now separate parameters (giIntensity, aoIntensity).
- Near-surface attenuation now uses a radius clamping approach (maxRadius)
  shared with SSAO, replacing the previous depth-based fade.
- Denoiser is fixed at 3 à-trous iterations with step schedule {4,2,1}.
- API struct fully redesigned: removed sliceCount, thickness, denoiseSteps; added
  giIntensity, aoIntensity, aoPower, maxRadius, bias.

### SSAO:
- Replace the depth-based near-surface fade (taken from [Bart Wronski's impl](https://github.com/bartwronski/CSharpRenderer/blob/master/shaders/ssao.fx)) with a physically
  motivated radius clamping approach: ssRadius is clamped to maxRadius * min(w,h),
  and AO intensity is scaled proportionally by how much the radius was clamped
  (radiusScale), preventing over-darkening without discarding sample contributions.
- Reviewed the empirical 4/sampleCount amplification factor from McGuire's reference
  implementation; replaced with 2/sampleCount so that intensity=1.0 is a natural
  baseline. Same rationale applied to SSIL GI term with a factor of 16/sampleCount.
- Default radius changed from 0.5 to 1.0; intensity from 0.5 to 1.0; power from
  1.5 to 1.0 (linear response, no artistic bias).