### PR TITLE
SSGI Overhaul

### DIFF
--- a/examples/sponza.c
+++ b/examples/sponza.c
@@ -16,6 +16,7 @@ int main(void)
 
     // Post-processing setup
     R3D_ENVIRONMENT_SET(bloom.mode, R3D_BLOOM_MIX);
+    R3D_ENVIRONMENT_SET(ssgi.intensity, 8.0f);
     R3D_ENVIRONMENT_SET(ssao.enabled, true);
 
     // Background and ambient

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -89,7 +89,7 @@
             .edgeFade = 0.1f,                           \
             .distanceFalloff = 1.0f,                    \
             .normalRejection = 0.0f,                    \
-            .intensity = 8.0f,                          \
+            .intensity = 1.0f,                          \
             .denoiseSteps = 5,                          \
             .enabled = false,                           \
         },                                              \
@@ -255,7 +255,7 @@ typedef struct R3D_EnvSSGI {
     float edgeFade;         ///< Fades out GI near screen edges to hide emissive objects partially off-screen. (default: 0.1)
     float distanceFalloff;  ///< How quickly indirect light fades with distance. Higher = shorter reach, darker result. (default: 1.0)
     float normalRejection;  ///< Prevents surfaces from receiving light through their own backside. 0 = off, 1 = physically correct. May look inconsistent with non-directional emissives. (default: 0.0)
-    float intensity;        ///< Overall brightness of the indirect lighting contribution. (default: 8.0)
+    float intensity;        ///< Brightness of the indirect lighting. Dimly lit scenes may require significantly higher values to show probable contribution. (default: 1.0)
     int denoiseSteps;       ///< Number of denoiser passes. Higher = smoother result, slightly higher cost. (default: 5)
     bool enabled;           ///< Enable or disable SSGI entirely. (default: false)
 } R3D_EnvSSGI;

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -90,7 +90,7 @@
             .distanceFalloff = 1.0f,                    \
             .normalRejection = 0.0f,                    \
             .intensity = 1.0f,                          \
-            .denoiseSteps = 5,                          \
+            .denoiseSteps = 4,                          \
             .enabled = false,                           \
         },                                              \
         .ssr = {                                        \

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -85,14 +85,11 @@
             .enabled = false,                           \
         },                                              \
         .ssgi = {                                       \
-            .sampleCount = 2,                           \
-            .maxRaySteps = 32,                          \
-            .stepSize = 0.125f,                         \
-            .thickness = 1.0f,                          \
-            .maxDistance = 4.0f,                        \
-            .intensity = 3.0f,                          \
-            .fadeStart = 8.0f,                          \
-            .fadeEnd = 16.0f,                           \
+            .sliceCount = 4,                            \
+            .edgeFade = 0.1f,                           \
+            .distanceFalloff = 1.0f,                    \
+            .normalRejection = 0.0f,                    \
+            .intensity = 8.0f,                          \
             .denoiseSteps = 5,                          \
             .enabled = false,                           \
         },                                              \
