### PR TITLE
Add configurable instance attribute formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,7 @@ add_library(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/src/r3d_mesh.c"
     "${R3D_ROOT_PATH}/src/r3d_mesh_data.c"
     "${R3D_ROOT_PATH}/src/r3d_model.c"
+    "${R3D_ROOT_PATH}/src/r3d_pack.c"
     "${R3D_ROOT_PATH}/src/r3d_probe.c"
     "${R3D_ROOT_PATH}/src/r3d_skeleton.c"
     "${R3D_ROOT_PATH}/src/r3d_shape.c"

--- a/examples/instanced.c
+++ b/examples/instanced.c
@@ -1,8 +1,16 @@
-#include "r3d/r3d_instance.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
+#include <stdint.h>
 
 #define INSTANCE_COUNT 1000
+
+typedef struct PackedRotation {
+    int16_t x, y, z, w;
+} PackedRotation;
+
+typedef struct PackedScale {
+    uint16_t x, y, z;
+} PackedScale;
 
 int main(void)
 {
@@ -20,38 +28,74 @@ int main(void)
     R3D_Mesh mesh = R3D_GenMeshCube(1, 1, 1);
     R3D_Material material = R3D_GetDefaultMaterial();
 
-    // Generate random transforms and colors for instances
-    R3D_InstanceBuffer instances = R3D_LoadInstanceBuffer(INSTANCE_COUNT, R3D_INSTANCE_POSITION | R3D_INSTANCE_ROTATION | R3D_INSTANCE_SCALE | R3D_INSTANCE_COLOR);
+    R3D_InstanceLayout layout = {
+        .formats = {
+            R3D_INSTANCE_FORMAT_FLOAT32,    // position
+            R3D_INSTANCE_FORMAT_SNORM16,    // rotation quaternion
+            R3D_INSTANCE_FORMAT_FLOAT16,    // scale
+            R3D_INSTANCE_FORMAT_UNORM8,     // color
+        },
+        .flags = R3D_INSTANCE_POSITION |
+                 R3D_INSTANCE_ROTATION |
+                 R3D_INSTANCE_SCALE |
+                 R3D_INSTANCE_COLOR,
+    };
+
+    R3D_InstanceBuffer instances = R3D_LoadInstanceBufferEx(INSTANCE_COUNT, layout);
+
     Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION);
-    Quaternion* rotations = R3D_MapInstances(instances, R3D_INSTANCE_ROTATION);
-    Vector3* scales = R3D_MapInstances(instances, R3D_INSTANCE_SCALE);
+    PackedRotation* rotations = R3D_MapInstances(instances, R3D_INSTANCE_ROTATION);
+    PackedScale* scales = R3D_MapInstances(instances, R3D_INSTANCE_SCALE);
     Color* colors = R3D_MapInstances(instances, R3D_INSTANCE_COLOR);
 
     for (int i = 0; i < INSTANCE_COUNT; i++)
     {
         positions[i] = (Vector3) {
-            (float)GetRandomValue(-50000, 50000) / 1000,
-            (float)GetRandomValue(-50000, 50000) / 1000,
-            (float)GetRandomValue(-50000, 50000) / 1000
+            (float)GetRandomValue(-50000, 50000) / 1000.0f,
+            (float)GetRandomValue(-50000, 50000) / 1000.0f,
+            (float)GetRandomValue(-50000, 50000) / 1000.0f
         };
-        rotations[i] = QuaternionFromEuler(
-            (float)GetRandomValue(-314000, 314000) / 100000,
-            (float)GetRandomValue(-314000, 314000) / 100000,
-            (float)GetRandomValue(-314000, 314000) / 100000
+
+        Quaternion rotation = QuaternionFromEuler(
+            (float)GetRandomValue(-314000, 314000) / 100000.0f,
+            (float)GetRandomValue(-314000, 314000) / 100000.0f,
+            (float)GetRandomValue(-314000, 314000) / 100000.0f
         );
-        scales[i] = (Vector3) {
-            (float)GetRandomValue(100, 2000) / 1000,
-            (float)GetRandomValue(100, 2000) / 1000,
-            (float)GetRandomValue(100, 2000) / 1000
+
+        rotations[i] = (PackedRotation) {
+            R3D_PackSnorm16(rotation.x),
+            R3D_PackSnorm16(rotation.y),
+            R3D_PackSnorm16(rotation.z),
+            R3D_PackSnorm16(rotation.w)
         };
+
+        Vector3 scale = {
+            (float)GetRandomValue(100, 2000) / 1000.0f,
+            (float)GetRandomValue(100, 2000) / 1000.0f,
+            (float)GetRandomValue(100, 2000) / 1000.0f
+        };
+
+        scales[i] = (PackedScale) {
+            R3D_PackFloat16(scale.x),
+            R3D_PackFloat16(scale.y),
+            R3D_PackFloat16(scale.z)
+        };
+
         colors[i] = ColorFromHSV(
-            (float)GetRandomValue(0, 360000) / 1000, 1.0f, 1.0f
+            (float)GetRandomValue(0, 360000) / 1000.0f,
+            1.0f,
+            1.0f
         );
     }
 
-    R3D_UnmapInstances(instances, R3D_INSTANCE_POSITION | R3D_INSTANCE_ROTATION | R3D_INSTANCE_SCALE | R3D_INSTANCE_COLOR);
+    R3D_UnmapInstances(
+        instances,
+        R3D_INSTANCE_POSITION |
+        R3D_INSTANCE_ROTATION |
+        R3D_INSTANCE_SCALE |
+        R3D_INSTANCE_COLOR
+    );
 
-    // Setup directional light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){0, -1, 0});
     R3D_SetLightActive(light, true);

--- a/include/r3d/r3d.h
+++ b/include/r3d/r3d.h
@@ -38,6 +38,7 @@
 #include "r3d_mesh_data.h"
 #include "r3d_mesh.h"
 #include "r3d_model.h"
+#include "r3d_pack.h"
 #include "r3d_probe.h"
 #include "r3d_screen_shader.h"
 #include "r3d_shape.h"

--- a/include/r3d/r3d_instance.h
+++ b/include/r3d/r3d_instance.h
@@ -30,30 +30,79 @@
 
 /**
  * @brief Bitmask defining which instance attributes are present.
+ *
+ * Each bit enables one per-instance attribute stream. Attribute data is stored
+ * in separate GPU buffers, one buffer per enabled attribute.
+ *
+ * The memory format of each enabled attribute is defined by `R3D_InstanceLayout`.
+ * In shaders, these attributes are exposed as floating-point vectors, including
+ * normalized integer formats such as UNORM/SNORM.
  */
 typedef uint32_t R3D_InstanceFlags;
 
-#define R3D_INSTANCE_POSITION   (1 << 0)    /*< Vector3     */
-#define R3D_INSTANCE_ROTATION   (1 << 1)    /*< Quaternion  */
-#define R3D_INSTANCE_SCALE      (1 << 2)    /*< Vector3     */
-#define R3D_INSTANCE_COLOR      (1 << 3)    /*< Color       */
-#define R3D_INSTANCE_CUSTOM     (1 << 4)    /*< Vector4     */
+#define R3D_INSTANCE_POSITION   (1u << 0)   /*< Position attribute: 3 components */
+#define R3D_INSTANCE_ROTATION   (1u << 1)   /*< Rotation attribute: 4 components (quaternion) */
+#define R3D_INSTANCE_SCALE      (1u << 2)   /*< Scale attribute: 3 components */
+#define R3D_INSTANCE_COLOR      (1u << 3)   /*< Color attribute: 4 components */
+#define R3D_INSTANCE_CUSTOM     (1u << 4)   /*< Custom attribute: 4 components */
+
+/**
+ * @brief Storage format used by an instance attribute.
+ *
+ * The selected format controls how the attribute is stored in GPU memory.
+ * All formats are read by the shader as floating-point values.
+ *
+ * UNORM formats are converted to the [0, 1] range.
+ * SNORM formats are converted to the [-1, 1] range.
+ */
+typedef enum R3D_InstanceFormat {
+    R3D_INSTANCE_FORMAT_FLOAT32,    ///< 32-bit floating-point component.
+    R3D_INSTANCE_FORMAT_FLOAT16,    ///< 16-bit floating-point component.
+    R3D_INSTANCE_FORMAT_UNORM16,    ///< 16-bit unsigned normalized component.
+    R3D_INSTANCE_FORMAT_SNORM16,    ///< 16-bit signed normalized component.
+    R3D_INSTANCE_FORMAT_UNORM8,     ///< 8-bit unsigned normalized component.
+    R3D_INSTANCE_FORMAT_SNORM8,     ///< 8-bit signed normalized component.
+
+    R3D_INSTANCE_FORMAT_COUNT       ///< Number of available instance formats.
+} R3D_InstanceFormat;
 
 // ========================================
 // STRUCT TYPES
 // ========================================
 
 /**
+ * @brief Describes the layout of an instance buffer.
+ *
+ * `flags` defines which instance attributes are allocated.
+ * `formats` defines the storage format used by each attribute.
+ *
+ * The `formats` array is indexed in the same order as the instance attribute
+ * flags:
+ *
+ * - index 0: `R3D_INSTANCE_POSITION`
+ * - index 1: `R3D_INSTANCE_ROTATION`
+ * - index 2: `R3D_INSTANCE_SCALE`
+ * - index 3: `R3D_INSTANCE_COLOR`
+ * - index 4: `R3D_INSTANCE_CUSTOM`
+ *
+ * Data uploaded or mapped for an attribute must match the format selected for
+ * that attribute.
+ */
+typedef struct R3D_InstanceLayout {
+    R3D_InstanceFormat formats[R3D_INSTANCE_ATTRIBUTE_COUNT];   ///< Storage format for each instance attribute.
+    R3D_InstanceFlags flags;                                    ///< Enabled instance attribute mask.
+} R3D_InstanceLayout;
+
+/**
  * @brief GPU buffers storing instance attribute streams.
  *
- * buffers: One VBO per attribute (indexed by flag order).
- * capcity: Maximum number of instances.
- * flags: Enabled attribute mask.
+ * Each enabled attribute owns one GPU buffer. The enabled attributes and their
+ * storage formats are described by `layout`.
  */
 typedef struct R3D_InstanceBuffer {
-    uint32_t buffers[R3D_INSTANCE_ATTRIBUTE_COUNT];
-    R3D_InstanceFlags flags;
-    int capacity;
+    uint32_t buffers[R3D_INSTANCE_ATTRIBUTE_COUNT];     ///< One GPU buffer per attribute, indexed by attribute order.
+    R3D_InstanceLayout layout;                          ///< Instance buffer layout.
+    int capacity;                                       ///< Maximum number of instances.
 } R3D_InstanceBuffer;
 
 // ========================================
@@ -65,12 +114,42 @@ extern "C" {
 #endif
 
 /**
- * @brief Create instance buffers on the GPU.
- * @param capacity Max instances.
+ * @brief Creates instance buffers on the GPU using the default layout.
+ *
+ * This is the simple entry point. It allocates one GPU buffer for each enabled
+ * attribute in `flags`.
+ *
+ * Default formats:
+ *
+ * - position: FLOAT32
+ * - rotation: FLOAT32
+ * - scale: FLOAT32
+ * - color: UNORM8
+ * - custom: FLOAT32
+ *
+ * @param capacity Maximum number of instances.
  * @param flags Attribute mask to allocate.
- * @return Initialized instance buffer.
+ *
+ * @return Initialized instance buffer, or an empty buffer on failure.
  */
 R3DAPI R3D_InstanceBuffer R3D_LoadInstanceBuffer(int capacity, R3D_InstanceFlags flags);
+
+/**
+ * @brief Creates instance buffers on the GPU using a custom layout.
+ *
+ * This is the advanced entry point. It allocates one GPU buffer for each
+ * enabled attribute in `layout.flags`, using the corresponding storage format
+ * from `layout.formats`.
+ *
+ * Data uploaded or mapped for each attribute must match the format selected in
+ * the layout.
+ *
+ * @param capacity Maximum number of instances.
+ * @param layout Instance layout describing enabled attributes and formats.
+ *
+ * @return Initialized instance buffer, or an empty buffer on failure.
+ */
+R3DAPI R3D_InstanceBuffer R3D_LoadInstanceBufferEx(int capacity, R3D_InstanceLayout layout);
 
 /**
  * @brief Destroy all GPU buffers owned by this instance buffer.
@@ -113,6 +192,35 @@ R3DAPI void* R3D_MapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag)
  * @param flags Bitmask of attributes to unmap.
  */
 R3DAPI void R3D_UnmapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flags);
+
+/**
+ * @brief Sets the storage format of an instance attribute in a layout.
+ *
+ * `attribute` must be a single instance attribute flag, such as
+ * `R3D_INSTANCE_POSITION`, not a combination of multiple flags.
+ *
+ * This function only changes the format stored in the layout. It does not
+ * enable the attribute in `layout.flags`.
+ *
+ * @param layout Layout to modify.
+ * @param attribute Single attribute flag to modify.
+ * @param format New storage format.
+ */
+R3DAPI void R3D_SetInstanceFormat(R3D_InstanceLayout* layout, R3D_InstanceFlags attribute, R3D_InstanceFormat format);
+
+/**
+ * @brief Gets the storage format of an instance attribute from a layout.
+ *
+ * `attribute` must be a single instance attribute flag, such as
+ * `R3D_INSTANCE_POSITION`, not a combination of multiple flags.
+ *
+ * @param layout Layout to read from.
+ * @param attribute Single attribute flag to query.
+ *
+ * @return Storage format of the requested attribute, or FLOAT32 if the
+ * attribute flag is invalid.
+ */
+R3DAPI R3D_InstanceFormat R3D_GetInstanceFormat(R3D_InstanceLayout layout, R3D_InstanceFlags attribute);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/r3d/r3d_pack.h
+++ b/include/r3d/r3d_pack.h
@@ -1,0 +1,141 @@
+/* r3d_pack.h -- R3D Pack Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#ifndef R3D_PACK_H
+#define R3D_PACK_H
+
+#include "./r3d_platform.h"
+#include <raylib.h>
+#include <stdint.h>
+
+/**
+ * @defgroup Pack Pack
+ * @{
+ */
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Packs a 32-bit float into a 16-bit floating-point value.
+ *
+ * @param x Value to pack.
+ *
+ * @return IEEE 754 half-precision representation.
+ */
+R3DAPI uint16_t R3D_PackFloat16(float x);
+
+/**
+ * @brief Packs a float into a 16-bit unsigned normalized value.
+ *
+ * The input value is clamped to the [0, 1] range before packing.
+ *
+ * @param x Value to pack.
+ *
+ * @return 16-bit UNORM representation.
+ */
+R3DAPI uint16_t R3D_PackUnorm16(float x);
+
+/**
+ * @brief Packs a float into a 16-bit signed normalized value.
+ *
+ * The input value is clamped to the [-1, 1] range before packing.
+ *
+ * @param x Value to pack.
+ *
+ * @return 16-bit SNORM representation.
+ */
+R3DAPI int16_t R3D_PackSnorm16(float x);
+
+/**
+ * @brief Packs a float into an 8-bit unsigned normalized value.
+ *
+ * The input value is clamped to the [0, 1] range before packing.
+ *
+ * @param x Value to pack.
+ *
+ * @return 8-bit UNORM representation.
+ */
+R3DAPI uint8_t R3D_PackUnorm8(float x);
+
+/**
+ * @brief Packs a float into an 8-bit signed normalized value.
+ *
+ * The input value is clamped to the [-1, 1] range before packing.
+ *
+ * @param x Value to pack.
+ *
+ * @return 8-bit SNORM representation.
+ */
+R3DAPI int8_t R3D_PackSnorm8(float x);
+
+/**
+ * @brief Unpacks a 16-bit floating-point value into a 32-bit float.
+ *
+ * @param x IEEE 754 half-precision representation.
+ *
+ * @return Unpacked float value.
+ */
+R3DAPI float R3D_UnpackFloat16(uint16_t x);
+
+/**
+ * @brief Unpacks a 16-bit unsigned normalized value.
+ *
+ * The returned value is in the [0, 1] range.
+ *
+ * @param x 16-bit UNORM representation.
+ *
+ * @return Unpacked float value.
+ */
+R3DAPI float R3D_UnpackUnorm16(uint16_t x);
+
+/**
+ * @brief Unpacks a 16-bit signed normalized value.
+ *
+ * The returned value is clamped to the [-1, 1] range.
+ *
+ * @param x 16-bit SNORM representation.
+ *
+ * @return Unpacked float value.
+ */
+R3DAPI float R3D_UnpackSnorm16(int16_t x);
+
+/**
+ * @brief Unpacks an 8-bit unsigned normalized value.
+ *
+ * The returned value is in the [0, 1] range.
+ *
+ * @param x 8-bit UNORM representation.
+ *
+ * @return Unpacked float value.
+ */
+R3DAPI float R3D_UnpackUnorm8(uint8_t x);
+
+/**
+ * @brief Unpacks an 8-bit signed normalized value.
+ *
+ * The returned value is clamped to the [-1, 1] range.
+ *
+ * @param x 8-bit SNORM representation.
+ *
+ * @return Unpacked float value.
+ */
+R3DAPI float R3D_UnpackSnorm8(int8_t x);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+/** @} */ // end of Pack
+
+#endif // R3D_PACK_H

--- a/include/r3d/r3d_vertex.h
+++ b/include/r3d/r3d_vertex.h
@@ -14,7 +14,7 @@
 #include <stdint.h>
 
 /**
- * @defgroup Vertex
+ * @defgroup Vertex Vertex
  * @{
  */
 
@@ -23,16 +23,20 @@
 // ========================================
 
 /**
- * @brief Represents a vertex and all its attributes for a mesh.
+ * @brief Compact vertex format used by R3D meshes.
+ *
+ * Texture coordinates are stored as float16 values.
+ * Normals and tangents are stored as signed normalized 8-bit values.
+ * Bone weights are stored as unsigned 8-bit values and should sum to 255.
  */
 typedef struct R3D_Vertex {
-    Vector3 position;           ///< The 3D position of the vertex in object space.
-    uint16_t texcoord[2];       ///< The 2D texture coordinates (UV) for mapping textures.
-    int8_t normal[4];           ///< The normal vector used for lighting calculations.
-    int8_t tangent[4];          ///< The tangent vector, used in normal mapping (often with a handedness in w).
-    Color color;                ///< Vertex color, in RGBA32.
-    uint8_t boneIndices[4];     ///< Indices of up to 4 bones that influence this vertex (for skinning).
-    uint8_t boneWeights[4];     ///< Corresponding bone weights (should sum to 255). Defines the influence of each bone.
+    Vector3 position;           ///< Vertex position in object space.
+    uint16_t texcoord[2];       ///< Texture coordinates stored as float16.
+    int8_t normal[4];           ///< Normal vector stored as SNORM8. XYZ are used, W is unused.
+    int8_t tangent[4];          ///< Tangent vector stored as SNORM8. XYZ are tangent, W stores handedness.
+    Color color;                ///< Vertex color in RGBA8.
+    uint8_t boneIndices[4];     ///< Indices of up to 4 bones influencing this vertex.
+    uint8_t boneWeights[4];     ///< Bone weights in UNORM8. Values should sum to 255.
 } R3D_Vertex;
 
 // ========================================
@@ -44,62 +48,87 @@ extern "C" {
 #endif
 
 /**
- * @brief Constructs a fully encoded @ref R3D_Vertex from unpacked attribute data.
+ * @brief Constructs a packed R3D vertex from unpacked attribute data.
+ *
+ * Texture coordinates are packed to float16.
+ * Normals and tangents are packed to SNORM8.
+ *
  * @param position Vertex position in object space.
- * @param texcoord UV texture coordinates (float, any range).
- * @param normal Unit normal vector.
- * @param tangent Tangent vector with handedness in w (+1 or -1).
+ * @param texcoord Texture coordinates in float32. Any range is supported.
+ * @param normal Normal vector. Components are clamped to the [-1, 1] range.
+ * @param tangent Tangent vector. XYZ components are clamped to [-1, 1], W stores handedness.
  * @param color Vertex color in RGBA8.
- * @return Encoded vertex ready for GPU upload.
+ *
+ * @return Packed vertex ready for GPU upload.
  */
 R3DAPI R3D_Vertex R3D_MakeVertex(Vector3 position, Vector2 texcoord, Vector3 normal, Vector4 tangent, Color color);
 
 /**
- * @brief Encodes a UV coordinate pair from float32 to float16.
- * @param dst Output buffer of 2 uint16_t (float16). Must not be NULL.
- * @param src UV coordinates in float32. Supports any range (tiling included).
+ * @brief Packs texture coordinates from float32 to float16.
+ *
+ * @param dst Output buffer of 2 uint16_t values. Must not be NULL.
+ * @param src Texture coordinates in float32. Any range is supported.
  */
-R3DAPI void R3D_EncodeTexCoord(uint16_t* dst, Vector2 src);
+R3DAPI void R3D_PackTexCoord(uint16_t* dst, Vector2 src);
 
 /**
- * @brief Decodes a float16 UV coordinate pair back to float32.
- * @param src Input buffer of 2 uint16_t (float16). Must not be NULL.
- * @return Decoded UV coordinates in float32.
+ * @brief Unpacks texture coordinates from float16 to float32.
+ *
+ * @param src Input buffer of 2 uint16_t values. Must not be NULL.
+ *
+ * @return Unpacked texture coordinates in float32.
  */
-R3DAPI Vector2 R3D_DecodeTexCoord(const uint16_t* src);
+R3DAPI Vector2 R3D_UnpackTexCoord(const uint16_t* src);
 
 /**
- * @brief Encodes a unit normal vector from float32 to snorm8 (XYZ).
- * @param dst Output buffer of 4 int8_t. W is set to 0. Must not be NULL.
- * @param src Unit normal vector. Components must be in [-1, 1].
+ * @brief Packs a normal vector from float32 to SNORM8.
+ *
+ * XYZ components are clamped to the [-1, 1] range before packing.
+ * The fourth component is set to 0.
+ *
+ * @param dst Output buffer of 4 int8_t values. Must not be NULL.
+ * @param src Normal vector to pack.
  */
-R3DAPI void R3D_EncodeNormal(int8_t* dst, Vector3 src);
+R3DAPI void R3D_PackNormal(int8_t* dst, Vector3 src);
 
 /**
- * @brief Decodes a snorm8 normal back to float32.
- * @param src Input buffer of 4 int8_t (only XYZ are read). Must not be NULL.
- * @return Decoded normal vector. Not guaranteed to be unit length.
+ * @brief Unpacks a normal vector from SNORM8 to float32.
+ *
+ * Only XYZ components are read.
+ *
+ * @param src Input buffer of 4 int8_t values. Must not be NULL.
+ *
+ * @return Unpacked normal vector. Not guaranteed to be unit length.
  */
-R3DAPI Vector3 R3D_DecodeNormal(const int8_t* src);
+R3DAPI Vector3 R3D_UnpackNormal(const int8_t* src);
 
 /**
- * @brief Encodes a tangent vector from float32 to snorm8, preserving handedness in W.
- * @param dst Output buffer of 4 int8_t. Must not be NULL.
- * @param src Tangent vector. XYZ must be in [-1, 1]; W encodes handedness (+1 or -1).
+ * @brief Packs a tangent vector from float32 to SNORM8.
+ *
+ * XYZ components are clamped to the [-1, 1] range before packing.
+ * W stores tangent handedness and is packed as either +1 or -1.
+ *
+ * @param dst Output buffer of 4 int8_t values. Must not be NULL.
+ * @param src Tangent vector to pack. W is interpreted as handedness.
  */
-R3DAPI void R3D_EncodeTangent(int8_t* dst, Vector4 src);
+R3DAPI void R3D_PackTangent(int8_t* dst, Vector4 src);
 
 /**
- * @brief Decodes a snorm8 tangent back to float32.
- * @param src Input buffer of 4 int8_t. Must not be NULL.
- * @return Decoded tangent. W is exactly +1.0 or -1.0 (handedness).
+ * @brief Unpacks a tangent vector from SNORM8 to float32.
+ *
+ * XYZ components are unpacked from SNORM8.
+ * W is returned as exactly +1.0f or -1.0f.
+ *
+ * @param src Input buffer of 4 int8_t values. Must not be NULL.
+ *
+ * @return Unpacked tangent vector.
  */
-R3DAPI Vector4 R3D_DecodeTangent(const int8_t* src);
+R3DAPI Vector4 R3D_UnpackTangent(const int8_t* src);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
 
-/** @} */ // end of MeshData
+/** @} */ // end of Vertex
 
 #endif // R3D_VERTEX_H

--- a/src/importer/r3d_importer_mesh.c
+++ b/src/importer/r3d_importer_mesh.c
@@ -42,7 +42,7 @@ static inline void process_vertex_position(Vector3* position, const struct aiVec
 static inline void process_vertex_texcoord(uint16_t* texcoord, const struct aiMesh* aiMesh, int index)
 {
     if (aiMesh->mTextureCoords[0] && aiMesh->mNumUVComponents[0] >= 2) {
-        R3D_EncodeTexCoord(texcoord, r3d_importer_cast_to_vector2(aiMesh->mTextureCoords[0][index]));
+        R3D_PackTexCoord(texcoord, r3d_importer_cast_to_vector2(aiMesh->mTextureCoords[0][index]));
     }
     // NOTE: Vertices are zero-initialized
     //else {
@@ -57,10 +57,10 @@ static inline void process_vertex_normal(int8_t* normal, const struct aiMesh* ai
         if (!hasBones) {
             vec = r3d_vector3_transform_linear(vec, normalMatrix);
         }
-        R3D_EncodeNormal(normal, Vector3Normalize(vec));
+        R3D_PackNormal(normal, Vector3Normalize(vec));
     }
     else {
-        R3D_EncodeNormal(normal, (Vector3){0.0f, 0.0f, 1.0f});
+        R3D_PackNormal(normal, (Vector3){0.0f, 0.0f, 1.0f});
     }
 }
 
@@ -84,13 +84,13 @@ static inline void process_vertex_tangent(R3D_Vertex* vertex, const struct aiMes
         Vector3 reconstructedBitangent = Vector3CrossProduct(normal, tangent);
         float handedness = Vector3DotProduct(reconstructedBitangent, bitangent);
 
-        R3D_EncodeTangent(vertex->tangent, (Vector4){
+        R3D_PackTangent(vertex->tangent, (Vector4){
             tangent.x, tangent.y, tangent.z,
             copysignf(1.0f, handedness)
         });
     }
     else {
-        R3D_EncodeTangent(vertex->tangent, (Vector4){1.0f, 0.0f, 0.0f, 1.0f});
+        R3D_PackTangent(vertex->tangent, (Vector4){1.0f, 0.0f, 0.0f, 1.0f});
     }
 }
 

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -21,6 +21,45 @@
 #include "../common/r3d_hash.h"
 
 // ========================================
+// MODULE CONSTANTS
+// ========================================
+
+static const GLenum INSTANCE_FORMAT_GL_TYPE[R3D_INSTANCE_FORMAT_COUNT] = {
+    [R3D_INSTANCE_FORMAT_FLOAT32] = GL_FLOAT,
+    [R3D_INSTANCE_FORMAT_FLOAT16] = GL_HALF_FLOAT,
+    [R3D_INSTANCE_FORMAT_UNORM16] = GL_UNSIGNED_SHORT,
+    [R3D_INSTANCE_FORMAT_SNORM16] = GL_SHORT,
+    [R3D_INSTANCE_FORMAT_UNORM8]  = GL_UNSIGNED_BYTE,
+    [R3D_INSTANCE_FORMAT_SNORM8]  = GL_BYTE,
+};
+
+static const GLboolean INSTANCE_FORMAT_NORMALIZED[R3D_INSTANCE_FORMAT_COUNT] = {
+    [R3D_INSTANCE_FORMAT_FLOAT32] = GL_FALSE,
+    [R3D_INSTANCE_FORMAT_FLOAT16] = GL_FALSE,
+    [R3D_INSTANCE_FORMAT_UNORM16] = GL_TRUE,
+    [R3D_INSTANCE_FORMAT_SNORM16] = GL_TRUE,
+    [R3D_INSTANCE_FORMAT_UNORM8]  = GL_TRUE,
+    [R3D_INSTANCE_FORMAT_SNORM8]  = GL_TRUE,
+};
+
+static const int INSTANCE_ATTRIBUTE_COMPONENTS[R3D_INSTANCE_ATTRIBUTE_COUNT] = {
+    /* POSITION */  3,
+    /* ROTATION */  4,
+    /* SCALE    */  3,
+    /* COLOR    */  4,
+    /* CUSTOM   */  4,
+};
+
+static const int INSTANCE_FORMAT_SIZE[R3D_INSTANCE_FORMAT_COUNT] = {
+    [R3D_INSTANCE_FORMAT_FLOAT32] = 4,
+    [R3D_INSTANCE_FORMAT_FLOAT16] = 2,
+    [R3D_INSTANCE_FORMAT_UNORM16] = 2,
+    [R3D_INSTANCE_FORMAT_SNORM16] = 2,
+    [R3D_INSTANCE_FORMAT_UNORM8]  = 1,
+    [R3D_INSTANCE_FORMAT_SNORM8]  = 1,
+};
+
+// ========================================
 // MODULE STATE
 // ========================================
 
@@ -408,61 +447,50 @@ void load_shape_cube(r3d_render_shape_t* shape)
 // INTERNAL INSTANCES FUNCTIONS
 // ========================================
 
-static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT], R3D_InstanceFlags flags, int offset)
+static void enable_instances(const GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT], R3D_InstanceLayout layout, int offset)
 {
     r3d_render_instance_state_t* state = &R3D_MOD_RENDER.instanceState;
 
-    if (flags == state->flags && offset == state->offset &&
-        memcmp(buffers, state->buffers, R3D_INSTANCE_ATTRIBUTE_COUNT * sizeof(GLuint)) == 0) {
+    if (offset == state->offset &&
+        memcmp(buffers, state->buffers, R3D_INSTANCE_ATTRIBUTE_COUNT * sizeof(GLuint)) == 0 &&
+        memcmp(&layout, &state->layout, sizeof(R3D_InstanceLayout)) == 0) {
         return;
     }
 
     memcpy(state->buffers, buffers, R3D_INSTANCE_ATTRIBUTE_COUNT * sizeof(GLuint));
-    state->flags = flags, state->offset = offset;
+    state->layout = layout;
+    state->offset = offset;
 
-    if (BIT_TEST(flags, R3D_INSTANCE_POSITION)) {
-        glBindBuffer(GL_ARRAY_BUFFER, buffers[0]);
-        glEnableVertexAttribArray(10);
-        glVertexAttribPointer(10, 3, GL_FLOAT, GL_FALSE, sizeof(Vector3), (void*)(offset * sizeof(Vector3)));
-    }
-    else {
-        glDisableVertexAttribArray(10);
-    }
+    for (int i = 0; i < R3D_INSTANCE_ATTRIBUTE_COUNT; i++) {
+        GLuint attrib = 10 + i;
+        R3D_InstanceFlags flag = 1u << i;
 
-    if (BIT_TEST(flags, R3D_INSTANCE_ROTATION)) {
-        glBindBuffer(GL_ARRAY_BUFFER, buffers[1]);
-        glEnableVertexAttribArray(11);
-        glVertexAttribPointer(11, 4, GL_FLOAT, GL_FALSE, sizeof(Quaternion), (void*)(offset * sizeof(Quaternion)));
-    }
-    else {
-        glDisableVertexAttribArray(11);
-    }
+        if (!BIT_TEST(layout.flags, flag)) {
+            glDisableVertexAttribArray(attrib);
+            continue;
+        }
 
-    if (BIT_TEST(flags, R3D_INSTANCE_SCALE)) {
-        glBindBuffer(GL_ARRAY_BUFFER, buffers[2]);
-        glEnableVertexAttribArray(12);
-        glVertexAttribPointer(12, 3, GL_FLOAT, GL_FALSE, sizeof(Vector3), (void*)(offset * sizeof(Vector3)));
-    }
-    else {
-        glDisableVertexAttribArray(12);
-    }
+        R3D_InstanceFormat format = layout.formats[i];
 
-    if (BIT_TEST(flags, R3D_INSTANCE_COLOR)) {
-        glBindBuffer(GL_ARRAY_BUFFER, buffers[3]);
-        glEnableVertexAttribArray(13);
-        glVertexAttribPointer(13, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(Color), (void*)(offset * sizeof(Color)));
-    }
-    else {
-        glDisableVertexAttribArray(13);
-    }
+        if (format < 0 || format >= R3D_INSTANCE_FORMAT_COUNT) {
+            glDisableVertexAttribArray(attrib);
+            R3D_TRACELOG(LOG_WARNING, "enable_instances -> invalid instance format (attribute=%d, format=%d)", i, format);
+            continue;
+        }
 
-    if (BIT_TEST(flags, R3D_INSTANCE_CUSTOM)) {
-        glBindBuffer(GL_ARRAY_BUFFER, buffers[4]);
-        glEnableVertexAttribArray(14);
-        glVertexAttribPointer(14, 4, GL_FLOAT, GL_FALSE, sizeof(Vector4), (void*)(offset * sizeof(Vector4)));
-    }
-    else {
-        glDisableVertexAttribArray(14);
+        int components = INSTANCE_ATTRIBUTE_COMPONENTS[i];
+        int stride = components * INSTANCE_FORMAT_SIZE[format];
+
+        glBindBuffer(GL_ARRAY_BUFFER, buffers[i]);
+        glEnableVertexAttribArray(attrib);
+        glVertexAttribPointer(
+            attrib,
+            components,
+            INSTANCE_FORMAT_GL_TYPE[format],
+            INSTANCE_FORMAT_NORMALIZED[format],
+            stride,
+            (void*)((size_t)offset * stride)
+        );
     }
 }
 
@@ -1475,7 +1503,7 @@ void r3d_render_draw_instanced(const r3d_render_call_t* call)
 
     const r3d_render_group_t* group = r3d_render_get_call_group(call);
 
-    enable_instances(group->instances.buffers, group->instances.flags, group->instanceOffset);
+    enable_instances(group->instances.buffers, group->instances.layout, group->instanceOffset);
 
     if (indexRange.count == 0) {
         glDrawArraysInstanced(primitive, vertexRange.offset, vertexRange.count, group->instanceCount);
@@ -1495,7 +1523,7 @@ void r3d_render_draw_instanced(const r3d_render_call_t* call)
     // the draw. This is safe as long as non-instanced vertex shaders
     // never read those locations.
 
-    //disable_instances(group->instances.flags);
+    //disable_instances(group->instances.layout.flags);
 }
 
 void r3d_render_draw_shape(r3d_render_shape_enum_t shape)

--- a/src/modules/r3d_render.h
+++ b/src/modules/r3d_render.h
@@ -157,9 +157,9 @@ typedef enum {
  * GL attribute reconfiguration when consecutive draw calls share
  * the same instance group.
  */
-typedef struct {
+typedef struct r3d_render_instance_state_t {
     GLuint buffers[R3D_INSTANCE_ATTRIBUTE_COUNT];
-    R3D_InstanceFlags flags;
+    R3D_InstanceLayout layout;
     int offset;
 } r3d_render_instance_state_t;
 

--- a/src/r3d_instance.c
+++ b/src/r3d_instance.c
@@ -10,22 +10,75 @@
 #include <r3d_config.h>
 #include <raylib.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 #include <glad.h>
 
+#include "./modules/r3d_driver.h"
 #include "./common/r3d_helper.h"
 
 // ========================================
 // INTERNAL CONSTANTS
 // ========================================
 
-static const size_t INSTANCE_ATTRIBUTE_SIZE[R3D_INSTANCE_ATTRIBUTE_COUNT] = {
-    /* POSITION */  sizeof(Vector3),
-    /* ROTATION */  sizeof(Quaternion),
-    /* SCALE    */  sizeof(Vector3),
-    /* COLOR    */  sizeof(Color),
-    /* CUSTOM   */  sizeof(Vector4),
+#define R3D_INSTANCE_VALID_FLAGS ((1u << R3D_INSTANCE_ATTRIBUTE_COUNT) - 1u)
+
+static const size_t INSTANCE_ATTRIBUTE_COMPONENTS[R3D_INSTANCE_ATTRIBUTE_COUNT] = {
+    /* POSITION */  3,
+    /* ROTATION */  4,
+    /* SCALE    */  3,
+    /* COLOR    */  4,
+    /* CUSTOM   */  4,
 };
+
+static const size_t INSTANCE_FORMAT_SIZE[R3D_INSTANCE_FORMAT_COUNT] = {
+    [R3D_INSTANCE_FORMAT_FLOAT32] = 4,
+    [R3D_INSTANCE_FORMAT_FLOAT16] = 2,
+    [R3D_INSTANCE_FORMAT_UNORM16] = 2,
+    [R3D_INSTANCE_FORMAT_SNORM16] = 2,
+    [R3D_INSTANCE_FORMAT_UNORM8]  = 1,
+    [R3D_INSTANCE_FORMAT_SNORM8]  = 1,
+};
+
+// ========================================
+// HELPER FUNCTIONS
+// ========================================
+
+static bool r3d_instance_format_is_valid(R3D_InstanceFormat format)
+{
+    return format >= 0 && format < R3D_INSTANCE_FORMAT_COUNT;
+}
+
+static size_t get_attribute_size(int attrIndex, R3D_InstanceFormat format)
+{
+    if (attrIndex < 0 || attrIndex >= R3D_INSTANCE_ATTRIBUTE_COUNT) return 0;
+    if (!r3d_instance_format_is_valid(format)) return 0;
+
+    return INSTANCE_ATTRIBUTE_COMPONENTS[attrIndex] * INSTANCE_FORMAT_SIZE[format];
+}
+
+static int r3d_instance_attribute_index(R3D_InstanceFlags attribute)
+{
+    if (attribute == 0 || (attribute & (attribute - 1)) != 0) return -1;
+
+    int index = r3d_lsb_index(attribute);
+    if (index < 0 || index >= R3D_INSTANCE_ATTRIBUTE_COUNT) return -1;
+
+    return index;
+}
+
+static bool get_buffer_size(int capacity, int attrIndex, R3D_InstanceFormat format, size_t* size)
+{
+    if (size == NULL) return false;
+
+    size_t attrSize = get_attribute_size(attrIndex, format);
+    if (capacity <= 0 || attrSize == 0) return false;
+
+    if ((size_t)capacity > SIZE_MAX / attrSize) return false;
+
+    *size = (size_t)capacity * attrSize;
+    return true;
+}
 
 // ========================================
 // PUBLIC API
@@ -33,23 +86,70 @@ static const size_t INSTANCE_ATTRIBUTE_SIZE[R3D_INSTANCE_ATTRIBUTE_COUNT] = {
 
 R3D_InstanceBuffer R3D_LoadInstanceBuffer(int capacity, R3D_InstanceFlags flags)
 {
+    R3D_InstanceLayout layout = {
+        .formats = {
+            R3D_INSTANCE_FORMAT_FLOAT32,
+            R3D_INSTANCE_FORMAT_FLOAT32,
+            R3D_INSTANCE_FORMAT_FLOAT32,
+            R3D_INSTANCE_FORMAT_UNORM8,
+            R3D_INSTANCE_FORMAT_FLOAT32,
+        },
+        .flags = flags,
+    };
+
+    return R3D_LoadInstanceBufferEx(capacity, layout);
+}
+
+R3D_InstanceBuffer R3D_LoadInstanceBufferEx(int capacity, R3D_InstanceLayout layout)
+{
     R3D_InstanceBuffer buffer = {0};
+
+    if (capacity <= 0) {
+        R3D_TRACELOG(LOG_WARNING, "InstanceBuffer -> invalid capacity (%d)", capacity);
+        return buffer;
+    }
+
+    if ((layout.flags & ~R3D_INSTANCE_VALID_FLAGS) != 0) {
+        R3D_TRACELOG(LOG_WARNING, "InstanceBuffer -> invalid attribute flags (0x%04x)", layout.flags);
+        return buffer;
+    }
+
+    if (layout.flags == 0) {
+        R3D_TRACELOG(LOG_WARNING, "InstanceBuffer -> no attributes requested");
+        return buffer;
+    }
 
     glGenBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, buffer.buffers);
 
     for (int i = 0; i < R3D_INSTANCE_ATTRIBUTE_COUNT; i++) {
-        if (BIT_TEST(flags, 1 << i)) {
-            glBindBuffer(GL_ARRAY_BUFFER, buffer.buffers[i]);
-            glBufferData(GL_ARRAY_BUFFER, capacity * INSTANCE_ATTRIBUTE_SIZE[i], NULL, GL_DYNAMIC_DRAW);
+        if (!BIT_TEST(layout.flags, 1u << i)) continue;
+
+        size_t size = 0;
+        if (!get_buffer_size(capacity, i, layout.formats[i], &size)) {
+            R3D_TRACELOG(LOG_WARNING, "InstanceBuffer -> invalid size or format (attribute=%d, format=%d)", i, layout.formats[i]);
+            glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, buffer.buffers);
+            return (R3D_InstanceBuffer){0};
+        }
+
+        glBindBuffer(GL_ARRAY_BUFFER, buffer.buffers[i]);
+
+        r3d_driver_clear_errors();
+        glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)size, NULL, GL_DYNAMIC_DRAW);
+
+        if (r3d_driver_check_error("InstanceBuffer -> glBufferData failed")) {
+            R3D_TRACELOG(LOG_WARNING, "InstanceBuffer -> failed to allocate attribute %d (%.2f MiB)", i, (double)size / (1024.0 * 1024.0));
+            glBindBuffer(GL_ARRAY_BUFFER, 0);
+            glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, buffer.buffers);
+            return (R3D_InstanceBuffer){0};
         }
     }
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
     buffer.capacity = capacity;
-    buffer.flags = flags;
+    buffer.layout = layout;
 
-    R3D_TRACELOG(LOG_INFO, "Instance buffer created successfully (capacity=%d | flags=0x%04x)", capacity, flags);
+    R3D_TRACELOG(LOG_INFO, "Instance buffer created successfully (capacity=%d | flags=0x%04x)", capacity, layout.flags);
 
     return buffer;
 }
@@ -61,7 +161,17 @@ void R3D_UnloadInstanceBuffer(R3D_InstanceBuffer buffer)
 
 void R3D_ResizeInstanceBuffer(R3D_InstanceBuffer* buffer, int newCapacity, bool keepData)
 {
+    if (buffer == NULL) {
+        R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> buffer is NULL");
+        return;
+    }
+
     if (newCapacity <= buffer->capacity) {
+        return;
+    }
+
+    if ((buffer->layout.flags & ~R3D_INSTANCE_VALID_FLAGS) != 0) {
+        R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> invalid attribute flags (0x%04x)", buffer->layout.flags);
         return;
     }
 
@@ -69,67 +179,152 @@ void R3D_ResizeInstanceBuffer(R3D_InstanceBuffer* buffer, int newCapacity, bool 
     glGenBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
 
     for (int i = 0; i < R3D_INSTANCE_ATTRIBUTE_COUNT; i++) {
-        if (!BIT_TEST(buffer->flags, 1 << i)) continue;
+        if (!BIT_TEST(buffer->layout.flags, 1u << i)) continue;
 
-        int newSize = newCapacity * (int)INSTANCE_ATTRIBUTE_SIZE[i];
+        size_t newSize = 0;
+        if (!get_buffer_size(newCapacity, i, buffer->layout.formats[i], &newSize)) {
+            R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> invalid new size or format (attribute=%d, format=%d)", i, buffer->layout.formats[i]);
+            glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+            return;
+        }
+
         glBindBuffer(GL_COPY_WRITE_BUFFER, newBuffers[i]);
-        glBufferData(GL_COPY_WRITE_BUFFER, newSize, NULL, GL_DYNAMIC_DRAW);
+
+        r3d_driver_clear_errors();
+        glBufferData(GL_COPY_WRITE_BUFFER, (GLsizeiptr)newSize, NULL, GL_DYNAMIC_DRAW);
+
+        if (r3d_driver_check_error("ResizeInstanceBuffer -> glBufferData failed")) {
+            R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> failed to allocate attribute %d (%.2f MiB)", i, (double)newSize / (1024.0 * 1024.0));
+            glBindBuffer(GL_COPY_READ_BUFFER, 0);
+            glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+            glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+            return;
+        }
 
         if (keepData && buffer->capacity > 0) {
-            int oldSize = buffer->capacity * (int)INSTANCE_ATTRIBUTE_SIZE[i];
+            size_t oldSize = 0;
+            if (!get_buffer_size(buffer->capacity, i, buffer->layout.formats[i], &oldSize)) {
+                R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> invalid old size (attribute=%d)", i);
+                glBindBuffer(GL_COPY_READ_BUFFER, 0);
+                glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+                glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+                return;
+            }
+
+            if (buffer->buffers[i] == 0) {
+                R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> invalid source buffer (attribute=%d)", i);
+                glBindBuffer(GL_COPY_READ_BUFFER, 0);
+                glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+                glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+                return;
+            }
+
             glBindBuffer(GL_COPY_READ_BUFFER, buffer->buffers[i]);
-            glCopyBufferSubData(GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER, 0, 0, oldSize);
+
+            r3d_driver_clear_errors();
+            glCopyBufferSubData(GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER, 0, 0, (GLsizeiptr)oldSize);
+
+            if (r3d_driver_check_error("ResizeInstanceBuffer -> glCopyBufferSubData failed")) {
+                R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> failed to copy attribute %d", i);
+                glBindBuffer(GL_COPY_READ_BUFFER, 0);
+                glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+                glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+                return;
+            }
         }
     }
+
+    glBindBuffer(GL_COPY_READ_BUFFER, 0);
+    glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
 
     glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, buffer->buffers);
     memcpy(buffer->buffers, newBuffers, R3D_INSTANCE_ATTRIBUTE_COUNT * sizeof(GLuint));
     buffer->capacity = newCapacity;
+
+    R3D_TRACELOG(LOG_INFO, "Instance buffer resized successfully (capacity=%d)", newCapacity);
 }
 
 void R3D_UploadInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag, int offset, int count, void* data)
 {
-    int index = r3d_lsb_index(flag);
-    if (index < 0 || index >= R3D_INSTANCE_ATTRIBUTE_COUNT) {
+    int index = r3d_instance_attribute_index(flag);
+    if (index < 0) {
         R3D_TRACELOG(LOG_WARNING, "UploadInstances -> invalid attribute flag (0x%04x)", flag);
         return;
     }
 
-    if (!BIT_TEST(buffer.flags, flag)) {
+    if (!BIT_TEST(buffer.layout.flags, flag)) {
         R3D_TRACELOG(LOG_WARNING, "UploadInstances -> attribute not allocated for this buffer (flag=0x%04x)", flag);
         return;
     }
 
-    if (offset + count > buffer.capacity) {
+    if (buffer.buffers[index] == 0) {
+        R3D_TRACELOG(LOG_WARNING, "UploadInstances -> invalid GPU buffer (flag=0x%04x)", flag);
+        return;
+    }
+
+    if (offset < 0 || count < 0 || offset > buffer.capacity || count > buffer.capacity - offset) {
         R3D_TRACELOG(LOG_WARNING, "UploadInstances -> range out of bounds (offset=%d, count=%d, capacity=%d)", offset, count, buffer.capacity);
         return;
     }
 
-    int attrSize = (int)INSTANCE_ATTRIBUTE_SIZE[index];
+    if (count == 0) {
+        return;
+    }
+
+    if (data == NULL) {
+        R3D_TRACELOG(LOG_WARNING, "UploadInstances -> data is NULL");
+        return;
+    }
+
+    size_t size = 0;
+    if (!get_buffer_size(count, index, buffer.layout.formats[index], &size)) {
+        R3D_TRACELOG(LOG_WARNING, "UploadInstances -> invalid upload size (flag=0x%04x)", flag);
+        return;
+    }
+
+    size_t attrSize = get_attribute_size(index, buffer.layout.formats[index]);
+    size_t offsetBytes = (size_t)offset * attrSize;
 
     glBindBuffer(GL_ARRAY_BUFFER, buffer.buffers[index]);
-    glBufferSubData(GL_ARRAY_BUFFER, offset * attrSize, count * attrSize, data);
+
+    r3d_driver_clear_errors();
+    glBufferSubData(GL_ARRAY_BUFFER, (GLintptr)offsetBytes, (GLsizeiptr)size, data);
+
+    if (r3d_driver_check_error("UploadInstances -> glBufferSubData failed")) {
+        R3D_TRACELOG(LOG_WARNING, "UploadInstances -> failed to upload attribute data (%.2f MiB)", (double)size / (1024.0 * 1024.0));
+    }
+
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
 void* R3D_MapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag)
 {
-    int index = r3d_lsb_index(flag);
-    if (index < 0 || index >= R3D_INSTANCE_ATTRIBUTE_COUNT) {
+    int index = r3d_instance_attribute_index(flag);
+    if (index < 0) {
         R3D_TRACELOG(LOG_WARNING, "MapInstances -> invalid attribute flag (0x%04x)", flag);
         return NULL;
     }
 
-    if (!BIT_TEST(buffer.flags, flag)) {
+    if (!BIT_TEST(buffer.layout.flags, flag)) {
         R3D_TRACELOG(LOG_WARNING, "MapInstances -> attribute not allocated for this buffer (flag=0x%04x)", flag);
         return NULL;
     }
 
-    glBindBuffer(GL_ARRAY_BUFFER, buffer.buffers[index]);
-    void* ptrMap = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
-    if (!ptrMap) {
-        R3D_TRACELOG(LOG_WARNING, "MapInstances -> failed to map GPU buffer (flag=0x%04x)", flag);
+    if (buffer.buffers[index] == 0) {
+        R3D_TRACELOG(LOG_WARNING, "MapInstances -> invalid GPU buffer (flag=0x%04x)", flag);
+        return NULL;
     }
+
+    glBindBuffer(GL_ARRAY_BUFFER, buffer.buffers[index]);
+
+    r3d_driver_clear_errors();
+    void* ptrMap = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+
+    if (r3d_driver_check_error("MapInstances -> glMapBuffer failed") || ptrMap == NULL) {
+        R3D_TRACELOG(LOG_WARNING, "MapInstances -> failed to map GPU buffer (flag=0x%04x)", flag);
+        ptrMap = NULL;
+    }
+
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
     return ptrMap;
@@ -137,11 +332,69 @@ void* R3D_MapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag)
 
 void R3D_UnmapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flags)
 {
-    for (int i = 0; i < R3D_INSTANCE_ATTRIBUTE_COUNT; i++) {
-        if (BIT_TEST(flags, 1 << i) && BIT_TEST(buffer.flags, 1 << i)) {
-            glBindBuffer(GL_ARRAY_BUFFER, buffer.buffers[i]);
-            glUnmapBuffer(GL_ARRAY_BUFFER);
-        }
+    if ((flags & ~R3D_INSTANCE_VALID_FLAGS) != 0) {
+        R3D_TRACELOG(LOG_WARNING, "UnmapInstances -> invalid attribute flags (0x%04x)", flags);
+        flags &= R3D_INSTANCE_VALID_FLAGS;
     }
+
+    for (int i = 0; i < R3D_INSTANCE_ATTRIBUTE_COUNT; i++) {
+        R3D_InstanceFlags flag = 1u << i;
+
+        if (!BIT_TEST(flags, flag) || !BIT_TEST(buffer.layout.flags, flag)) {
+            continue;
+        }
+
+        if (buffer.buffers[i] == 0) {
+            R3D_TRACELOG(LOG_WARNING, "UnmapInstances -> invalid GPU buffer (flag=0x%04x)", flag);
+            continue;
+        }
+
+        glBindBuffer(GL_ARRAY_BUFFER, buffer.buffers[i]);
+
+        r3d_driver_clear_errors();
+        if (!glUnmapBuffer(GL_ARRAY_BUFFER)) {
+            R3D_TRACELOG(LOG_WARNING, "UnmapInstances -> GPU data may be corrupted (flag=0x%04x)", flag);
+        }
+
+        r3d_driver_check_error("UnmapInstances -> glUnmapBuffer failed");
+    }
+
     glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void R3D_SetInstanceFormat(R3D_InstanceLayout* layout, R3D_InstanceFlags attribute, R3D_InstanceFormat format)
+{
+    if (layout == NULL) {
+        R3D_TRACELOG(LOG_WARNING, "SetInstanceFormat -> layout is NULL");
+        return;
+    }
+
+    int index = r3d_instance_attribute_index(attribute);
+    if (index < 0) {
+        R3D_TRACELOG(LOG_WARNING, "SetInstanceFormat -> invalid attribute flag (0x%04x)", attribute);
+        return;
+    }
+
+    if (!r3d_instance_format_is_valid(format)) {
+        R3D_TRACELOG(LOG_WARNING, "SetInstanceFormat -> invalid format (%d)", format);
+        return;
+    }
+
+    layout->formats[index] = format;
+}
+
+R3D_InstanceFormat R3D_GetInstanceFormat(R3D_InstanceLayout layout, R3D_InstanceFlags attribute)
+{
+    int index = r3d_instance_attribute_index(attribute);
+    if (index < 0) {
+        R3D_TRACELOG(LOG_WARNING, "GetInstanceFormat -> invalid attribute flag (0x%04x)", attribute);
+        return R3D_INSTANCE_FORMAT_FLOAT32;
+    }
+
+    if (!r3d_instance_format_is_valid(layout.formats[index])) {
+        R3D_TRACELOG(LOG_WARNING, "GetInstanceFormat -> invalid format for attribute flag (0x%04x)", attribute);
+        return R3D_INSTANCE_FORMAT_FLOAT32;
+    }
+
+    return layout.formats[index];
 }

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -1700,12 +1700,12 @@ void R3D_TransformMeshData(R3D_MeshData* meshData, Matrix transform)
         R3D_Vertex* v = &meshData->vertices[i];
         v->position = r3d_vector3_transform(v->position, &transform);
 
-        Vector3 normal = R3D_DecodeNormal((int8_t*)v->normal);
-        R3D_EncodeNormal((int8_t*)v->normal, r3d_vector3_transform_normal(normal, &matNormal));
+        Vector3 normal = R3D_UnpackNormal((int8_t*)v->normal);
+        R3D_PackNormal((int8_t*)v->normal, r3d_vector3_transform_normal(normal, &matNormal));
 
-        Vector4 tangent = R3D_DecodeTangent((int8_t*)v->tangent);
+        Vector4 tangent = R3D_UnpackTangent((int8_t*)v->tangent);
         Vector3 t = Vector3Normalize(r3d_vector3_transform_normal((Vector3){tangent.x, tangent.y, tangent.z}, &matNormal));
-        R3D_EncodeTangent((int8_t*)v->tangent, (Vector4){t.x, t.y, t.z, tangent.w});
+        R3D_PackTangent((int8_t*)v->tangent, (Vector4){t.x, t.y, t.z, tangent.w});
     }
 }
 
@@ -1730,12 +1730,12 @@ void R3D_RotateMeshData(R3D_MeshData* meshData, Quaternion rotation)
 
         v->position = Vector3RotateByQuaternion(v->position, rotation);
 
-        Vector3 normal = R3D_DecodeNormal((int8_t*)v->normal);
-        R3D_EncodeNormal((int8_t*)v->normal, Vector3RotateByQuaternion(normal, rotation));
+        Vector3 normal = R3D_UnpackNormal((int8_t*)v->normal);
+        R3D_PackNormal((int8_t*)v->normal, Vector3RotateByQuaternion(normal, rotation));
 
-        Vector4 tangent = R3D_DecodeTangent((int8_t*)v->tangent);
+        Vector4 tangent = R3D_UnpackTangent((int8_t*)v->tangent);
         Vector3 t = Vector3RotateByQuaternion((Vector3){tangent.x, tangent.y, tangent.z}, rotation);
-        R3D_EncodeTangent((int8_t*)v->tangent, (Vector4){t.x, t.y, t.z, tangent.w});
+        R3D_PackTangent((int8_t*)v->tangent, (Vector4){t.x, t.y, t.z, tangent.w});
     }
 }
 
@@ -1760,13 +1760,13 @@ void R3D_ScaleMeshData(R3D_MeshData* meshData, Vector3 scale)
         v->position.z *= scale.z;
 
         if (!uniform) {
-            Vector3 normal = R3D_DecodeNormal((int8_t*)v->normal);
-            normal = Vector3Normalize((Vector3){ normal.x * invScale.x, normal.y * invScale.y, normal.z * invScale.z });
-            R3D_EncodeNormal((int8_t*)v->normal, normal);
+            Vector3 normal = R3D_UnpackNormal((int8_t*)v->normal);
+            normal = Vector3Normalize((Vector3){normal.x * invScale.x, normal.y * invScale.y, normal.z * invScale.z});
+            R3D_PackNormal((int8_t*)v->normal, normal);
 
-            Vector4 tangent = R3D_DecodeTangent((int8_t*)v->tangent);
-            Vector3 t = Vector3Normalize((Vector3){ tangent.x * scale.x, tangent.y * scale.y, tangent.z * scale.z });
-            R3D_EncodeTangent((int8_t*)v->tangent, (Vector4){t.x, t.y, t.z, tangent.w});
+            Vector4 tangent = R3D_UnpackTangent((int8_t*)v->tangent);
+            Vector3 t = Vector3Normalize((Vector3){tangent.x * scale.x, tangent.y * scale.y, tangent.z * scale.z});
+            R3D_PackTangent((int8_t*)v->tangent, (Vector4){t.x, t.y, t.z, tangent.w});
         }
     }
 }
@@ -1785,7 +1785,7 @@ void R3D_GenMeshDataUVsPlanar(R3D_MeshData* meshData, Vector2 uvScale, Vector3 a
         Vector3 pos = meshData->vertices[i].position;
         float u = Vector3DotProduct(pos, tangent) * uvScale.x;
         float v = Vector3DotProduct(pos, bitangent) * uvScale.y;
-        R3D_EncodeTexCoord(meshData->vertices[i].texcoord, (Vector2){u, v});
+        R3D_PackTexCoord(meshData->vertices[i].texcoord, (Vector2){u, v});
     }
 }
 
@@ -1797,7 +1797,7 @@ void R3D_GenMeshDataUVsSpherical(R3D_MeshData* meshData)
         Vector3 pos = Vector3Normalize(meshData->vertices[i].position);
         float u = 0.5f + atan2f(pos.z, pos.x) / (2.0f * PI);
         float v = 0.5f - asinf(pos.y) * (1.0f / PI);
-        R3D_EncodeTexCoord(meshData->vertices[i].texcoord, (Vector2){u, v});
+        R3D_PackTexCoord(meshData->vertices[i].texcoord, (Vector2){u, v});
     }
 }
 
@@ -1809,7 +1809,7 @@ void R3D_GenMeshDataUVsCylindrical(R3D_MeshData* meshData)
         Vector3 pos = meshData->vertices[i].position;
         float u = 0.5f + atan2f(pos.z, pos.x) / (2.0f * PI);
         float v = pos.y;
-        R3D_EncodeTexCoord(meshData->vertices[i].texcoord, (Vector2){u, v});
+        R3D_PackTexCoord(meshData->vertices[i].texcoord, (Vector2){u, v});
     }
 }
 
