### PR TITLE
Instance buffer: discard support and GPU sync improvements

### DIFF
--- a/examples/animation.c
+++ b/examples/animation.c
@@ -44,7 +44,7 @@ int main(void)
 
     // Create model instances
     R3D_InstanceBuffer instances = R3D_LoadInstanceBuffer(4, R3D_INSTANCE_POSITION);
-    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION);
+    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION, false);
     for (int z = 0; z < 2; z++) {
         for (int x = 0; x < 2; x++) {
             positions[z*2 + x] = (Vector3) {(float)x - 0.5f, 0, (float)z - 0.5f};

--- a/examples/billboards.c
+++ b/examples/billboards.c
@@ -35,8 +35,8 @@ int main(void)
 
     // Create transforms for instanced billboards
     R3D_InstanceBuffer instances = R3D_LoadInstanceBuffer(64, R3D_INSTANCE_POSITION | R3D_INSTANCE_SCALE);
-    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION);
-    Vector3* scales = R3D_MapInstances(instances, R3D_INSTANCE_SCALE);
+    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION, false);
+    Vector3* scales = R3D_MapInstances(instances, R3D_INSTANCE_SCALE, false);
     for (int i = 0; i < 64; i++) {
         float scaleFactor = GetRandomValue(25, 50) / 10.0f;
         scales[i] = (Vector3) {scaleFactor, scaleFactor, 1.0f};

--- a/examples/decal.c
+++ b/examples/decal.c
@@ -31,7 +31,7 @@ int main(void)
 
     // Create data for instanced drawing
     R3D_InstanceBuffer instances = R3D_LoadInstanceBuffer(3, R3D_INSTANCE_POSITION);
-    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION);
+    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION, false);
     positions[0] = (Vector3){ -1.25f, 0, 1 };
     positions[1] = (Vector3){ 0, 0, 1 };
     positions[2] = (Vector3){ 1.25f, 0, 1 };

--- a/examples/dof.c
+++ b/examples/dof.c
@@ -39,8 +39,8 @@ int main(void)
     float offsetZ = (Y_INSTANCES * spacing) / 2.0f;
     int idx = 0;
     R3D_InstanceBuffer instances = R3D_LoadInstanceBuffer(INSTANCE_COUNT, R3D_INSTANCE_POSITION | R3D_INSTANCE_COLOR);
-    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION);
-    Color* colors = R3D_MapInstances(instances, R3D_INSTANCE_COLOR);
+    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION, false);
+    Color* colors = R3D_MapInstances(instances, R3D_INSTANCE_COLOR, false);
     for (int x = 0; x < X_INSTANCES; x++) {
         for (int y = 0; y < Y_INSTANCES; y++) {
             positions[idx] = (Vector3) {x * spacing - offsetX, 0, y * spacing - offsetZ};

--- a/examples/instanced.c
+++ b/examples/instanced.c
@@ -43,10 +43,10 @@ int main(void)
 
     R3D_InstanceBuffer instances = R3D_LoadInstanceBufferEx(INSTANCE_COUNT, layout);
 
-    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION);
-    PackedRotation* rotations = R3D_MapInstances(instances, R3D_INSTANCE_ROTATION);
-    PackedScale* scales = R3D_MapInstances(instances, R3D_INSTANCE_SCALE);
-    Color* colors = R3D_MapInstances(instances, R3D_INSTANCE_COLOR);
+    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION, false);
+    PackedRotation* rotations = R3D_MapInstances(instances, R3D_INSTANCE_ROTATION, false);
+    PackedScale* scales = R3D_MapInstances(instances, R3D_INSTANCE_SCALE, false);
+    Color* colors = R3D_MapInstances(instances, R3D_INSTANCE_COLOR, false);
 
     for (int i = 0; i < INSTANCE_COUNT; i++)
     {

--- a/examples/lights.c
+++ b/examples/lights.c
@@ -29,7 +29,7 @@ int main(void)
 
     // Allocate transforms for all spheres
     R3D_InstanceBuffer instances = R3D_LoadInstanceBuffer(GRID_SIZE * GRID_SIZE, R3D_INSTANCE_POSITION);
-    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION);
+    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION, false);
     for (int x = -50; x < 50; x++) {
         for (int z = -50; z < 50; z++) {
             positions[(z+50)*GRID_SIZE + (x+50)] = (Vector3) {x + 0.5f, 0, z + 0.5f};

--- a/examples/particles.c
+++ b/examples/particles.c
@@ -92,7 +92,7 @@ int main(void)
         }
         particleCount = alive;
 
-        R3D_UploadInstances(instances, R3D_INSTANCE_POSITION, 0, particleCount, positions);
+        R3D_UploadInstances(instances, R3D_INSTANCE_POSITION, 0, particleCount, positions, true);
 
         BeginDrawing();
             R3D_Begin(camera);

--- a/examples/sun.c
+++ b/examples/sun.c
@@ -22,7 +22,7 @@ int main(void)
 
     // Create transforms for instanced spheres
     R3D_InstanceBuffer instances = R3D_LoadInstanceBuffer(INSTANCE_COUNT, R3D_INSTANCE_POSITION);
-    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION);
+    Vector3* positions = R3D_MapInstances(instances, R3D_INSTANCE_POSITION, false);
     float spacing = 1.5f;
     float offsetX = (X_INSTANCES * spacing) / 2.0f;
     float offsetZ = (Y_INSTANCES * spacing) / 2.0f;

