### PR TITLE
Shadow opacity

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@
   Or rendering only the object's shadows without rendering the object itself, using the camera layer mask.
   _(in addition to the existing shadow casting mode, this will allow for more different configurations per light)_
 
-* [ ] **Add shadow opacity parameter**
+* [x] **Add shadow opacity parameter**
   Allows controlling the transparency of shadows relative to the light.
 
 * [ ] **Add specular parameter in the ORM map**

--- a/include/r3d/r3d_lighting.h
+++ b/include/r3d/r3d_lighting.h
@@ -515,6 +515,26 @@ R3DAPI float R3D_GetShadowSoftness(R3D_Light id);
 R3DAPI void R3D_SetShadowSoftness(R3D_Light id, float softness);
 
 /**
+ * @brief Retrieves the shadow opacity for a light.
+ *
+ * @param id The ID of the light.
+ * @return The current shadow opacity.
+ */
+R3DAPI float R3D_GetShadowOpacity(R3D_Light id);
+
+/**
+ * @brief Sets the shadow opacity for a light.
+ *
+ * The opacity controls the visual strength of shadows. A value of 0 makes shadows
+ * fully transparent, while 1 applies full opacity. Values are not clamped, but the
+ * usual range is 0 to 1.
+ *
+ * @param id The ID of the light.
+ * @param opacity The shadow opacity to apply.
+ */
+R3DAPI void R3D_SetShadowOpacity(R3D_Light id, float opacity);
+
+/**
  * @brief Gets the shadow depth bias value.
  */
 R3DAPI float R3D_GetShadowDepthBias(R3D_Light id);

--- a/include/r3d/r3d_lighting.h
+++ b/include/r3d/r3d_lighting.h
@@ -529,6 +529,9 @@ R3DAPI float R3D_GetShadowOpacity(R3D_Light id);
  * fully transparent, while 1 applies full opacity. Values are not clamped, but the
  * usual range is 0 to 1.
  *
+ * When the opacity is exactly 0, the light still owns its shadow map, but shadow
+ * map rendering and shadow application are entirely skipped.
+ *
  * @param id The ID of the light.
  * @param opacity The shadow opacity to apply.
  */

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -123,7 +123,7 @@ void main()
         shadow *= smoothstep(0.0, 1.0, (theta - uLight.outerCutOff) / epsilon);
     }
 
-    if (uLight.shadowLayer >= 0 && shadow > 1e-4) {
+    if (uLight.shadowLayer >= 0 && uLight.shadowOpacity != 0.0 && shadow > 1e-4) {
         mat2 diskRot = L_ShadowDebandingMatrix(gl_FragCoord.xy);
         switch (uLight.type) {
         case LIGHT_DIR:  shadow *= L_SampleShadowDir(P, depth, NdotL, diskRot); break;

--- a/shaders/include/blocks/light.glsl
+++ b/shaders/include/blocks/light.glsl
@@ -63,6 +63,7 @@ struct Light {
     float innerCutOff;
     float outerCutOff;
     float shadowSoftness;
+    float shadowOpacity;
     float shadowDepthBias;
     float shadowSlopeBias;
     int shadowLayer;        //< less than zero if no shadows
@@ -137,9 +138,8 @@ DECL_SHADOW_DIR(L_SampleShadowDir)
     vec3 distToBorder = min(projCoords, 1.0 - projCoords);
     float edgeFade = smoothstep(0.0, 0.05, min(distToBorder.x, min(distToBorder.y, distToBorder.z)));
     float distFade = smoothstep(LIGHT.range, LIGHT.range * 0.75, Zvs);
-    shadow = mix(1.0, shadow, edgeFade * distFade);
 
-    return shadow;
+    return mix(1.0, shadow, edgeFade * distFade * LIGHT.shadowOpacity);
 }
 
 DECL_SHADOW_SPOT(L_SampleShadowSpot)
@@ -157,8 +157,9 @@ DECL_SHADOW_SPOT(L_SampleShadowSpot)
         vec2 offset = diskRot * VOGEL_DISK[i] * LIGHT.shadowSoftness;
         shadow += texture(uShadowSpotTex, vec4(projCoords.xy + offset, LIGHT.shadowLayer, compareDepth));
     }
+    shadow /= float(SHADOW_SAMPLES);
 
-   return shadow / float(SHADOW_SAMPLES);
+    return mix(1.0, shadow, LIGHT.shadowOpacity);
 }
 
 DECL_SHADOW_OMNI(L_SampleShadowOmni)
@@ -176,8 +177,9 @@ DECL_SHADOW_OMNI(L_SampleShadowOmni)
         vec2 diskOffset = diskRot * VOGEL_DISK[i] * LIGHT.shadowSoftness;
         shadow += texture(uShadowOmniTex, vec4(OBN * vec3(diskOffset.xy, 1.0), LIGHT.shadowLayer), compareDepth);
     }
+    shadow /= float(SHADOW_SAMPLES);
 
-    return shadow / float(SHADOW_SAMPLES);
+    return mix(1.0, shadow, LIGHT.shadowOpacity);
 }
 
 #endif // L_SHADOW_IMPL

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -155,7 +155,7 @@ void main()
             shadow *= smoothstep(0.0, 1.0, (theta - light.outerCutOff) / epsilon);
         }
 
