### PR TITLE
Update r3d-cs binding version to 0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Here is a list with all the ports available. Feel free to send a PR if you know 
 | --- | :-: | :-: | :-: |
 | [r3d-odin](https://github.com/Bigfoot71/r3d-odin) | **0.9.1** | [Odin](https://odin-lang.org/) | Zlib |
 | [ray4laz_r3d](https://github.com/GuvaCode/ray4laz_r3d) | **0.9.1** | [FreePascal](https://en.wikipedia.org/wiki/Free_Pascal) | MIT |
-| [r3d-cs](https://github.com/graphnode/r3d-cs) | **0.9** | [C#](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)) | Zlib |
+| [r3d-cs](https://github.com/graphnode/r3d-cs) | **0.9.1** | [C#](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)) | Zlib |
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Updated [r3d-cs](https://github.com/graphnode/r3d-cs) binding version from 0.9 to 0.9.1 in the bindings table.

### Note
While updating the bindings we found that calling `R3D_Close()`/`R3D_Init()` across `CloseWindow()`/`InitWindow()` cycles in the same process causes rendering artifacts (magenta tint) due to stale state in raylib's internal `rlglData` static struct, which is not fully reset between window close/init cycles. The v0.9.1 binding caches (sampler/UBO bindings) interact with this stale state. We worked around it on our side by spawning a separate process per example, but it may be worth noting that `R3D_Close`/`R3D_Init` is not safe to call multiple times in the same process after `CloseWindow`/`InitWindow`. See [graphnode/r3d-cs#1](https://github.com/graphnode/r3d-cs/issues/1) for details.