--- a/include/r3d/r3d_instance.h
+++ b/include/r3d/r3d_instance.h
@@ -123,12 +123,12 @@ extern "C" {
  *
  * - position: FLOAT32
  * - rotation: FLOAT32
- * - scale: FLOAT32
- * - color: UNORM8
- * - custom: FLOAT32
+ * - scale:    FLOAT32
+ * - color:    UNORM8
+ * - custom:   FLOAT32
  *
  * @param capacity Maximum number of instances.
- * @param flags Attribute mask to allocate.
+ * @param flags    Attribute mask to allocate.
  *
  * @return Initialized instance buffer, or an empty buffer on failure.
  */
@@ -145,7 +145,7 @@ R3DAPI R3D_InstanceBuffer R3D_LoadInstanceBuffer(int capacity, R3D_InstanceFlags
  * the layout.
  *
  * @param capacity Maximum number of instances.
- * @param layout Instance layout describing enabled attributes and formats.
+ * @param layout   Instance layout describing enabled attributes and formats.
  *
  * @return Initialized instance buffer, or an empty buffer on failure.
  */
@@ -164,28 +164,57 @@ R3DAPI void R3D_UnloadInstanceBuffer(R3D_InstanceBuffer buffer);
  * if keepData is true, their existing content is copied to the new
  * buffers before the old ones are deleted.
  *
- * @param buffer Instance buffer to resize (updated in place).
+ * @param buffer      Instance buffer to resize (updated in place).
  * @param newCapacity Desired minimum capacity in number of instances.
- * @param keepData If true, preserves existing instance data.
+ * @param keepData    If true, preserves existing instance data.
  */
 R3DAPI void R3D_ResizeInstanceBuffer(R3D_InstanceBuffer* buffer, int newCapacity, bool keepData);
 
 /**
- * @brief Upload a contiguous range of instance data.
- * @param flag Attribute being updated (single bit).
- * @param offset First instance index.
- * @param count Number of instances.
- * @param data Source pointer.
+ * @brief Upload a contiguous range of instance data to a GPU buffer.
+ *
+ * @param buffer  Instance buffer containing the target GPU buffer.
+ * @param flag    Attribute to update (single bit).
+ * @param offset  First instance index.
+ * @param count   Number of instances to upload.
+ * @param data    Source data pointer.
+ * @param discard If true, the entire GPU buffer is orphaned before upload,
+ *                avoiding a GPU/CPU sync at the cost of discarding existing data.
+ *                Safe to use when rewriting the full buffer each frame.
  */
 R3DAPI void R3D_UploadInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag,
-                                int offset, int count, void* data);
+                                int offset, int count, const void* data, bool discard);
 
 /**
- * @brief Map an attribute buffer for CPU write access.
- * @param flag Attribute to map (single bit).
- * @return Writable pointer, or NULL on error.
+ * @brief Map an entire attribute buffer for CPU write access.
+ *
+ * Call R3D_UnmapInstances when done writing.
+ *
+ * @param buffer  Instance buffer containing the target GPU buffer.
+ * @param flag    Attribute to map (single bit).
+ * @param discard If true, existing buffer contents are invalidated,
+ *                allowing the driver to return a fresh memory region
+ *                without stalling on in-flight GPU reads.
+ * @return        Writable pointer to the full buffer, or NULL on error.
  */