-        if (light.shadowLayer >= 0 && shadow > 1e-4) {
+        if (light.shadowLayer >= 0 && light.shadowOpacity != 0.0 && shadow > 1e-4) {
             switch (light.type) {
             case LIGHT_DIR:  shadow *= L_SampleShadowDir(i, vPosLightSpace[i], vLinearDepth, NdotL, diskRot); break;
             case LIGHT_SPOT: shadow *= L_SampleShadowSpot(i, vPosLightSpace[i], NdotL, diskRot); break;

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -235,8 +235,7 @@ static bool init_light(r3d_light_t* light, R3D_LightType type)
     light->outerCutOff = cosf(45.0f * DEG2RAD);
 
     light->shadowSoftness = 4.0f / R3D_LIGHT_SHADOW_SIZE[light->type];
-    light->casterMask = R3D_LAYER_ALL;
-
+    light->shadowOpacity = 1.0f;
     switch (type) {
     case R3D_LIGHT_DIR:
         light->shadowDepthBias = 4.0f / R3D_LIGHT_SHADOW_SIZE[light->type];
@@ -253,6 +252,7 @@ static bool init_light(r3d_light_t* light, R3D_LightType type)
     default:
         break;
     }
+    light->casterMask = R3D_LAYER_ALL;
 
     light->type = type;
     light->enabled = false;

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -681,7 +681,11 @@ void r3d_light_update_and_cull(const R3D_Frustum* viewFrustum, R3D_Camera camera
 
 bool r3d_light_shadow_should_be_updated(r3d_light_t* light, bool willBeUpdated)
 {
+    // If the light does not have a shadow map assigned, we return
     if (light->shadowLayer < 0) return false;
+
+    // If the shadow opacity is set to zero, the update is ignored
+    if (light->shadowOpacity == 0.0f) return false;
 
     bool shouldUpdate = light->state.shadowShouldBeUpdated;
 

--- a/src/modules/r3d_light.h
+++ b/src/modules/r3d_light.h
@@ -70,6 +70,7 @@ typedef struct {
     float innerCutOff;          // Spot light inner cutoff angle
     float outerCutOff;          // Spot light outer cutoff angle
     float shadowSoftness;       // Softness factor for penumbra
+    float shadowOpacity;        // Shadow opacity factor
     float shadowDepthBias;      // Constant depth bias
     float shadowSlopeBias;      // Slope-scaled depth bias
     R3D_Layer casterMask;       // Shadow caster mask

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -532,6 +532,7 @@ typedef struct {
     alignas(4) float innerCutOff;
     alignas(4) float outerCutOff;
     alignas(4) float shadowSoftness;
+    alignas(4) float shadowOpacity;
     alignas(4) float shadowDepthBias;
     alignas(4) float shadowSlopeBias;
     alignas(4) int32_t shadowLayer;

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -720,6 +720,7 @@ void upload_light_array_block_for_mesh(const r3d_render_call_t* call, bool shado
         data->innerCutOff = light->innerCutOff;
         data->outerCutOff = light->outerCutOff;
         data->shadowSoftness = light->shadowSoftness;
+        data->shadowOpacity = light->shadowOpacity;
         data->shadowDepthBias = light->shadowDepthBias;
         data->shadowSlopeBias = light->shadowSlopeBias;
         data->shadowLayer = shadow ? light->shadowLayer : -1;
@@ -2034,6 +2035,7 @@ void pass_deferred_lights(void)
             .innerCutOff = light->innerCutOff,
             .outerCutOff = light->outerCutOff,
             .shadowSoftness = light->shadowSoftness,
+            .shadowOpacity = light->shadowOpacity,
             .shadowDepthBias = light->shadowDepthBias,
             .shadowSlopeBias = light->shadowSlopeBias,
             .shadowLayer = light->shadowLayer,

--- a/src/r3d_lighting.c
+++ b/src/r3d_lighting.c
@@ -320,6 +320,18 @@ void R3D_SetShadowSoftness(R3D_Light id, float softness)
     light->shadowSoftness = softness / R3D_LIGHT_SHADOW_SIZE[light->type];
 }
 
+float R3D_GetShadowOpacity(R3D_Light id)
+{
+    GET_LIGHT_OR_RETURN(light, id, 0.0f);
+    return light->shadowOpacity;
+}
+
+void R3D_SetShadowOpacity(R3D_Light id, float opacity)
+{
+    GET_LIGHT_OR_RETURN(light, id);
+    light->shadowOpacity = opacity;
+}
+
 float R3D_GetShadowDepthBias(R3D_Light id)
 {
     GET_LIGHT_OR_RETURN(light, id, 0);


### PR DESCRIPTION
## Summary

Adds support for per-light shadow opacity.

A value of 0.0 makes shadows fully transparent, while 1.0 applies full opacity.
Values are not clamped, but 0.0 to 1.0 is the usual range.

When opacity is exactly 0.0, the light keeps its shadow map, but shadow map rendering and shadow evaluation are skipped.

## API Changes

```c
R3DAPI float R3D_GetShadowOpacity(R3D_Light id);
R3DAPI void R3D_SetShadowOpacity(R3D_Light id, float opacity);
```