@@ -251,20 +248,16 @@ typedef struct R3D_EnvSSIL {
 /**
  * @brief Screen Space Global Illumination (SSGI) settings.
  *
- * Real-time global illlumination calculated in screen space.
- * @note Best suited for enclosed/indoor environments.
+ * Computes indirect lighting from the scene's visible surfaces in real time.
  */
 typedef struct R3D_EnvSSGI {
-    int sampleCount;        ///< Number of rays per pixel (default: 2)
-    int maxRaySteps;        ///< Maximum ray marching steps (default: 32)
-    float stepSize;         ///< Ray step size (default: 0.125)
-    float thickness;        ///< Depth tolerance for valid hits (default: 1.0)
-    float maxDistance;      ///< Maximum ray distance (default: 4.0)
-    float intensity;        ///< GI intensity multiplier (default: 3.0)
-    float fadeStart;        ///< Distance at which the GI fade begins (default: 8.0)
-    float fadeEnd;          ///< Distance at which GI is fully faded (default: 16.0)
-    int denoiseSteps;       ///< Number of denoiser iterations (default: 5)
-    bool enabled;           ///< Enable/disable SSGI (default: false)
+    int sliceCount;         ///< Number of directions sampled per pixel. Higher = fewer noise streaks, higher cost. (default: 4)
+    float edgeFade;         ///< Fades out GI near screen edges to hide emissive objects partially off-screen. (default: 0.1)
+    float distanceFalloff;  ///< How quickly indirect light fades with distance. Higher = shorter reach, darker result. (default: 1.0)
+    float normalRejection;  ///< Prevents surfaces from receiving light through their own backside. 0 = off, 1 = physically correct. May look inconsistent with non-directional emissives. (default: 0.0)
+    float intensity;        ///< Overall brightness of the indirect lighting contribution. (default: 8.0)
+    int denoiseSteps;       ///< Number of denoiser passes. Higher = smoother result, slightly higher cost. (default: 5)
+    bool enabled;           ///< Enable or disable SSGI entirely. (default: false)
 } R3D_EnvSSGI;
 
 /**

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -256,7 +256,7 @@ typedef struct R3D_EnvSSGI {
     float distanceFalloff;  ///< How quickly indirect light fades with distance. Higher = shorter reach, darker result. (default: 1.0)
     float normalRejection;  ///< Prevents surfaces from receiving light through their own backside. 0 = off, 1 = physically correct. May look inconsistent with non-directional emissives. (default: 0.0)
     float intensity;        ///< Brightness of the indirect lighting. Dimly lit scenes may require significantly higher values to show probable contribution. (default: 1.0)
-    int denoiseSteps;       ///< Number of denoiser passes. Higher = smoother result, slightly higher cost. (default: 5)
+    int denoiseSteps;       ///< Number of denoiser passes. Higher = smoother result, slightly higher cost. (default: 4)
     bool enabled;           ///< Enable or disable SSGI entirely. (default: false)
 } R3D_EnvSSGI;
 

--- a/shaders/deferred/ambient.frag
+++ b/shaders/deferred/ambient.frag
@@ -76,8 +76,7 @@ void main()
     vec3 specular = vec3(0.0);
     E_ComputeAmbientAndProbes(diffuse, specular, kD, orm, F0, P, N, V, NdotV);
 
-    // Apply AO to SSGI to restore contrast lost in far/blurred regions
-    vec3 gi = ssgi.rgb * uSsgiIntensity * orm.x;
+    vec3 gi = ssgi.rgb * uSsgiIntensity;
     gi += ssil.rgb * uSsilIntensity;
     gi *= kD;
 

--- a/shaders/prepare/atrous_wavelet.frag
+++ b/shaders/prepare/atrous_wavelet.frag
@@ -60,14 +60,14 @@ const float WEIGHTS[8] = float[8](
 void main()
 {
     ivec2 resolution = textureSize(uSourceTex, 0);
-    ivec2 pixCoord   = ivec2(gl_FragCoord.xy);
+    ivec2 pixCoord = ivec2(gl_FragCoord.xy);
 
     vec3 cp = V_GetViewPosition(uDepthTex, pixCoord);
     vec3 cn = V_GetViewNormal(uNormalTex, pixCoord);
     vec4 cc = texelFetch(uSourceTex, pixCoord, 0);
 
     float invScale2 = 1.0 / dot(cp, cp);
-    float viewCos = max(abs(dot(cn, normalize(-cp))), 0.05);
+    float viewCos = max(abs(dot(cn, cp)) * sqrt(invScale2), 0.05);
     float angleFactor = min(1.0 / viewCos, 4.0);
 
     float planeSharp = invScale2 * (angleFactor * angleFactor) * uInvDepthSharp;
@@ -87,13 +87,13 @@ void main()
 
         vec3 delta = sp - cp;
         float pd = dot(delta, cn);
-        float td = length(delta) - abs(pd);
+        float td2 = max(dot(delta, delta) - pd * pd, 0.0);
         float nDiff = dot(cn - sn, cn - sn) * uInvStepWidth2;
 
         float w = WEIGHTS[i] * exp(
             -nDiff * uInvNormalSharp
             -pd * pd * planeSharp
-            -td * td * tangSharp
+            -td2 * tangSharp
         );
 
         result += sc * w;

--- a/shaders/prepare/atrous_wavelet.frag
+++ b/shaders/prepare/atrous_wavelet.frag
@@ -10,7 +10,6 @@
 
 /* === Includes === */
 
-#include "../include/blocks/view.glsl"
 #include "../include/math.glsl"
 
 /* === Varyings === */
@@ -54,16 +53,68 @@ const float WEIGHTS[8] = float[8](
 
 /* === Main === */
 
+#ifdef SMART_FILTER
+
+#include "../include/blocks/view.glsl"
+
+void main()
+{
+    ivec2 resolution = textureSize(uSourceTex, 0);
+    ivec2 pixCoord   = ivec2(gl_FragCoord.xy);
+
+    vec3 cp = V_GetViewPosition(uDepthTex, pixCoord);
+    vec3 cn = V_GetViewNormal(uNormalTex, pixCoord);
+    vec4 cc = texelFetch(uSourceTex, pixCoord, 0);
+
+    float invScale2 = 1.0 / dot(cp, cp);
+    float viewCos = max(abs(dot(cn, normalize(-cp))), 0.05);
+    float angleFactor = min(1.0 / viewCos, 4.0);
+
+    float planeSharp = invScale2 * (angleFactor * angleFactor) * uInvDepthSharp;
+    float tangSharp = invScale2 * uInvDepthSharp * 0.1;
+
+    vec4 result = cc * 0.25;
+    float weightSum = 0.25;
+
+    for (int i = 0; i < KERNEL_SIZE; i++)
+    {
+        ivec2 sampleCoord = pixCoord + OFFSETS[i] * uStepWidth;
+        if (OFFSCREEN(sampleCoord, resolution)) continue;
+
+        vec3 sp = V_GetViewPosition(uDepthTex, sampleCoord);
+        vec3 sn = V_GetViewNormal(uNormalTex, sampleCoord);
+        vec4 sc = texelFetch(uSourceTex, sampleCoord, 0);
+
+        vec3 delta = sp - cp;
+        float pd = dot(delta, cn);
+        float td = length(delta) - abs(pd);
+        float nDiff = dot(cn - sn, cn - sn) * uInvStepWidth2;
+
+        float w = WEIGHTS[i] * exp(
+            -nDiff * uInvNormalSharp
+            -pd * pd * planeSharp
+            -td * td * tangSharp
+        );
+
+        result += sc * w;
+        weightSum += w;
+    }
+
+    FragColor = result / max(weightSum, 1e-4);
+}
+
+#else
+
 void main()
 {
     ivec2 resolution = textureSize(uSourceTex, 0);
     ivec2 pixCoord = ivec2(gl_FragCoord.xy);
 
-    vec3 centerNormal = M_DecodeOctahedral(texelFetch(uNormalTex, pixCoord, 0).rg);
-    float centerDepth = texelFetch(uDepthTex,  pixCoord, 0).r;
-    vec4 centerColor = texelFetch(uSourceTex, pixCoord, 0);
+    vec3 cn = M_DecodeOctahedral(texelFetch(uNormalTex, pixCoord, 0).rg);
+    float cz = texelFetch(uDepthTex,  pixCoord, 0).r;
+    vec4 cc = texelFetch(uSourceTex, pixCoord, 0);
 
-    vec4 result = centerColor * 0.25;
+    vec4 result = cc * 0.25;
     float weightSum = 0.25;
 
     for (int i = 0; i < KERNEL_SIZE; i++)
@@ -72,12 +123,12 @@ void main()
         if (OFFSCREEN(sampleCoord, resolution)) continue;
 
         vec3 sn = M_DecodeOctahedral(texelFetch(uNormalTex, sampleCoord, 0).rg);
-        float sd = texelFetch(uDepthTex,  sampleCoord, 0).r;
+        float sz = texelFetch(uDepthTex,  sampleCoord, 0).r;
         vec4 sc = texelFetch(uSourceTex, sampleCoord, 0);
 
-        vec3 nt = centerNormal - sn;
-        float dz = (centerDepth - sd);
-        float dist2 = dot(nt, nt) * uInvStepWidth2;
+        vec3 dn = cn - sn;
+        float dist2 = dot(dn, dn) * uInvStepWidth2;
+        float dz = cz - sz;
 
         float w = WEIGHTS[i] * exp(
             -dist2 * uInvNormalSharp
@@ -90,3 +141,5 @@ void main()
 
     FragColor = result / max(weightSum, 1e-4);
 }
+
+#endif // SMART_FILTER

--- a/shaders/prepare/ssgi.frag
+++ b/shaders/prepare/ssgi.frag
@@ -19,7 +19,6 @@ noperspective in vec2 vTexCoord;
 
 /* === Uniforms === */
 
-uniform sampler2D uHistoryTex;
 uniform sampler2D uDiffuseTex;
 uniform sampler2D uNormalTex;
 uniform sampler2D uDepthTex;
@@ -103,11 +102,10 @@ vec3 TraceRay(vec3 startViewPos, vec3 dirVS)
 
     if (!hit) return vec3(0.0);
 
-    vec3 hist = textureLod(uHistoryTex, hitUV, 0.0).rgb;
-    vec3 diff = textureLod(uDiffuseTex, hitUV, 0.0).rgb;
+    vec3 diffuse = textureLod(uDiffuseTex, hitUV, 0.0).rgb;
+    float distFade = smoothstep(uMaxDistance, 0.0, sqrt(distSq));
 
-    float distFade = 1.0 - smoothstep(0.0, uMaxDistance, sqrt(distSq));
-    return (diff + hist) * distFade;
+    return diffuse * distFade;
 }
 
 /* === Main Program === */

--- a/shaders/prepare/ssgi.frag
+++ b/shaders/prepare/ssgi.frag
@@ -89,7 +89,7 @@ void main()
 
         // Distance in pixels to the nearest screen edge along sliceDir
         vec2 t = mix((viewport - gl_FragCoord.xy) / sliceDir, -gl_FragCoord.xy / sliceDir, lessThan(sliceDir, vec2(0.0)));
-        int stepCount = int(log(min(t.x, t.y) * invStartStep) * invLogStepGrowth) + 1;
+        int stepCount = int(log(max(min(t.x, t.y), 1.0) * invStartStep) * invLogStepGrowth) + 1;
 
         vec3 giSlice = vec3(0.0);
         float pixelDistMult = 1.0;
@@ -123,11 +123,11 @@ void main()
                 float distFade = exp2(-dist * uDistanceFalloff);
 
                 // Reject light from back-facing emitters
-                float facing = -dot(sampleNorm, delta / dist);
+                float facing = -dot(sampleNorm, delta / max(dist, 1e-4));
                 float normalFade = mix(1.0, smoothstep(0.0, 0.1, facing), uNormalRejection);
 
                 giSlice += light * contrib * edgeFade * distFade * normalFade;
-                horizonAngle = sampleAngle; // raise the horizon
+                horizonAngle = sampleAngle; // tighten horizon
             }
         }
 