-R3DAPI void* R3D_MapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag);
+R3DAPI void* R3D_MapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag, bool discard);
+
+/**
+ * @brief Map a sub-range of an attribute buffer for CPU write access.
+ *
+ * Prefer this over R3D_MapInstances for partial updates to avoid
+ * touching unrelated data. Call R3D_UnmapInstances when done writing.
+ *
+ * @param buffer  Instance buffer containing the target GPU buffer.
+ * @param flag    Attribute to map (single bit).
+ * @param offset  First instance index of the mapped range.
+ * @param count   Number of instances to map.
+ * @param discard If true, the mapped range is invalidated, allowing the
+ *                driver to skip syncing that region with in-flight GPU reads.
+ * @return        Writable pointer to the mapped range, or NULL on error.
+ */
+R3DAPI void* R3D_MapInstancesEx(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag,
+                                int offset, int count, bool discard);
 
 /**
  * @brief Unmap one or more previously mapped attribute buffers.
@@ -202,9 +231,9 @@ R3DAPI void R3D_UnmapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag
  * This function only changes the format stored in the layout. It does not
  * enable the attribute in `layout.flags`.
  *
- * @param layout Layout to modify.
+ * @param layout    Layout to modify.
  * @param attribute Single attribute flag to modify.
- * @param format New storage format.
+ * @param format    New storage format.
  */
 R3DAPI void R3D_SetInstanceFormat(R3D_InstanceLayout* layout, R3D_InstanceFlags attribute, R3D_InstanceFormat format);
 