@@ -1838,7 +1838,7 @@ void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType type)
     if (type == R3D_PRIMITIVE_POINTS ||  type == R3D_PRIMITIVE_LINES ||
         type == R3D_PRIMITIVE_LINE_STRIP ||  type == R3D_PRIMITIVE_LINE_LOOP) {
         for (int i = 0; i < meshData->vertexCount; i++) {
-            R3D_EncodeNormal((int8_t*)meshData->vertices[i].normal, (Vector3){0.0f, 0.0f, 1.0f});
+            R3D_PackNormal((int8_t*)meshData->vertices[i].normal, (Vector3){0.0f, 0.0f, 1.0f});
         }
         return;
     }
@@ -1882,7 +1882,7 @@ void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType type)
     }
 
     for (int i = 0; i < meshData->vertexCount; i++) {
-        R3D_EncodeNormal((int8_t*)meshData->vertices[i].normal, Vector3Normalize(normals[i]));
+        R3D_PackNormal((int8_t*)meshData->vertices[i].normal, Vector3Normalize(normals[i]));
     }
 
     RL_FREE(normals);
@@ -1894,9 +1894,9 @@ static void process_triangle_tangents(Vector3* tangents, Vector3* bitangents, R3
     Vector3 v1 = meshData->vertices[i1].position;
     Vector3 v2 = meshData->vertices[i2].position;
 
-    Vector2 uv0 = R3D_DecodeTexCoord(meshData->vertices[i0].texcoord);
-    Vector2 uv1 = R3D_DecodeTexCoord(meshData->vertices[i1].texcoord);
-    Vector2 uv2 = R3D_DecodeTexCoord(meshData->vertices[i2].texcoord);
+    Vector2 uv0 = R3D_UnpackTexCoord(meshData->vertices[i0].texcoord);
+    Vector2 uv1 = R3D_UnpackTexCoord(meshData->vertices[i1].texcoord);
+    Vector2 uv2 = R3D_UnpackTexCoord(meshData->vertices[i2].texcoord);
 
     Vector3 edge1 = Vector3Subtract(v1, v0);
     Vector3 edge2 = Vector3Subtract(v2, v0);
@@ -1938,7 +1938,7 @@ void R3D_GenMeshDataTangents(R3D_MeshData* meshData, R3D_PrimitiveType type)
     if (type == R3D_PRIMITIVE_POINTS || type == R3D_PRIMITIVE_LINES ||
         type == R3D_PRIMITIVE_LINE_STRIP || type == R3D_PRIMITIVE_LINE_LOOP) {
         for (int i = 0; i < meshData->vertexCount; i++) {
-            R3D_EncodeTangent((int8_t*)meshData->vertices[i].tangent, (Vector4){ 1.0f, 0.0f, 0.0f, 1.0f });
+            R3D_PackTangent((int8_t*)meshData->vertices[i].tangent, (Vector4){1.0f, 0.0f, 0.0f, 1.0f});
         }
         return;
     }
@@ -1989,7 +1989,7 @@ void R3D_GenMeshDataTangents(R3D_MeshData* meshData, R3D_PrimitiveType type)
     // Orthogonalization (Gram-Schmidt) and handedness calculation
     for (int i = 0; i < meshData->vertexCount; i++)
     {
-        Vector3 n = R3D_DecodeNormal((int8_t*)meshData->vertices[i].normal);
+        Vector3 n = R3D_UnpackNormal((int8_t*)meshData->vertices[i].normal);
         Vector3 t = tangents[i];
 
         // Gram-Schmidt orthogonalization
@@ -2004,7 +2004,7 @@ void R3D_GenMeshDataTangents(R3D_MeshData* meshData, R3D_PrimitiveType type)
         }
 
         float handedness = Vector3DotProduct(Vector3CrossProduct(n, t), bitangents[i]) < 0.0f ? -1.0f : 1.0f;
-        R3D_EncodeTangent((int8_t*)meshData->vertices[i].tangent, (Vector4){t.x, t.y, t.z, handedness});
+        R3D_PackTangent((int8_t*)meshData->vertices[i].tangent, (Vector4){t.x, t.y, t.z, handedness});
     }
 
     RL_FREE(tangents);