--- a/shaders/prepare/ssgi.frag
+++ b/shaders/prepare/ssgi.frag
@@ -8,6 +8,9 @@
 
 #version 330 core
 
+// Adapted from SSVGI by Alexander Sannikov, available in his LegitEngine repository:
+// SEE: https://github.com/Raikiri/LegitEngine/tree/master/bin/data/Shaders/glsl/SSVGI
+
 /* === Includes === */
 
 #include "../include/blocks/view.glsl"
@@ -23,121 +26,113 @@ uniform sampler2D uDiffuseTex;
 uniform sampler2D uNormalTex;
 uniform sampler2D uDepthTex;
 
-uniform int uSampleCount;
-uniform int uMaxRaySteps;
-uniform float uStepSize;
-uniform float uThickness;
-uniform float uMaxDistance;
-uniform float uFadeStart;
-uniform float uFadeEnd;
-
-/* === Constants === */
-
-const uint TILE_LOG2          = 2u; // 1u
-const uint TILE_SIZE          = 1u << TILE_LOG2;
-const uint TILE_MASK          = TILE_SIZE - 1u;
-const uint PIXELS_PER_TILE    = TILE_SIZE * TILE_SIZE; // 16
-const float F_PIXELS_PER_TILE = float(PIXELS_PER_TILE);
-
-/* === Fragments === */
+uniform int uSliceCount        = 4;
+uniform float uEdgeFade        = 0.1;
+uniform float uDistanceFalloff = 1.0;
+uniform float uNormalRejection = 0.0;
 
 out vec4 FragColor;
 
 /* === Helper Functions === */
 
-vec2 TileCranleyPatterson(uvec2 cell)
+// Analytically integrates dot(N,w)*sin(th) over the horizon
+// arc [h0, h1] in the slice plane defined by eyeDir and tangent
+float HorizonContribution(float NdotE, float NdotT, float h0, float h1)
 {
-    uint a = cell.x * 0x9E3779B9u ^ cell.y * 0x85EBCA6Bu;
-    uint b = cell.y * 0xC2B2AE35u ^ cell.x * 0xBF58476Du;
-    a ^= a >> 16u;
-    b ^= b >> 16u;
-    return vec2(a, b) * (1.0 / 4294967296.0);
+    return 0.25 * NdotE * (cos(2.0 * h0) - cos(2.0 * h1))
+         + 0.25 * NdotT * (2.0 * (h1 - h0) - sin(2.0 * h1) + sin(2.0 * h0));
 }
 
