### PR TITLE
Shadow caster mask

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@
   Add a signed integer indicating render priority in materials, in order to control whether certain objects should be rendered before or after others.
   It should integrate easily with the existing material-based sorting.
 
-* [ ] **Add layer mask support for shadows**
+* [x] **Add layer mask support for shadows**
   Allows rendering an object in the scene without rendering its shadows.
   Or rendering only the object's shadows without rendering the object itself, using the camera layer mask.
   _(in addition to the existing shadow casting mode, this will allow for more different configurations per light)_

--- a/include/r3d/r3d_lighting.h
+++ b/include/r3d/r3d_lighting.h
@@ -10,6 +10,7 @@
 #define R3D_LIGHTING_H
 
 #include "./r3d_platform.h"
+#include "./r3d_camera.h"
 #include <raylib.h>
 #include <stdint.h>
 
@@ -541,6 +542,36 @@ R3DAPI float R3D_GetShadowSlopeBias(R3D_Light id);
  * incorrectly appearing or disappearing along object edges.
  */
 R3DAPI void R3D_SetShadowSlopeBias(R3D_Light id, float value);
+
+/**
+ * @brief Gets the shadow caster mask.
+ */
+R3DAPI R3D_Layer R3D_GetShadowCasterMask(R3D_Light id);
+
+/**
+ * @brief Replaces the shadow caster mask.
+ */
+R3DAPI void R3D_SetShadowCasterMask(R3D_Light id, R3D_Layer cullMask);
+
+/**
+ * @brief Enables one or more layers in the shadow caster mask.
+ */
+R3DAPI void R3D_EnableShadowCasterLayers(R3D_Light id, R3D_Layer layerMask);
+
+/**
+ * @brief Disables one or more layers from the shadow caster mask.
+ */
+R3DAPI void R3D_DisableShadowCasterLayers(R3D_Light id, R3D_Layer layerMask);
+
+/**
+ * @brief Toggles one or more layers in the shadow caster mask.
+ */
+R3DAPI void R3D_ToggleShadowCasterLayers(R3D_Light id, R3D_Layer layerMask);
+
+/**
+ * @brief Checks whether at least one object layer is visible to the shadow caster.
+ */
+R3DAPI bool R3D_IsShadowCasterLayerVisible(R3D_Light id, R3D_Layer layerMask);
 
 // ----------------------------------------
 // LIGHTING: Light Helper Functions

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -235,6 +235,7 @@ static bool init_light(r3d_light_t* light, R3D_LightType type)
     light->outerCutOff = cosf(45.0f * DEG2RAD);
 
     light->shadowSoftness = 4.0f / R3D_LIGHT_SHADOW_SIZE[light->type];
+    light->casterMask = R3D_LAYER_ALL;
 
     switch (type) {
     case R3D_LIGHT_DIR:

--- a/src/modules/r3d_light.h
+++ b/src/modules/r3d_light.h
@@ -72,6 +72,7 @@ typedef struct {
     float shadowSoftness;       // Softness factor for penumbra
     float shadowDepthBias;      // Constant depth bias
     float shadowSlopeBias;      // Slope-scaled depth bias
+    R3D_Layer casterMask;       // Shadow caster mask
 
     R3D_LightType type;
     bool enabled;

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -33,7 +33,8 @@
 // HELPER MACROS
 // ========================================
 
-#define IS_MESH_VALID(mesh) (((mesh).vertexCount > 0) && ((mesh).layerMask != 0))
+#define IS_MESH_VALID(mesh) \
+    (((mesh).vertexCount > 0) && ((mesh).layerMask != 0))
 
 #define IS_MESH_VISIBLE(mesh, cullMask) \
     (BIT_TEST_ANY((cullMask), (mesh).layerMask))
@@ -1455,6 +1456,11 @@ void pass_scene_shadow(void)
     r3d_driver_set_depth_func(GL_LEQUAL);
     r3d_driver_set_depth_mask(GL_TRUE);
 
+    #define COND (                                                          \
+        (call->mesh.instance.shadowCastMode != R3D_SHADOW_CAST_DISABLED) && \
+        IS_MESH_VISIBLE(call->mesh.instance, light->casterMask)             \
+    )
+
     R3D_LIGHT_FOR_EACH_VISIBLE(light)
     {
         if (!r3d_light_shadow_should_be_updated(light, true)) {
@@ -1469,13 +1475,11 @@ void pass_scene_shadow(void)
                 const R3D_Frustum* frustum = &light->frustum[iFace];
                 r3d_render_cull_groups(frustum);
 
-                #define COND (call->mesh.instance.shadowCastMode != R3D_SHADOW_CAST_DISABLED)
                 R3D_RENDER_FOR_EACH(call, COND, frustum, R3D_RENDER_PACKLIST_SHADOW) {
                     if (r3d_render_should_cast_shadow(call)) {
                         raster_depth_cube(call, &light->viewProj[iFace], light);
                     }
                 }
-                #undef COND
             }
         }
         else {
@@ -1485,15 +1489,15 @@ void pass_scene_shadow(void)
             const R3D_Frustum* frustum = &light->frustum[0];
             r3d_render_cull_groups(frustum);
 
-            #define COND (call->mesh.instance.shadowCastMode != R3D_SHADOW_CAST_DISABLED)
             R3D_RENDER_FOR_EACH(call, COND, frustum, R3D_RENDER_PACKLIST_SHADOW) {
                 if (r3d_render_should_cast_shadow(call)) {
                     raster_depth(call, &light->viewProj[0], light);
                 }
             }
-            #undef COND
         }
     }