@@ -214,7 +243,7 @@ R3DAPI void R3D_SetInstanceFormat(R3D_InstanceLayout* layout, R3D_InstanceFlags 
  * `attribute` must be a single instance attribute flag, such as
  * `R3D_INSTANCE_POSITION`, not a combination of multiple flags.
  *
- * @param layout Layout to read from.
+ * @param layout    Layout to read from.
  * @param attribute Single attribute flag to query.
  *
  * @return Storage format of the requested attribute, or FLOAT32 if the

--- a/src/r3d_instance.c
+++ b/src/r3d_instance.c
@@ -175,72 +175,96 @@ void R3D_ResizeInstanceBuffer(R3D_InstanceBuffer* buffer, int newCapacity, bool 
         return;
     }
 
-    GLuint newBuffers[R3D_INSTANCE_ATTRIBUTE_COUNT] = {0};
-    glGenBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+    if (!keepData) {
+        // Orphan path: reallocate existing buffers in-place, avoids GPU stall and new IDs
+        for (int i = 0; i < R3D_INSTANCE_ATTRIBUTE_COUNT; i++) {
+            if (!BIT_TEST(buffer->layout.flags, 1u << i)) continue;
 
-    for (int i = 0; i < R3D_INSTANCE_ATTRIBUTE_COUNT; i++) {
-        if (!BIT_TEST(buffer->layout.flags, 1u << i)) continue;
-
-        size_t newSize = 0;
-        if (!get_buffer_size(newCapacity, i, buffer->layout.formats[i], &newSize)) {
-            R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> invalid new size or format (attribute=%d, format=%d)", i, buffer->layout.formats[i]);
-            glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
-            return;
-        }
-
-        glBindBuffer(GL_COPY_WRITE_BUFFER, newBuffers[i]);
-
-        r3d_driver_clear_errors();
-        glBufferData(GL_COPY_WRITE_BUFFER, (GLsizeiptr)newSize, NULL, GL_DYNAMIC_DRAW);
-
-        if (r3d_driver_check_error("ResizeInstanceBuffer -> glBufferData failed")) {
-            R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> failed to allocate attribute %d (%.2f MiB)", i, (double)newSize / (1024.0 * 1024.0));
-            glBindBuffer(GL_COPY_READ_BUFFER, 0);
-            glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
-            glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
-            return;
-        }
-
-        if (keepData && buffer->capacity > 0) {
-            size_t oldSize = 0;
-            if (!get_buffer_size(buffer->capacity, i, buffer->layout.formats[i], &oldSize)) {
-                R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> invalid old size (attribute=%d)", i);
-                glBindBuffer(GL_COPY_READ_BUFFER, 0);
-                glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
-                glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+            size_t newSize = 0;
+            if (!get_buffer_size(newCapacity, i, buffer->layout.formats[i], &newSize)) {
+                R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> invalid size or format (attribute=%d, format=%d)", i, buffer->layout.formats[i]);
+                glBindBuffer(GL_ARRAY_BUFFER, 0);
                 return;
             }
 
+            // Generate buffer on first use
             if (buffer->buffers[i] == 0) {
-                R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> invalid source buffer (attribute=%d)", i);
-                glBindBuffer(GL_COPY_READ_BUFFER, 0);
-                glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
-                glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
-                return;
+                glGenBuffers(1, &buffer->buffers[i]);
             }
 
-            glBindBuffer(GL_COPY_READ_BUFFER, buffer->buffers[i]);
-
+            glBindBuffer(GL_ARRAY_BUFFER, buffer->buffers[i]);
             r3d_driver_clear_errors();
-            glCopyBufferSubData(GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER, 0, 0, (GLsizeiptr)oldSize);
+            glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)newSize, NULL, GL_DYNAMIC_DRAW);
 
-            if (r3d_driver_check_error("ResizeInstanceBuffer -> glCopyBufferSubData failed")) {
-                R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> failed to copy attribute %d", i);
-                glBindBuffer(GL_COPY_READ_BUFFER, 0);
-                glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
-                glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+            if (r3d_driver_check_error("ResizeInstanceBuffer -> glBufferData failed")) {
+                R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> failed to orphan attribute %d (%.2f MiB)", i, (double)newSize / (1024.0 * 1024.0));
+                glBindBuffer(GL_ARRAY_BUFFER, 0);
                 return;
             }
         }
+
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+    }
+    else {
+        // Copy path: allocate new buffers, copy existing data, swap and delete old
+        GLuint newBuffers[R3D_INSTANCE_ATTRIBUTE_COUNT] = {0};
+
+        for (int i = 0; i < R3D_INSTANCE_ATTRIBUTE_COUNT; i++) {
+            if (!BIT_TEST(buffer->layout.flags, 1u << i)) continue;
+
+            size_t newSize = 0;
+            if (!get_buffer_size(newCapacity, i, buffer->layout.formats[i], &newSize)) {
+                R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> invalid size or format (attribute=%d, format=%d)", i, buffer->layout.formats[i]);
+                glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+                return;
+            }
+
+            glGenBuffers(1, &newBuffers[i]);
+            glBindBuffer(GL_COPY_WRITE_BUFFER, newBuffers[i]);
+            r3d_driver_clear_errors();
+            glBufferData(GL_COPY_WRITE_BUFFER, (GLsizeiptr)newSize, NULL, GL_DYNAMIC_DRAW);
+
+            if (r3d_driver_check_error("ResizeInstanceBuffer -> glBufferData failed")) {
+                R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> failed to allocate attribute %d (%.2f MiB)", i, (double)newSize / (1024.0 * 1024.0));
+                glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+                glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+                return;
+            }
+
+            // Copy old content if it exists
+            if (buffer->capacity > 0 && buffer->buffers[i] != 0) {
+                size_t oldSize = 0;
+                if (!get_buffer_size(buffer->capacity, i, buffer->layout.formats[i], &oldSize)) {
+                    R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> invalid old size (attribute=%d)", i);
+                    glBindBuffer(GL_COPY_READ_BUFFER, 0);
+                    glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+                    glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+                    return;
+                }
+
+                glBindBuffer(GL_COPY_READ_BUFFER, buffer->buffers[i]);
+                r3d_driver_clear_errors();
+                glCopyBufferSubData(GL_COPY_READ_BUFFER, GL_COPY_WRITE_BUFFER, 0, 0, (GLsizeiptr)oldSize);
+
+                if (r3d_driver_check_error("ResizeInstanceBuffer -> glCopyBufferSubData failed")) {
+                    R3D_TRACELOG(LOG_WARNING, "ResizeInstanceBuffer -> failed to copy attribute %d", i);
+                    glBindBuffer(GL_COPY_READ_BUFFER, 0);
+                    glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+                    glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, newBuffers);
+                    return;
+                }
+            }
+        }
+
+        glBindBuffer(GL_COPY_READ_BUFFER, 0);
+        glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+
+        // Swap: delete old GPU buffers and take ownership of new ones
+        glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, buffer->buffers);
+        memcpy(buffer->buffers, newBuffers, sizeof(newBuffers));
     }
 
-    glBindBuffer(GL_COPY_READ_BUFFER, 0);
-    glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
-
-    glDeleteBuffers(R3D_INSTANCE_ATTRIBUTE_COUNT, buffer->buffers);
-    memcpy(buffer->buffers, newBuffers, R3D_INSTANCE_ATTRIBUTE_COUNT * sizeof(GLuint));
     buffer->capacity = newCapacity;
-
     R3D_TRACELOG(LOG_INFO, "Instance buffer resized successfully (capacity=%d)", newCapacity);
 }
 