-vec3 FibonacciHemisphere(float fidx, float invTotal, vec2 cpOffset)
-{
-    float u = fract((fidx + 0.5) * invTotal + cpOffset.x);
-    float phi = fract(fidx * M_PHI_FRAC + cpOffset.y) * M_TAU;
-
-    float cosT = sqrt(1.0 - u);
-    float sinT = sqrt(u);
-
-    float cosPhi = cos(phi);
-    float sinPhi = sin(phi);
-
-    return vec3(cosPhi * sinT, sinPhi * sinT, cosT);
-}
-
-vec3 TraceRay(vec3 startViewPos, vec3 dirVS, vec3 normalVS)
-{
-    float normalBias = uStepSize * max(1.0, -startViewPos.z * 0.1);
-    vec3 posVS = startViewPos + normalVS * normalBias + dirVS * uStepSize;
-
-    float stepLenSq = dot(dirVS * uStepSize, dirVS * uStepSize);
-    float distSq = stepLenSq;
-    float maxLenSq = uMaxDistance * uMaxDistance;
-
-    vec2 hitUV = vec2(0.0);
-    bool hit = false;
-
-    for (int i = 1; i < uMaxRaySteps; i++)
-    {
-        if (distSq > maxLenSq) break;
-
-        vec2 uv = V_ViewToScreen(posVS);
-        if (V_OffScreen(uv)) break;
-
-        float sceneZ = -textureLod(uDepthTex, uv, 0.0).r;
-        float dz = sceneZ - posVS.z;
-
-        if (dz > 0.0 && dz < uThickness) {
-            hitUV = uv;
-            hit = true;
-            break;
-        }
-
-        posVS += dirVS * uStepSize;
-        distSq += stepLenSq;
-    }
-
-    if (!hit) return vec3(0.0);
-
-    vec3 diffuse = textureLod(uDiffuseTex, hitUV, 0.0).rgb;
-    float distFade = smoothstep(uMaxDistance, 0.0, sqrt(distSq));
-
-    return diffuse * distFade;
-}
-
-/* === Main Program === */
+/* === Main Function === */
 
 void main()
 {
-    ivec2 pix = ivec2(gl_FragCoord.xy);
-    float depth = texelFetch(uDepthTex, pix, 0).r;
-    if (depth >= uFadeEnd) { FragColor = vec4(0.0); return; }
+    vec2 viewport = vec2(textureSize(uDiffuseTex, 0));
+    vec2 invViewport = 1.0 / viewport;
 
-    vec3 Nvs = V_GetViewNormal(uNormalTex, pix);
-    vec3 Pvs = V_GetViewPosition(vTexCoord, depth);
-    mat3 TBN = M_OrthonormalBasis(Nvs);
+    // Receiver geometry
+    float depth = texelFetch(uDepthTex, ivec2(gl_FragCoord.xy), 0).r;
+    vec3 viewPos = V_GetViewPosition(vTexCoord, depth);
+    vec3 viewNorm = V_GetViewNormal(uNormalTex, vTexCoord);
+    vec3 eyeDir = normalize(-viewPos);
+    float NdotE = dot(viewNorm, eyeDir);
 
-    uint tileIdx = (uint(pix.x) & TILE_MASK) | ((uint(pix.y) & TILE_MASK) << TILE_LOG2);
-    float fidx = float(tileIdx);
+    // Per-pixel jitter
+    float jitter = M_HashIGN(gl_FragCoord.xy);
+    float angOffset = M_TAU * jitter;
+    float linOffset = jitter;
 
-    uvec2 cell = uvec2(pix) >> TILE_LOG2;
-    vec2 cpOffset = TileCranleyPatterson(cell);
-
-    uint S = uint(max(uSampleCount, 1));
-    float invTotal = 1.0 / float(PIXELS_PER_TILE * S);
-    float invS = 1.0 / float(S);
+    // Exponential step size parameters
+    float startStep = viewport.x / 1000.0;
+    float invStartStep = 1.0 / startStep;
+    float stepGrowth = M_TAU / float(uSliceCount) + 1.0;
+    float invLogStepGrowth = 1.0 / log(stepGrowth);
+    float pixelDistBase = startStep * pow(stepGrowth, linOffset);
+    float pixelDistOffset = 1.0 - startStep;
 
     vec3 gi = vec3(0.0);
 
-    for (uint s = 0u; s < S; s++) {
-        vec3 localDir = FibonacciHemisphere(fidx, invTotal, cpOffset);
-        gi += TraceRay(Pvs, TBN * localDir, Nvs);
-        fidx += F_PIXELS_PER_TILE;
+    for (int slice = 0; slice < uSliceCount; slice++)
+    {
+        // Slice direction in screen space
+        float sliceAngle = angOffset + M_TAU / float(uSliceCount) * float(slice);
+        vec2 sliceDir = vec2(cos(sliceAngle), sin(sliceAngle));
+
+        // Tangent in view space derived from a small screen-space offset at the same depth
+        vec2 offsetUV = (gl_FragCoord.xy + sliceDir * 0.1) * invViewport;
+        vec3 offsetPos = V_GetViewPosition(offsetUV, depth);
+        vec3 tangent = normalize(normalize(offsetPos) + eyeDir);
+        float NdotT = dot(viewNorm, tangent);
+
+        // Initial horizon angle: projection of the surface normal into the slice plane
+        float horizonAngle = atan(NdotE, -NdotT);
+
+        // Distance in pixels to the nearest screen edge along sliceDir
+        vec2 t = mix((viewport - gl_FragCoord.xy) / sliceDir, -gl_FragCoord.xy / sliceDir, lessThan(sliceDir, vec2(0.0)));
+        int stepCount = int(log(min(t.x, t.y) * invStartStep) * invLogStepGrowth) + 1;
+
+        vec3 giSlice = vec3(0.0);
+        float pixelDistMult = 1.0;
+
+        for (int step = 0; step < stepCount; step++)
+        {
+            // Exponentially growing pixel offset + linear jitter
+            float pixelDist = pixelDistBase * pixelDistMult + pixelDistOffset;
+            pixelDistMult *= stepGrowth;
+
+            vec2 sampleUV = (gl_FragCoord.xy + sliceDir * pixelDist) * invViewport;
+            vec3 sampleViewPos = V_GetViewPosition(uDepthTex, sampleUV);
+            vec3 sampleNorm = V_GetViewNormal(uNormalTex, sampleUV);
+            vec3 delta = sampleViewPos - viewPos;
+
+            // Skip samples on the same continuous surface (coplanar + similar normal)
+            if (abs(dot(delta, viewNorm)) < 0.03 && dot(sampleNorm, viewNorm) > 0.95) continue;
+
+            float sampleAngle = atan(dot(tangent, delta), dot(eyeDir, delta));
+
+            // Only samples above the current horizon contribute
+            if (sampleAngle < horizonAngle)
+            {
+                vec3 light = textureLod(uDiffuseTex, sampleUV, 0.0).rgb;
+                float contrib = max(0.0, HorizonContribution(NdotE, NdotT, sampleAngle, horizonAngle));
+
+                vec2 edge = min(sampleUV, 1.0 - sampleUV);
+                float edgeFade = smoothstep(0.0, uEdgeFade, min(edge.x, edge.y));
+
+                float dist = length(delta);
+                float distFade = exp2(-dist * uDistanceFalloff);
+
+                // Reject light from back-facing emitters
+                float facing = -dot(sampleNorm, delta / dist);
+                float normalFade = mix(1.0, smoothstep(0.0, 0.1, facing), uNormalRejection);
+
+                giSlice += light * contrib * edgeFade * distFade * normalFade;
+                horizonAngle = sampleAngle; // raise the horizon
+            }
+        }
+
+        gi += 2.0 * giSlice / float(uSliceCount);
     }
 
-    float fade = smoothstep(uFadeEnd, uFadeStart, depth);
-    FragColor  = vec4(gi * invS * fade, 1.0);
+    FragColor = vec4(gi, 1.0);
 }

--- a/shaders/prepare/ssgi.frag
+++ b/shaders/prepare/ssgi.frag
@@ -26,10 +26,10 @@ uniform sampler2D uDiffuseTex;
 uniform sampler2D uNormalTex;
 uniform sampler2D uDepthTex;
 
-uniform int uSliceCount        = 4;
-uniform float uEdgeFade        = 0.1;
-uniform float uDistanceFalloff = 1.0;
-uniform float uNormalRejection = 0.0;
+uniform int uSliceCount;
+uniform float uEdgeFade;
+uniform float uDistanceFalloff;
+uniform float uNormalRejection;
 
 out vec4 FragColor;
 
@@ -70,12 +70,16 @@ void main()
     float pixelDistBase = startStep * pow(stepGrowth, linOffset);
     float pixelDistOffset = 1.0 - startStep;
 
+    // Slice constants
+    float sliceStep = M_TAU / float(uSliceCount);
+    float sliceWeight = 2.0 / float(uSliceCount);
+
     vec3 gi = vec3(0.0);
 
     for (int slice = 0; slice < uSliceCount; slice++)
     {
         // Slice direction in screen space
-        float sliceAngle = angOffset + M_TAU / float(uSliceCount) * float(slice);
+        float sliceAngle = angOffset + sliceStep * float(slice);
         vec2 sliceDir = vec2(cos(sliceAngle), sin(sliceAngle));
 
         // Tangent in view space derived from a small screen-space offset at the same depth
@@ -119,11 +123,11 @@ void main()
                 vec2 edge = min(sampleUV, 1.0 - sampleUV);
                 float edgeFade = smoothstep(0.0, uEdgeFade, min(edge.x, edge.y));
 
-                float dist = length(delta);
-                float distFade = exp2(-dist * uDistanceFalloff);
+                float dist2 = dot(delta, delta);
+                float distFade = 1.0 / (1.0 + dist2 * uDistanceFalloff);
 
                 // Reject light from back-facing emitters
-                float facing = -dot(sampleNorm, delta / max(dist, 1e-4));
+                float facing = -dot(sampleNorm, delta * inversesqrt(max(dist2, 1e-8)));
                 float normalFade = mix(1.0, smoothstep(0.0, 0.1, facing), uNormalRejection);
 
                 giSlice += light * contrib * edgeFade * distFade * normalFade;
@@ -131,7 +135,7 @@ void main()
             }
         }
 