+
+    #undef COND
 }
 
 void pass_scene_probes(void)

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -33,7 +33,7 @@
 // HELPER MACROS
 // ========================================
 
-#define IS_MESH_VALID(mesh) ((mesh).vertexCount > 0)
+#define IS_MESH_VALID(mesh) (((mesh).vertexCount > 0) && ((mesh).layerMask != 0))
 
 #define IS_MESH_VISIBLE(mesh, cullMask) \
     (BIT_TEST_ANY((cullMask), (mesh).layerMask))

--- a/src/r3d_lighting.c
+++ b/src/r3d_lighting.c
@@ -344,6 +344,42 @@ void R3D_SetShadowSlopeBias(R3D_Light id, float value)
     light->shadowSlopeBias = value;
 }
 
+R3D_Layer R3D_GetShadowCasterMask(R3D_Light id)
+{
+    GET_LIGHT_OR_RETURN(light, id, 0);
+    return light->casterMask;
+}
+
+void R3D_SetShadowCasterMask(R3D_Light id, R3D_Layer cullMask)
+{
+    GET_LIGHT_OR_RETURN(light, id);
+    light->casterMask = cullMask;
+}
+
+void R3D_EnableShadowCasterLayers(R3D_Light id, R3D_Layer layerMask)
+{
+    GET_LIGHT_OR_RETURN(light, id);
+    light->casterMask |= layerMask;
+}
+
+void R3D_DisableShadowCasterLayers(R3D_Light id, R3D_Layer layerMask)
+{
+    GET_LIGHT_OR_RETURN(light, id);
+    light->casterMask &= ~layerMask;
+}
+
+void R3D_ToggleShadowCasterLayers(R3D_Light id, R3D_Layer layerMask)
+{
+    GET_LIGHT_OR_RETURN(light, id);
+    light->casterMask ^= layerMask;
+}
+
+bool R3D_IsShadowCasterLayerVisible(R3D_Light id, R3D_Layer layerMask)
+{
+    GET_LIGHT_OR_RETURN(light, id, false);
+    return (light->casterMask & layerMask) != 0;
+}
+
 BoundingBox R3D_GetLightBoundingBox(R3D_Light id)
 {
     GET_LIGHT_OR_RETURN(light, id, (BoundingBox) {0});


### PR DESCRIPTION
## Summary

Adds support for shadow caster culling masks.

This makes it possible to control which objects are rendered into shadow maps on a per-light basis.
The behavior follows the same logic as `R3D_Camera` layer masks.

A "fast path" was also added to completely skip mesh rendering when the layer mask is zero.

## API Changes

### New functions

```c
R3DAPI R3D_Layer R3D_GetShadowCasterMask(R3D_Light id);
R3DAPI void R3D_SetShadowCasterMask(R3D_Light id, R3D_Layer cullMask);

R3DAPI void R3D_EnableShadowCasterLayers(R3D_Light id, R3D_Layer layerMask);
R3DAPI void R3D_DisableShadowCasterLayers(R3D_Light id, R3D_Layer layerMask);
R3DAPI void R3D_ToggleShadowCasterLayers(R3D_Light id, R3D_Layer layerMask);

R3DAPI bool R3D_IsShadowCasterLayerVisible(R3D_Light id, R3D_Layer layerMask);