### PR TITLE
Fix ambient map initialization for C++ in R3D_ENVIRONMENT_BASE 

### DIFF
--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -63,7 +63,7 @@
         .ambient = {                                    \
             .color = BLACK,                             \
             .energy = 1.0f,                             \
-            .map = (R3D_AmbientMap) {0},                \
+            .map = R3D_TYPEINIT(R3D_AmbientMap)         \
         },                                              \
         .ssao = {                                       \
             .sampleCount = 16,                          \

--- a/include/r3d/r3d_platform.h
+++ b/include/r3d/r3d_platform.h
@@ -36,4 +36,12 @@
 #   endif
 #endif
 
+#ifndef R3D_TYPEINIT
+#   ifdef __cplusplus
+#       define R3D_TYPEINIT(type) type{0}
+#   else
+#       define R3D_TYPEINIT(type) (type) {0}
+#   endif
+#endif
+
 #endif // R3D_API_H


### PR DESCRIPTION
`R3D_ENVIRONMENT_BASE` was using C style initialization for `ambient.map` which was invalid for C++ projects. This adds a macro to do the assignment based on language.

I did not find any other cases where this was an issue and `ambient.map` could probably just be initialized with `{0}` to avoid adding the new macro but this keeps the type explicit if that is wanted.