-        gi += 2.0 * giSlice / float(uSliceCount);
+        gi += giSlice * sliceWeight;
     }
 
     FragColor = vec4(gi, 1.0);

--- a/shaders/prepare/ssgi.frag
+++ b/shaders/prepare/ssgi.frag
@@ -68,14 +68,14 @@ vec3 FibonacciHemisphere(float fidx, float invTotal, vec2 cpOffset)
     return vec3(cosPhi * sinT, sinPhi * sinT, cosT);
 }
 
-vec3 TraceRay(vec3 startViewPos, vec3 dirVS)
+vec3 TraceRay(vec3 startViewPos, vec3 dirVS, vec3 normalVS)
 {
-    vec3 stepVS = dirVS * uStepSize;
-    float stepLenSq = dot(stepVS, stepVS);
-    float maxLenSq = uMaxDistance * uMaxDistance;
+    float normalBias = uStepSize * max(1.0, -startViewPos.z * 0.1);
+    vec3 posVS = startViewPos + normalVS * normalBias + dirVS * uStepSize;
 
-    vec3 posVS = startViewPos + stepVS;
+    float stepLenSq = dot(dirVS * uStepSize, dirVS * uStepSize);
     float distSq = stepLenSq;
+    float maxLenSq = uMaxDistance * uMaxDistance;
 
     vec2 hitUV = vec2(0.0);
     bool hit = false;
@@ -96,7 +96,7 @@ vec3 TraceRay(vec3 startViewPos, vec3 dirVS)
             break;
         }
 
-        posVS += stepVS;
+        posVS += dirVS * uStepSize;
         distSq += stepLenSq;
     }
 
@@ -134,7 +134,7 @@ void main()
 
     for (uint s = 0u; s < S; s++) {
         vec3 localDir = FibonacciHemisphere(fidx, invTotal, cpOffset);
-        gi += TraceRay(Pvs, TBN * localDir);
+        gi += TraceRay(Pvs, TBN * localDir, Nvs);
         fidx += F_PIXELS_PER_TILE;
     }
 

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -253,20 +253,44 @@ static GLuint load_shader(const char* vsCode, const char* fsCode)
 // SHADER LOADING FUNCTIONS
 // ========================================
 