--- a/src/r3d_pack.c
+++ b/src/r3d_pack.c
@@ -1,0 +1,70 @@
+/* r3d_pack.c -- R3D Pack Module.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#include <r3d/r3d_pack.h>
+#include <math.h>
+
+#include "./common/r3d_half.h"
+
+// ========================================
+// PUBLIC API
+// ========================================
+
+uint16_t R3D_PackFloat16(float x)
+{
+    return r3d_half_from_float(x);
+}
+
+uint16_t R3D_PackUnorm16(float x)
+{
+    x = fminf(fmaxf(x, 0.0f), 1.0f);
+    return (uint16_t)roundf(x * 65535.0f);
+}
+
+int16_t R3D_PackSnorm16(float x)
+{
+    x = fminf(fmaxf(x, -1.0f), 1.0f);
+    return (int16_t)roundf(x * 32767.0f);
+}
+
+uint8_t R3D_PackUnorm8(float x)
+{
+    x = fminf(fmaxf(x, 0.0f), 1.0f);
+    return (uint8_t)roundf(x * 255.0f);
+}
+
+int8_t R3D_PackSnorm8(float x)
+{
+    x = fminf(fmaxf(x, -1.0f), 1.0f);
+    return (int8_t)roundf(x * 127.0f);
+}
+
+float R3D_UnpackFloat16(uint16_t x)
+{
+    return r3d_half_to_float(x);
+}
+
+float R3D_UnpackUnorm16(uint16_t x)
+{
+    return (float)x / 65535.0f;
+}
+
+float R3D_UnpackSnorm16(int16_t x)
+{
+    return fmaxf((float)x / 32767.0f, -1.0f);
+}
+
+float R3D_UnpackUnorm8(uint8_t x)
+{
+    return (float)x / 255.0f;
+}
+
+float R3D_UnpackSnorm8(int8_t x)
+{
+    return fmaxf((float)x / 127.0f, -1.0f);
+}

--- a/src/r3d_vertex.c
+++ b/src/r3d_vertex.c
@@ -7,10 +7,7 @@
  */
 
 #include <r3d/r3d_vertex.h>