--- a/src/r3d_instance.c
+++ b/src/r3d_instance.c
@@ -268,7 +268,8 @@ void R3D_ResizeInstanceBuffer(R3D_InstanceBuffer* buffer, int newCapacity, bool 
     R3D_TRACELOG(LOG_INFO, "Instance buffer resized successfully (capacity=%d)", newCapacity);
 }
 
-void R3D_UploadInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag, int offset, int count, void* data)
+void R3D_UploadInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag,
+                         int offset, int count, const void* data, bool discard)
 {
     int index = r3d_instance_attribute_index(flag);
     if (index < 0) {
@@ -277,7 +278,7 @@ void R3D_UploadInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag, int 
     }
 
     if (!BIT_TEST(buffer.layout.flags, flag)) {
-        R3D_TRACELOG(LOG_WARNING, "UploadInstances -> attribute not allocated for this buffer (flag=0x%04x)", flag);
+        R3D_TRACELOG(LOG_WARNING, "UploadInstances -> attribute not allocated (flag=0x%04x)", flag);
         return;
     }
 
@@ -286,12 +287,8 @@ void R3D_UploadInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag, int 
         return;
     }
 
-    if (offset < 0 || count < 0 || offset > buffer.capacity || count > buffer.capacity - offset) {
+    if (offset < 0 || count <= 0 || offset > buffer.capacity || count > buffer.capacity - offset) {
         R3D_TRACELOG(LOG_WARNING, "UploadInstances -> range out of bounds (offset=%d, count=%d, capacity=%d)", offset, count, buffer.capacity);
-        return;
-    }
-
-    if (count == 0) {
         return;
     }
 
@@ -300,58 +297,87 @@ void R3D_UploadInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag, int 
         return;
     }
 
-    size_t size = 0;
-    if (!get_buffer_size(count, index, buffer.layout.formats[index], &size)) {
-        R3D_TRACELOG(LOG_WARNING, "UploadInstances -> invalid upload size (flag=0x%04x)", flag);
+    size_t attrSize = get_attribute_size(index, buffer.layout.formats[index]);
+    if (attrSize == 0) {
+        R3D_TRACELOG(LOG_WARNING, "UploadInstances -> invalid attribute size (flag=0x%04x)", flag);
         return;
     }
 
-    size_t attrSize = get_attribute_size(index, buffer.layout.formats[index]);
+    size_t uploadSize = (size_t)count * attrSize;
     size_t offsetBytes = (size_t)offset * attrSize;
 
     glBindBuffer(GL_ARRAY_BUFFER, buffer.buffers[index]);
 
+    // Orphan the buffer to avoid GPU sync; old data is discarded entirely
+    if (discard) {
+        size_t totalSize = (size_t)buffer.capacity * attrSize;
+        glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)totalSize, NULL, GL_DYNAMIC_DRAW);
+    }
+
     r3d_driver_clear_errors();