-bool r3d_shader_load_prepare_atrous_wavelet(r3d_shader_custom_t* custom)
+bool r3d_shader_load_prepare_atrous_wavelet_smart(r3d_shader_custom_t* custom)
 {
-    DECL_SHADER(r3d_shader_prepare_atrous_wavelet_t, prepare, atrousWavelet);
-    LOAD_SHADER(atrousWavelet, SCREEN_VERT, ATROUS_WAVELET_FRAG);
+    DECL_SHADER(r3d_shader_prepare_atrous_wavelet_t, prepare, atrousWaveletSmart);
 
-    GET_LOCATION(atrousWavelet, uInvNormalSharp);
-    GET_LOCATION(atrousWavelet, uInvDepthSharp);
-    GET_LOCATION(atrousWavelet, uInvStepWidth2);
-    GET_LOCATION(atrousWavelet, uStepWidth);
+    const char* FS_DEFINES[] = {"SMART_FILTER"};
+    char* fragCode = inject_defines(ATROUS_WAVELET_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
+    LOAD_SHADER(atrousWaveletSmart, SCREEN_VERT, fragCode);
+    RL_FREE(fragCode);
 
-    USE_SHADER(atrousWavelet);
-    SET_SAMPLER(atrousWavelet, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
-    SET_SAMPLER(atrousWavelet, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
-    SET_SAMPLER(atrousWavelet, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+    SET_UNIFORM_BUFFER(atrousWaveletSmart, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
+
+    GET_LOCATION(atrousWaveletSmart, uInvNormalSharp);
+    GET_LOCATION(atrousWaveletSmart, uInvDepthSharp);
+    GET_LOCATION(atrousWaveletSmart, uInvStepWidth2);
+    GET_LOCATION(atrousWaveletSmart, uStepWidth);
+
+    USE_SHADER(atrousWaveletSmart);
+    SET_SAMPLER(atrousWaveletSmart, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+    SET_SAMPLER(atrousWaveletSmart, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
+    SET_SAMPLER(atrousWaveletSmart, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+
+    return true;
+}
+
+bool r3d_shader_load_prepare_atrous_wavelet_fast(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_prepare_atrous_wavelet_t, prepare, atrousWaveletFast);
+    LOAD_SHADER(atrousWaveletFast, SCREEN_VERT, ATROUS_WAVELET_FRAG);
+
+    GET_LOCATION(atrousWaveletFast, uInvNormalSharp);
+    GET_LOCATION(atrousWaveletFast, uInvDepthSharp);
+    GET_LOCATION(atrousWaveletFast, uInvStepWidth2);
+    GET_LOCATION(atrousWaveletFast, uStepWidth);
+
+    USE_SHADER(atrousWaveletFast);
+    SET_SAMPLER(atrousWaveletFast, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+    SET_SAMPLER(atrousWaveletFast, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
+    SET_SAMPLER(atrousWaveletFast, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 
     return true;
 }
@@ -1560,7 +1584,8 @@ void r3d_shader_quit()
 {
     glDeleteBuffers(R3D_SHADER_BLOCK_COUNT, R3D_MOD_SHADER.uniformBuffers);
 
-    UNLOAD_SHADER(prepare.atrousWavelet);
+    UNLOAD_SHADER(prepare.atrousWaveletSmart);
+    UNLOAD_SHADER(prepare.atrousWaveletFast);
     UNLOAD_SHADER(prepare.blurDown);
     UNLOAD_SHADER(prepare.blurUp);
     UNLOAD_SHADER(prepare.depthPyramid);

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -420,13 +420,10 @@ bool r3d_shader_load_prepare_ssgi(r3d_shader_custom_t* custom)
 
     SET_UNIFORM_BUFFER(ssgi, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
-    GET_LOCATION(ssgi, uSampleCount);
-    GET_LOCATION(ssgi, uMaxRaySteps);
-    GET_LOCATION(ssgi, uStepSize);
-    GET_LOCATION(ssgi, uThickness);
-    GET_LOCATION(ssgi, uMaxDistance);
-    GET_LOCATION(ssgi, uFadeStart);
-    GET_LOCATION(ssgi, uFadeEnd);
+    GET_LOCATION(ssgi, uSliceCount);
+    GET_LOCATION(ssgi, uEdgeFade);
+    GET_LOCATION(ssgi, uDistanceFalloff);
+    GET_LOCATION(ssgi, uNormalRejection);
 
     USE_SHADER(ssgi);
 

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -406,7 +406,6 @@ bool r3d_shader_load_prepare_ssgi(r3d_shader_custom_t* custom)
 
     USE_SHADER(ssgi);
 
-    SET_SAMPLER(ssgi, uHistoryTex, R3D_SHADER_SAMPLER_BUFFER_SSGI);
     SET_SAMPLER(ssgi, uDiffuseTex, R3D_SHADER_SAMPLER_BUFFER_DIFFUSE);
     SET_SAMPLER(ssgi, uNormalTex, R3D_SHADER_SAMPLER_BUFFER_NORMAL);
     SET_SAMPLER(ssgi, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -1154,7 +1154,8 @@ extern struct r3d_mod_shader {
 
     // Prepare shaders
     struct {
-        r3d_shader_prepare_atrous_wavelet_t atrousWavelet;
+        r3d_shader_prepare_atrous_wavelet_t atrousWaveletSmart;
+        r3d_shader_prepare_atrous_wavelet_t atrousWaveletFast;
         r3d_shader_prepare_blur_down_t blurDown;
         r3d_shader_prepare_blur_up_t blurUp;
         r3d_shader_prepare_depth_pyramid_t depthPyramid;
@@ -1227,7 +1228,8 @@ extern struct r3d_mod_shader {
 
 typedef bool (*r3d_shader_loader_func)(r3d_shader_custom_t* custom);
 
-bool r3d_shader_load_prepare_atrous_wavelet(r3d_shader_custom_t* custom);
+bool r3d_shader_load_prepare_atrous_wavelet_smart(r3d_shader_custom_t* custom);
+bool r3d_shader_load_prepare_atrous_wavelet_fast(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_blur_down(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_blur_up(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_depth_pyramid(r3d_shader_custom_t* custom);
@@ -1293,7 +1295,8 @@ static const struct r3d_shader_loader {
 
     // Prepare shaders
     struct {
-        r3d_shader_loader_func atrousWavelet;
+        r3d_shader_loader_func atrousWaveletSmart;
+        r3d_shader_loader_func atrousWaveletFast;
         r3d_shader_loader_func blurDown;
         r3d_shader_loader_func blurUp;
         r3d_shader_loader_func depthPyramid;
@@ -1364,7 +1367,8 @@ static const struct r3d_shader_loader {
 } R3D_MOD_SHADER_LOADER = {
 
     .prepare = {
-        .atrousWavelet = r3d_shader_load_prepare_atrous_wavelet,
+        .atrousWaveletSmart = r3d_shader_load_prepare_atrous_wavelet_smart,
+        .atrousWaveletFast = r3d_shader_load_prepare_atrous_wavelet_fast,
         .blurDown = r3d_shader_load_prepare_blur_down,
         .blurUp = r3d_shader_load_prepare_blur_up,
         .depthPyramid = r3d_shader_load_prepare_depth_pyramid,

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -651,7 +651,6 @@ typedef struct {
 
 typedef struct {
     GLuint id;
-    r3d_shader_uniform_sampler_t uHistoryTex;
     r3d_shader_uniform_sampler_t uDiffuseTex;
     r3d_shader_uniform_sampler_t uNormalTex;
     r3d_shader_uniform_sampler_t uDepthTex;

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -654,13 +654,10 @@ typedef struct {
     r3d_shader_uniform_sampler_t uDiffuseTex;
     r3d_shader_uniform_sampler_t uNormalTex;
     r3d_shader_uniform_sampler_t uDepthTex;
-    r3d_shader_uniform_int_t uSampleCount;
-    r3d_shader_uniform_int_t uMaxRaySteps;
-    r3d_shader_uniform_float_t uStepSize;
-    r3d_shader_uniform_float_t uThickness;
-    r3d_shader_uniform_float_t uMaxDistance;
-    r3d_shader_uniform_float_t uFadeStart;
-    r3d_shader_uniform_float_t uFadeEnd;
+    r3d_shader_uniform_int_t uSliceCount;
+    r3d_shader_uniform_float_t uEdgeFade;
+    r3d_shader_uniform_float_t uDistanceFalloff;
+    r3d_shader_uniform_float_t uNormalRejection;
 } r3d_shader_prepare_ssgi_t;
 
 typedef struct {

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -89,7 +89,6 @@ static const target_config_t TARGET_CONFIG[] = {
     [R3D_TARGET_SSIL_1]      = { FORMAT_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSGI_0]      = { FORMAT_RGB16F,  0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSGI_1]      = { FORMAT_RGB16F,  0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
-    [R3D_TARGET_SSGI_2]      = { FORMAT_RGB16F,  0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSR]         = { FORMAT_RGBA16F, 0.5f, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR,  0, {0} },
     [R3D_TARGET_DOF_COC]     = { FORMAT_R16F,    1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_DOF_0]       = { FORMAT_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -38,7 +38,6 @@ typedef enum {
     R3D_TARGET_SSIL_1,          //< Half - Mip 1 - RGBA16F
     R3D_TARGET_SSGI_0,          //< Half - Mip 1 - RGB16F
     R3D_TARGET_SSGI_1,          //< Half - Mip 1 - RGB16F
-    R3D_TARGET_SSGI_2,          //< Half - Mip 1 - RGB16F
     R3D_TARGET_SSR,             //< Half - Mip N - RGBA16F
     R3D_TARGET_DOF_COC,         //< Full - Mip 1 - R16F
     R3D_TARGET_DOF_0,           //< Half - Mip 1 - RGBA16F

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1770,13 +1770,10 @@ r3d_target_t pass_prepare_ssgi(void)
     R3D_SHADER_BIND_SAMPLER(prepare.ssgi, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
     R3D_SHADER_BIND_SAMPLER(prepare.ssgi, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
 
-    R3D_SHADER_SET_INT(prepare.ssgi, uSampleCount, R3D.environment.ssgi.sampleCount);
-    R3D_SHADER_SET_INT(prepare.ssgi, uMaxRaySteps, R3D.environment.ssgi.maxRaySteps);
-    R3D_SHADER_SET_FLOAT(prepare.ssgi, uStepSize, R3D.environment.ssgi.stepSize);
-    R3D_SHADER_SET_FLOAT(prepare.ssgi, uThickness, R3D.environment.ssgi.thickness);
-    R3D_SHADER_SET_FLOAT(prepare.ssgi, uMaxDistance, R3D.environment.ssgi.maxDistance);
-    R3D_SHADER_SET_FLOAT(prepare.ssgi, uFadeStart, R3D.environment.ssgi.fadeStart);
-    R3D_SHADER_SET_FLOAT(prepare.ssgi, uFadeEnd, R3D.environment.ssgi.fadeEnd);
+    R3D_SHADER_SET_INT(prepare.ssgi, uSliceCount, R3D.environment.ssgi.sliceCount);
+    R3D_SHADER_SET_INT(prepare.ssgi, uEdgeFade, R3D.environment.ssgi.edgeFade);
+    R3D_SHADER_SET_FLOAT(prepare.ssgi, uDistanceFalloff, R3D.environment.ssgi.distanceFalloff);
+    R3D_SHADER_SET_FLOAT(prepare.ssgi, uNormalRejection, R3D.environment.ssgi.normalRejection);
 
     R3D_RENDER_SCREEN();
 
@@ -1817,10 +1814,10 @@ r3d_target_t pass_prepare_ssgi(void)
         R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletSmart, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
         R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletSmart, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
 
-        R3D_SHADER_SET_FLOAT(prepare.atrousWaveletSmart, uInvNormalSharp, 15.0f);
-        R3D_SHADER_SET_FLOAT(prepare.atrousWaveletSmart, uInvDepthSharp, 150.0f);
+        R3D_SHADER_SET_FLOAT(prepare.atrousWaveletSmart, uInvNormalSharp, 20.0f);
+        R3D_SHADER_SET_FLOAT(prepare.atrousWaveletSmart, uInvDepthSharp, 200.0f);
 
-        int stepWidth[] = {32, 16, 8, 4, 2, 1};
+        int stepWidth[] = {16, 8, 4, 2, 1};
         steps = MIN(steps, ARRAY_SIZE(stepWidth));
 
         for (int i = 0; i < steps; i++)

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1643,13 +1643,13 @@ r3d_target_t pass_prepare_ssao(void)
     r3d_target_t src = R3D_TARGET_SSAO_0;
     r3d_target_t dst = R3D_TARGET_SSAO_1;
 
-    R3D_SHADER_USE(prepare.atrousWavelet);
+    R3D_SHADER_USE(prepare.atrousWaveletFast);
 
-    R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
-    R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
+    R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletFast, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
+    R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletFast, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
 
-    R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvNormalSharp, 20.0f);
-    R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvDepthSharp, 100.0f);
+    R3D_SHADER_SET_FLOAT(prepare.atrousWaveletFast, uInvNormalSharp, 20.0f);
+    R3D_SHADER_SET_FLOAT(prepare.atrousWaveletFast, uInvDepthSharp, 100.0f);
 
     int stepWidth[] = {2, 1};
 
@@ -1658,9 +1658,9 @@ r3d_target_t pass_prepare_ssao(void)
         float invStepWidth2 = 1.0f / (stepWidth[i]*stepWidth[i]);
 
         R3D_TARGET_BIND(false, dst);
-        R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uSourceTex, r3d_target_get(src));
-        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvStepWidth2, invStepWidth2);
-        R3D_SHADER_SET_INT(prepare.atrousWavelet, uStepWidth, stepWidth[i]);
+        R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletFast, uSourceTex, r3d_target_get(src));
+        R3D_SHADER_SET_FLOAT(prepare.atrousWaveletFast, uInvStepWidth2, invStepWidth2);
+        R3D_SHADER_SET_INT(prepare.atrousWaveletFast, uStepWidth, stepWidth[i]);
         R3D_RENDER_SCREEN();
 
         SWAP(r3d_target_t, src, dst);
@@ -1715,13 +1715,13 @@ r3d_target_t pass_prepare_ssil(void)
     r3d_target_t src = R3D_TARGET_SSIL_0;
     r3d_target_t dst = R3D_TARGET_SSIL_1;
 
-    R3D_SHADER_USE(prepare.atrousWavelet);
+    R3D_SHADER_USE(prepare.atrousWaveletFast);
 
-    R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
-    R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
+    R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletFast, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
+    R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletFast, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
 
-    R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvNormalSharp, 20.0f);
-    R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvDepthSharp, 200.0f);
+    R3D_SHADER_SET_FLOAT(prepare.atrousWaveletFast, uInvNormalSharp, 20.0f);
+    R3D_SHADER_SET_FLOAT(prepare.atrousWaveletFast, uInvDepthSharp, 200.0f);
 
     int stepWidth[] = {4, 2, 1};
 
@@ -1730,9 +1730,9 @@ r3d_target_t pass_prepare_ssil(void)
         float invStepWidth2 = 1.0f / (stepWidth[i]*stepWidth[i]);
 
         R3D_TARGET_BIND(false, dst);
-        R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uSourceTex, r3d_target_get(src));
-        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvStepWidth2, invStepWidth2);
-        R3D_SHADER_SET_INT(prepare.atrousWavelet, uStepWidth, stepWidth[i]);
+        R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletFast, uSourceTex, r3d_target_get(src));
+        R3D_SHADER_SET_FLOAT(prepare.atrousWaveletFast, uInvStepWidth2, invStepWidth2);
+        R3D_SHADER_SET_INT(prepare.atrousWaveletFast, uStepWidth, stepWidth[i]);
         R3D_RENDER_SCREEN();
 
         SWAP(r3d_target_t, src, dst);
@@ -1812,13 +1812,13 @@ r3d_target_t pass_prepare_ssgi(void)
 
     if (steps > 0)
     {
-        R3D_SHADER_USE(prepare.atrousWavelet);
+        R3D_SHADER_USE(prepare.atrousWaveletSmart);
 
-        R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
-        R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
+        R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletSmart, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
+        R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletSmart, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
 
-        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvNormalSharp, 2.5f);
-        R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvDepthSharp, 20.0f);
+        R3D_SHADER_SET_FLOAT(prepare.atrousWaveletSmart, uInvNormalSharp, 15.0f);
+        R3D_SHADER_SET_FLOAT(prepare.atrousWaveletSmart, uInvDepthSharp, 150.0f);
 
         int stepWidth[] = {32, 16, 8, 4, 2, 1};
         steps = MIN(steps, ARRAY_SIZE(stepWidth));
@@ -1828,9 +1828,9 @@ r3d_target_t pass_prepare_ssgi(void)
             float invStepWidth2 = 1.0f / (stepWidth[i]*stepWidth[i]);
 
             R3D_TARGET_BIND(false, dst);
-            R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uSourceTex, r3d_target_get(src));
-            R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvStepWidth2, invStepWidth2);
-            R3D_SHADER_SET_INT(prepare.atrousWavelet, uStepWidth, stepWidth[i]);
+            R3D_SHADER_BIND_SAMPLER(prepare.atrousWaveletSmart, uSourceTex, r3d_target_get(src));
+            R3D_SHADER_SET_FLOAT(prepare.atrousWaveletSmart, uInvStepWidth2, invStepWidth2);
+            R3D_SHADER_SET_INT(prepare.atrousWaveletSmart, uStepWidth, stepWidth[i]);
             R3D_RENDER_SCREEN();
 
             SWAP(r3d_target_t, src, dst);

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1743,16 +1743,6 @@ r3d_target_t pass_prepare_ssil(void)
 
 r3d_target_t pass_prepare_ssgi(void)
 {
-    /* --- Check if we need history --- */
-
-    static r3d_target_t SSGI_HISTORY  = R3D_TARGET_SSGI_0;
-    static r3d_target_t SSGI_RAW      = R3D_TARGET_SSGI_1;
-    static r3d_target_t SSGI_FILTERED = R3D_TARGET_SSGI_2;
-
-    if (r3d_target_get_or_null(SSGI_HISTORY) == 0) {
-        R3D_TARGET_CLEAR(false, SSGI_HISTORY);
-    }
-
     /* --- Setup OpenGL pipeline --- */
 
     r3d_driver_disable(GL_STENCIL_TEST);
@@ -1773,10 +1763,9 @@ r3d_target_t pass_prepare_ssgi(void)
 
     /* --- Calculate SSGI (RAW) --- */
 
-    R3D_TARGET_BIND_LEVEL(0, SSGI_RAW);
+    R3D_TARGET_BIND_LEVEL(0, R3D_TARGET_SSGI_0);
     R3D_SHADER_USE(prepare.ssgi);
 
-    R3D_SHADER_BIND_SAMPLER(prepare.ssgi, uHistoryTex, r3d_target_get(SSGI_HISTORY));
     R3D_SHADER_BIND_SAMPLER(prepare.ssgi, uDiffuseTex, r3d_target_get_level(R3D_TARGET_DIFFUSE, 1));
     R3D_SHADER_BIND_SAMPLER(prepare.ssgi, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
     R3D_SHADER_BIND_SAMPLER(prepare.ssgi, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
@@ -1816,8 +1805,8 @@ r3d_target_t pass_prepare_ssgi(void)
             3 steps : 32 16  8
     */
 
-    r3d_target_t* src = &SSGI_RAW;
-    r3d_target_t* dst = &SSGI_FILTERED;
+    r3d_target_t src = R3D_TARGET_SSGI_0;
+    r3d_target_t dst = R3D_TARGET_SSGI_1;
 
     int steps = R3D.environment.ssgi.denoiseSteps;
 
@@ -1838,19 +1827,17 @@ r3d_target_t pass_prepare_ssgi(void)
         {
             float invStepWidth2 = 1.0f / (stepWidth[i]*stepWidth[i]);
 
-            R3D_TARGET_BIND(false, *dst);
-            R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uSourceTex, r3d_target_get(*src));
+            R3D_TARGET_BIND(false, dst);
+            R3D_SHADER_BIND_SAMPLER(prepare.atrousWavelet, uSourceTex, r3d_target_get(src));
             R3D_SHADER_SET_FLOAT(prepare.atrousWavelet, uInvStepWidth2, invStepWidth2);
             R3D_SHADER_SET_INT(prepare.atrousWavelet, uStepWidth, stepWidth[i]);
             R3D_RENDER_SCREEN();
 
-            SWAP(r3d_target_t, *src, *dst);
+            SWAP(r3d_target_t, src, dst);
         }
     }
 
-    SWAP(r3d_target_t, SSGI_HISTORY, *src);
-
-    return SSGI_HISTORY;
+    return src;
 }
 
 r3d_target_t pass_prepare_ssr(void)

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1780,7 +1780,7 @@ r3d_target_t pass_prepare_ssgi(void)
     /*
         A-trous step schedule (largest -> smallest).
 
-        We use a fixed pyramid: {32, 16, 8, 4, 2, 1}.
+        We use a fixed pyramid: {16, 8, 4, 2, 1}.
         When fewer iterations are requested we simply truncate the list.
 
         The largest steps are what stabilize the filter in motion.
@@ -1792,14 +1792,13 @@ r3d_target_t pass_prepare_ssgi(void)
         noticeably less stable when the camera moves.
 
         Keeping the same large radii and only dropping the final refinement
-        passes preserves the temporal stability of the 6-step filter while
+        passes preserves the spatial stability of the 5-step filter while
         allowing cheaper configurations.
 
         Examples:
-            6 steps : 32 16  8  4  2  1
-            5 steps : 32 16  8  4  2
-            4 steps : 32 16  8  4
-            3 steps : 32 16  8
+            5 steps : 16  8  4  2  1
+            4 steps : 16  8  4  2
+            3 steps : 16  8  4
     */
 
     r3d_target_t src = R3D_TARGET_SSGI_0;


### PR DESCRIPTION
Replace raymarching SSGI with horizon-based SSGI

Replaces the previous raymarching-based SSGI implementation with a
horizon-based approach adapted from Alexander Sannikov's SSVGI, available [here](https://github.com/Raikiri/LegitEngine/tree/master/bin/data/Shaders/glsl/SSVGI)

The key improvement is frame time stability: on Sponza at 720p (RTX 3050),
the previous implementation averaged 0.6ms but spiked between 0.5-0.9ms
depending on scene content. The new implementation holds a constant 0.6ms
regardless of what is on screen, as step count is determined by screen
position rather than scene geometry.

Further quality and performance improvements may be made over time.