-#include <math.h>
-
-#include "./common/r3d_helper.h"
-#include "./common/r3d_half.h"
+#include <r3d/r3d_pack.h>
 
 // ========================================
 // PUBLIC API
@@ -19,59 +16,61 @@
 R3D_Vertex R3D_MakeVertex(Vector3 position, Vector2 texcoord, Vector3 normal, Vector4 tangent, Color color)
 {
     R3D_Vertex v = {0};
+
     v.position = position;
-    R3D_EncodeTexCoord(v.texcoord, texcoord);
-    R3D_EncodeNormal((int8_t*)v.normal, normal);
-    R3D_EncodeTangent((int8_t*)v.tangent, tangent);
+    R3D_PackTexCoord(v.texcoord, texcoord);
+    R3D_PackNormal((int8_t*)v.normal, normal);
+    R3D_PackTangent((int8_t*)v.tangent, tangent);
     v.color = color;
+
     return v;
 }
 
-void R3D_EncodeTexCoord(uint16_t* dst, Vector2 src)
+void R3D_PackTexCoord(uint16_t* dst, Vector2 src)
 {
-    dst[0] = r3d_half_from_float(src.x);
-    dst[1] = r3d_half_from_float(src.y);
+    dst[0] = R3D_PackFloat16(src.x);
+    dst[1] = R3D_PackFloat16(src.y);
 }
 