-    glBufferSubData(GL_ARRAY_BUFFER, (GLintptr)offsetBytes, (GLsizeiptr)size, data);
+    glBufferSubData(GL_ARRAY_BUFFER, (GLintptr)offsetBytes, (GLsizeiptr)uploadSize, data);
 
     if (r3d_driver_check_error("UploadInstances -> glBufferSubData failed")) {
-        R3D_TRACELOG(LOG_WARNING, "UploadInstances -> failed to upload attribute data (%.2f MiB)", (double)size / (1024.0 * 1024.0));
+        R3D_TRACELOG(LOG_WARNING, "UploadInstances -> failed to upload attribute data (%.2f MiB)", (double)uploadSize / (1024.0 * 1024.0));
     }
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
-void* R3D_MapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag)
+void* R3D_MapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag, bool discard)
+{
+    return R3D_MapInstancesEx(buffer, flag, 0, buffer.capacity, discard);
+}
+
+void* R3D_MapInstancesEx(R3D_InstanceBuffer buffer, R3D_InstanceFlags flag,
+                         int offset, int count, bool discard)
 {
     int index = r3d_instance_attribute_index(flag);
     if (index < 0) {
-        R3D_TRACELOG(LOG_WARNING, "MapInstances -> invalid attribute flag (0x%04x)", flag);
+        R3D_TRACELOG(LOG_WARNING, "MapInstancesEx -> invalid attribute flag (0x%04x)", flag);
         return NULL;
     }
 
     if (!BIT_TEST(buffer.layout.flags, flag)) {
-        R3D_TRACELOG(LOG_WARNING, "MapInstances -> attribute not allocated for this buffer (flag=0x%04x)", flag);
+        R3D_TRACELOG(LOG_WARNING, "MapInstancesEx -> attribute not allocated (flag=0x%04x)", flag);
         return NULL;
     }
 
     if (buffer.buffers[index] == 0) {
-        R3D_TRACELOG(LOG_WARNING, "MapInstances -> invalid GPU buffer (flag=0x%04x)", flag);
+        R3D_TRACELOG(LOG_WARNING, "MapInstancesEx -> invalid GPU buffer (flag=0x%04x)", flag);
         return NULL;
     }
+
+    if (offset < 0 || count <= 0 || offset > buffer.capacity || count > buffer.capacity - offset) {
+        R3D_TRACELOG(LOG_WARNING, "MapInstancesEx -> range out of bounds (offset=%d, count=%d, capacity=%d)", offset, count, buffer.capacity);
+        return NULL;
+    }
+
+    size_t attrSize = get_attribute_size(index, buffer.layout.formats[index]);
+    if (attrSize == 0) {
+        R3D_TRACELOG(LOG_WARNING, "MapInstancesEx -> invalid attribute size (flag=0x%04x)", flag);
+        return NULL;
+    }
+
+    GLbitfield mapFlags = GL_MAP_WRITE_BIT;
+    if (discard) mapFlags |= GL_MAP_INVALIDATE_RANGE_BIT;
+
+    GLintptr offsetBytes = (GLintptr)((size_t)offset * attrSize);
+    GLsizeiptr rangeSize = (GLsizeiptr)((size_t)count * attrSize);
 
     glBindBuffer(GL_ARRAY_BUFFER, buffer.buffers[index]);
 
     r3d_driver_clear_errors();
-    void* ptrMap = glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+    void* ptr = glMapBufferRange(GL_ARRAY_BUFFER, offsetBytes, rangeSize, mapFlags);
 
-    if (r3d_driver_check_error("MapInstances -> glMapBuffer failed") || ptrMap == NULL) {
-        R3D_TRACELOG(LOG_WARNING, "MapInstances -> failed to map GPU buffer (flag=0x%04x)", flag);
-        ptrMap = NULL;
+    if (r3d_driver_check_error("MapInstancesEx -> glMapBufferRange failed") || ptr == NULL) {
+        R3D_TRACELOG(LOG_WARNING, "MapInstancesEx -> failed to map GPU buffer (flag=0x%04x)", flag);
+        ptr = NULL;
     }
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-    return ptrMap;
+    return ptr;
 }
 
 void R3D_UnmapInstances(R3D_InstanceBuffer buffer, R3D_InstanceFlags flags)


### PR DESCRIPTION
### API changes

- `R3D_UploadInstances` and `R3D_MapInstances` gain a `bool discard` parameter. When true, existing buffer contents are invalidated before the operation, allowing the driver to avoid a GPU/CPU sync.
- New `R3D_MapInstancesEx(buffer, flag, offset, count, discard)` for partial mapping with range invalidation (`GL_MAP_INVALIDATE_RANGE_BIT`).

### Internal changes

- `R3D_ResizeInstanceBuffer`: when `keepData=false`, existing buffers are now orphaned in-place via `glBufferData(NULL)` (this had temporarily changed here: https://github.com/Bigfoot71/r3d/pull/290)
- `R3D_MapInstances` now uses `glMapBufferRange` instead of `glMapBuffer`, enabling invalidation hints.
- `R3D_UploadInstances`: discard path calls `glBufferData(NULL)` before `glBufferSubData` to orphan the full buffer.