-Vector2 R3D_DecodeTexCoord(const uint16_t* src)
+Vector2 R3D_UnpackTexCoord(const uint16_t* src)
 {
-    Vector2 result;
-    result.x = r3d_half_from_float(src[0]);
-    result.y = r3d_half_from_float(src[1]);
-    return result;
-}
-
-void R3D_EncodeNormal(int8_t* dst, Vector3 src)
-{
-    dst[0] = (int8_t)roundf(CLAMP(src.x, -1.0f, 1.0f) * 127.0f);
-    dst[1] = (int8_t)roundf(CLAMP(src.y, -1.0f, 1.0f) * 127.0f);
-    dst[2] = (int8_t)roundf(CLAMP(src.z, -1.0f, 1.0f) * 127.0f);
-    dst[3] = 0;
-}
-
-Vector3 R3D_DecodeNormal(const int8_t* src)
-{
-    return (Vector3){
-        (src[0] == -128) ? -1.0f : src[0] / 127.0f,
-        (src[1] == -128) ? -1.0f : src[1] / 127.0f,
-        (src[2] == -128) ? -1.0f : src[2] / 127.0f
+    return (Vector2) {
+        R3D_UnpackFloat16(src[0]),
+        R3D_UnpackFloat16(src[1])
     };
 }
 
-void R3D_EncodeTangent(int8_t* dst, Vector4 src)
+void R3D_PackNormal(int8_t* dst, Vector3 src)
 {
-    dst[0] = (int8_t)roundf(CLAMP(src.x, -1.0f, 1.0f) * 127.0f);
-    dst[1] = (int8_t)roundf(CLAMP(src.y, -1.0f, 1.0f) * 127.0f);
-    dst[2] = (int8_t)roundf(CLAMP(src.z, -1.0f, 1.0f) * 127.0f);
+    dst[0] = R3D_PackSnorm8(src.x);
+    dst[1] = R3D_PackSnorm8(src.y);
+    dst[2] = R3D_PackSnorm8(src.z);
+    dst[3] = 0;
+}
+
+Vector3 R3D_UnpackNormal(const int8_t* src)
+{
+    return (Vector3) {
+        R3D_UnpackSnorm8(src[0]),
+        R3D_UnpackSnorm8(src[1]),
+        R3D_UnpackSnorm8(src[2])
+    };
+}
+
+void R3D_PackTangent(int8_t* dst, Vector4 src)
+{
+    dst[0] = R3D_PackSnorm8(src.x);
+    dst[1] = R3D_PackSnorm8(src.y);
+    dst[2] = R3D_PackSnorm8(src.z);
     dst[3] = (src.w >= 0.0f) ? 127 : -127;
 }
 
-Vector4 R3D_DecodeTangent(const int8_t* src)
+Vector4 R3D_UnpackTangent(const int8_t* src)
 {
-    return (Vector4){
-        (src[0] == -128) ? -1.0f : src[0] / 127.0f,
-        (src[1] == -128) ? -1.0f : src[1] / 127.0f,
-        (src[2] == -128) ? -1.0f : src[2] / 127.0f,
+    return (Vector4) {
+        R3D_UnpackSnorm8(src[0]),
+        R3D_UnpackSnorm8(src[1]),
+        R3D_UnpackSnorm8(src[2]),
         (src[3] >= 0) ? 1.0f : -1.0f
     };
 }


### PR DESCRIPTION
## Summary

This PR adds configurable formats for instance attributes, so instance buffers can use more compact storage when needed while keeping the default path unchanged.

It also tightens instance buffer checks/logs, adds small pack/unpack helpers, and updates the instancing example to show packed attributes.

## API changes

- Added `R3D_InstanceFormat` to describe instance attribute storage formats:
  - `FLOAT32`
  - `FLOAT16`
  - `UNORM16`
  - `SNORM16`
  - `UNORM8`
  - `SNORM8`

- Added `R3D_InstanceLayout` allowing each instance attribute to specify its own storage format

- Added `R3D_LoadInstanceBufferEx()` for creating instance buffers with a custom layout

- Kept `R3D_LoadInstanceBuffer()` as the simple entry point using the default layout:
  - position: `FLOAT32`
  - rotation: `FLOAT32`
  - scale: `FLOAT32`
  - color: `UNORM8`
  - custom: `FLOAT32`

- Added helpers to set and query attribute formats in a layout:
  - `R3D_SetInstanceFormat()`
  - `R3D_GetInstanceFormat()`

- Added packing/unpacking helpers for compact numeric formats:
  - `R3D_PackFloat16()` / `R3D_UnpackFloat16()`
  - `R3D_PackUnorm16()` / `R3D_UnpackUnorm16()`
  - `R3D_PackSnorm16()` / `R3D_UnpackSnorm16()`
  - `R3D_PackUnorm8()` / `R3D_UnpackUnorm8()`
  - `R3D_PackSnorm8()` / `R3D_UnpackSnorm8()`

- Renamed packed vertex helpers from `Encode/Decode` to `Pack/Unpack`:
  - `R3D_PackTexCoord()` / `R3D_UnpackTexCoord()`
  - `R3D_PackNormal()` / `R3D_UnpackNormal()`
  - `R3D_PackTangent()` / `R3D_UnpackTangent()`

## Internal changes

- Updated instance buffer allocation to use the selected format size per attribute
- Updated instance attribute binding to use the full `R3D_InstanceLayout`, not only the attribute flags
- Added format-aware OpenGL attribute setup for normalized and floating-point formats
- Improved instance buffer validation, safety checks and logging:
  - invalid capacity checks
  - invalid flags checks
  - invalid format checks
  - upload range validation
  - null data checks
  - OpenGL allocation/upload/copy/map/unmap error logging
- Made instance buffer resize safer by keeping the old buffers alive if the new allocation or copy fails

## Vertex packing changes

- Updated vertex packing helpers to use the new `r3d_pack` module
- Kept the packed vertex format consistent:
  - texture coordinates are stored as float16
  - normals are stored as SNORM8
  - tangents are stored as SNORM8 with handedness in W

## Examples

- Updated the instanced rendering example to demonstrate packed instance attributes.
- The example now uses:
  - `SNORM16` for quaternion rotations
  - `FLOAT16` for scales
  - `UNORM8` for colors
  - `FLOAT32` for positions