### PR TITLE
Added support for auto-exposure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,7 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/prepare/smaa_edge_detection.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/blur_down.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/blur_up.frag"
+    "${R3D_ROOT_PATH}/shaders/prepare/luminance.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/depth_pyramid.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssao_in_down.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssao.frag"
@@ -352,8 +353,9 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/deferred/compose.frag"
     "${R3D_ROOT_PATH}/shaders/deferred/fog.frag"
     # Post
-    "${R3D_ROOT_PATH}/shaders/post/bloom.frag"
     "${R3D_ROOT_PATH}/shaders/post/dof.frag"
+    "${R3D_ROOT_PATH}/shaders/post/bloom.frag"
+    "${R3D_ROOT_PATH}/shaders/post/auto_exposure.frag"
     "${R3D_ROOT_PATH}/shaders/post/screen.frag"
     "${R3D_ROOT_PATH}/shaders/post/output.frag"
     "${R3D_ROOT_PATH}/shaders/post/fxaa.frag"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,7 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/prepare/blur_down.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/blur_up.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/luminance.frag"
+    "${R3D_ROOT_PATH}/shaders/prepare/exposure_adapt.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/depth_pyramid.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssao_in_down.frag"
     "${R3D_ROOT_PATH}/shaders/prepare/ssao.frag"

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -126,10 +126,11 @@
             .filterRadius = 1.0f,                       \
         },                                              \
         .autoExposure = {                               \
-            .minEV = -4.0f,                             \
-            .maxEV =  4.0f,                             \
+            .minEV = -1.0f,                             \
+            .maxEV =  1.0f,                             \
             .exposureCompensation = 0.0f,               \
-            .adaptationSpeed = 1.0f,                    \
+            .adaptationToBright = 0.5f,                 \
+            .adaptationToDark = 1.0f,                   \
         },                                              \
         .tonemap = {                                    \
             .mode = R3D_TONEMAP_LINEAR,                 \
@@ -323,15 +324,22 @@ typedef struct R3D_EnvBloom {
 /**
  * @brief Auto exposure post-processing settings.
  *
- * Simulates eye adaptation by automatically adjusting scene exposure
- * based on average luminance. Uses asymmetric temporal smoothing:
- * adaptation to brightness is faster than adaptation to darkness.
+ * Automatically adjusts scene exposure from average luminance,
+ * simulating eye adaptation. Adaptation should physically be
+ * faster toward bright scenes than toward dark scenes,
+ * as dark adaptation is slower.
+ *
+ * @warning Current implementation keeps a single temporal history. Enabling
+ * auto exposure for multiple scene passes in the same frame, or across
+ * different scenes, may produce incorrect adaptation. For now, use it only on
+ * one continuous begin/end scene render path.
  */
 typedef struct R3D_EnvAutoExposure {
-    float minEV;                ///< Minimum exposure in EV stops: clamps adaptation floor (default: -4.0)
-    float maxEV;                ///< Maximum exposure in EV stops: clamps adaptation ceiling (default: 4.0)
+    float minEV;                ///< Minimum measured luminance in EV stops, relative to middle gray (default: -1.0)
+    float maxEV;                ///< Maximum measured luminance in EV stops, relative to middle gray (default:  1.0)
     float exposureCompensation; ///< Artistic exposure bias in EV stops: +1 = one stop brighter (default: 0.0)
-    float adaptationSpeed;      ///< Adaptation time constant in seconds: lower = faster (default: 1.0)
+    float adaptationToBright;   ///< Time constant in seconds when scene luminance increases; lower = faster (default: 0.5)
+    float adaptationToDark;     ///< Time constant in seconds when scene luminance decreases; lower = faster (default: 1.0)
     bool enabled;               ///< Enable auto exposure (default: false)
 } R3D_EnvAutoExposure;
 

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -102,14 +102,6 @@
             .edgeFade = 0.25f,                          \
             .enabled = false,                           \
         },                                              \
-        .bloom = {                                      \
-            .mode = R3D_BLOOM_DISABLED,                 \
-            .levels = 0.5f,                             \
-            .intensity = 0.05f,                         \
-            .threshold = 0.0f,                          \
-            .softThreshold = 0.5f,                      \
-            .filterRadius = 1.0f,                       \
-        },                                              \
         .fog = {                                        \
             .mode = R3D_FOG_DISABLED,                   \
             .color = {255, 255, 255, 255},              \
@@ -124,6 +116,20 @@
             .focusScale = 1.0f,                         \
             .nearScale = 1.0f,                          \
             .maxBlurSize = 20.0f,                       \
+        },                                              \
+        .bloom = {                                      \
+            .mode = R3D_BLOOM_DISABLED,                 \
+            .levels = 0.5f,                             \
+            .intensity = 0.05f,                         \
+            .threshold = 0.0f,                          \
+            .softThreshold = 0.5f,                      \
+            .filterRadius = 1.0f,                       \
+        },                                              \
+        .autoExposure = {                               \
+            .minEV = -4.0f,                             \
+            .maxEV =  4.0f,                             \
+            .exposureCompensation = 0.0f,               \
+            .adaptationSpeed = 1.0f,                    \
         },                                              \
         .tonemap = {                                    \
             .mode = R3D_TONEMAP_LINEAR,                 \
@@ -276,20 +282,6 @@ typedef struct R3D_EnvSSR {
 } R3D_EnvSSR;
 
 /**
- * @brief Bloom post-processing settings.
- *
- * Glow effect around bright areas in the scene.
- */
-typedef struct R3D_EnvBloom {
-    R3D_Bloom mode;         ///< Bloom blending mode (default: R3D_BLOOM_DISABLED)
-    float levels;           ///< Mipmap spread factor [0-1]: higher = wider glow (default: 0.5)
-    float intensity;        ///< Bloom strength multiplier (default: 0.05)
-    float threshold;        ///< Minimum brightness to trigger bloom (default: 0.0)
-    float softThreshold;    ///< Softness of brightness cutoff transition (default: 0.5)
-    float filterRadius;     ///< Blur filter radius during upscaling (default: 1.0)
-} R3D_EnvBloom;
-
-/**
  * @brief Fog atmospheric effect settings.
  */
 typedef struct R3D_EnvFog {
@@ -313,6 +305,35 @@ typedef struct R3D_EnvDoF {
     float nearScale;        ///< Near blur intensity: 0.0 = disabled, 1.0 = symmetric to far (default: 1.0)
     float maxBlurSize;      ///< Maximum blur radius, similar to aperture (default: 20.0)
 } R3D_EnvDoF;
+
+/**
+ * @brief Bloom post-processing settings.
+ *
+ * Glow effect around bright areas in the scene.
+ */
+typedef struct R3D_EnvBloom {
+    R3D_Bloom mode;         ///< Bloom blending mode (default: R3D_BLOOM_DISABLED)
+    float levels;           ///< Mipmap spread factor [0-1]: higher = wider glow (default: 0.5)
+    float intensity;        ///< Bloom strength multiplier (default: 0.05)
+    float threshold;        ///< Minimum brightness to trigger bloom (default: 0.0)
+    float softThreshold;    ///< Softness of brightness cutoff transition (default: 0.5)
+    float filterRadius;     ///< Blur filter radius during upscaling (default: 1.0)
+} R3D_EnvBloom;
+
+/**
+ * @brief Auto exposure post-processing settings.
+ *
+ * Simulates eye adaptation by automatically adjusting scene exposure
+ * based on average luminance. Uses asymmetric temporal smoothing:
+ * adaptation to brightness is faster than adaptation to darkness.
+ */
+typedef struct R3D_EnvAutoExposure {
+    float minEV;                ///< Minimum exposure in EV stops: clamps adaptation floor (default: -4.0)
+    float maxEV;                ///< Maximum exposure in EV stops: clamps adaptation ceiling (default: 4.0)
+    float exposureCompensation; ///< Artistic exposure bias in EV stops: +1 = one stop brighter (default: 0.0)
+    float adaptationSpeed;      ///< Adaptation time constant in seconds: lower = faster (default: 1.0)
+    bool enabled;               ///< Enable auto exposure (default: false)
+} R3D_EnvAutoExposure;
 
 /**
  * @brief Tone mapping and exposure settings.
@@ -343,17 +364,18 @@ typedef struct R3D_EnvColor {
  * Initialize with R3D_ENVIRONMENT_BASE for default values.
  */
 typedef struct R3D_Environment {
-    R3D_EnvBackground background;   ///< Background and skybox settings
-    R3D_EnvAmbient    ambient;      ///< Ambient lighting configuration
-    R3D_EnvSSAO       ssao;         ///< Screen space ambient occlusion
-    R3D_EnvSSIL       ssil;         ///< Screen space indirect lighting
-    R3D_EnvSSGI       ssgi;         ///< Screen space global illumination
-    R3D_EnvSSR        ssr;          ///< Screen space reflections
-    R3D_EnvBloom      bloom;        ///< Bloom glow effect
-    R3D_EnvFog        fog;          ///< Atmospheric fog
-    R3D_EnvDoF        dof;          ///< Depth of field focus effect
-    R3D_EnvTonemap    tonemap;      ///< HDR tone mapping
-    R3D_EnvColor      color;        ///< Color grading adjustments
+    R3D_EnvBackground   background;     ///< Background and skybox settings
+    R3D_EnvAmbient      ambient;        ///< Ambient lighting configuration
+    R3D_EnvSSAO         ssao;           ///< Screen space ambient occlusion
+    R3D_EnvSSIL         ssil;           ///< Screen space indirect lighting
+    R3D_EnvSSGI         ssgi;           ///< Screen space global illumination
+    R3D_EnvSSR          ssr;            ///< Screen space reflections
+    R3D_EnvFog          fog;            ///< Atmospheric fog
+    R3D_EnvDoF          dof;            ///< Depth of field focus effect
+    R3D_EnvBloom        bloom;          ///< Bloom glow effect
+    R3D_EnvAutoExposure autoExposure;   ///< Auto exposure effect
+    R3D_EnvTonemap      tonemap;        ///< HDR tone mapping
+    R3D_EnvColor        color;          ///< Color grading adjustments
 } R3D_Environment;
 
 // ========================================

--- a/shaders/post/auto_exposure.frag
+++ b/shaders/post/auto_exposure.frag
@@ -1,12 +1,13 @@
 #version 330 core
 
 uniform sampler2D uSceneTex;
-uniform float uExposure;
+uniform sampler2D uExposureTex;
 
 out vec4 FragColor;
 
 void main()
 {
     vec4 color = texelFetch(uSceneTex, ivec2(gl_FragCoord.xy), 0);
-    FragColor = vec4(color.rgb * uExposure, 1.0);
+    float exposure = texelFetch(uExposureTex, ivec2(0), 0).r;
+    FragColor = vec4(color.rgb * exposure, color.a);
 }

--- a/shaders/post/auto_exposure.frag
+++ b/shaders/post/auto_exposure.frag
@@ -1,0 +1,12 @@
+#version 330 core
+
+uniform sampler2D uSceneTex;
+uniform float uExposure;
+
+out vec4 FragColor;
+
+void main()
+{
+    vec4 color = texelFetch(uSceneTex, ivec2(gl_FragCoord.xy), 0);
+    FragColor = vec4(color.rgb * uExposure, 1.0);
+}

--- a/shaders/prepare/exposure_adapt.frag
+++ b/shaders/prepare/exposure_adapt.frag
@@ -1,0 +1,31 @@
+#version 330 core
+
+uniform sampler2D uMeasuredLogLumTex;
+uniform sampler2D uPrevAutoExposureTex;
+
+uniform float uDeltaTime;
+uniform float uMinLogLum;
+uniform float uMaxLogLum;
+uniform float uSpeedUp;
+uniform float uSpeedDown;
+uniform float uExposureCompLog;
+
+out vec4 FragColor;
+
+void main()
+{
+    const float LOG_MIDDLE_GRAY = -1.7147984280919266; // log(0.18)
+
+    float measuredLogLum = texelFetch(uMeasuredLogLumTex, ivec2(0, 0), 0).r;
+    float prevLogLum = texelFetch(uPrevAutoExposureTex, ivec2(0, 0), 0).g;
+
+    measuredLogLum = clamp(measuredLogLum, uMinLogLum, uMaxLogLum);
+
+    float speed = measuredLogLum > prevLogLum ? uSpeedUp : uSpeedDown;
+    float blend = 1.0 - exp(-uDeltaTime * speed);
+
+    float adaptedLogLum = mix(prevLogLum, measuredLogLum, blend);
+    float exposure = exp(LOG_MIDDLE_GRAY - adaptedLogLum + uExposureCompLog);
+
+    FragColor = vec4(exposure, adaptedLogLum, 0.0, 1.0);
+}

--- a/shaders/prepare/luminance.frag
+++ b/shaders/prepare/luminance.frag
@@ -8,7 +8,6 @@ void main()
 {
     ivec2 pixCoord = 2 * ivec2(gl_FragCoord.xy);
 
-#ifdef LUMINANCE_COMPUTE
     vec3 c0 = texelFetch(uSourceTex, pixCoord + ivec2(0, 0), 0).rgb;
     vec3 c1 = texelFetch(uSourceTex, pixCoord + ivec2(1, 0), 0).rgb;
     vec3 c2 = texelFetch(uSourceTex, pixCoord + ivec2(0, 1), 0).rgb;
@@ -23,16 +22,4 @@ void main()
                   + log(l2 + 0.0001) + log(l3 + 0.0001)) * 0.25;
 
     FragColor = vec4(avgLog, 0.0, 0.0, 1.0);
-
-#else // LUMINANCE_DOWNSAMPLE
-    float l0 = texelFetch(uSourceTex, pixCoord + ivec2(0, 0), 0).r;
-    float l1 = texelFetch(uSourceTex, pixCoord + ivec2(1, 0), 0).r;
-    float l2 = texelFetch(uSourceTex, pixCoord + ivec2(0, 1), 0).r;
-    float l3 = texelFetch(uSourceTex, pixCoord + ivec2(1, 1), 0).r;
-
-    float avg = (l0 + l1 + l2 + l3) * 0.25;
-
-    FragColor = vec4(avg, 0.0, 0.0, 1.0);
-
-#endif
 }

--- a/shaders/prepare/luminance.frag
+++ b/shaders/prepare/luminance.frag
@@ -2,24 +2,30 @@
 
 uniform sampler2D uSourceTex;
 
-out vec4 FragColor;
+out float FragColor;
 
 void main()
 {
-    ivec2 pixCoord = 2 * ivec2(gl_FragCoord.xy);
+    const vec3 LUMA = vec3(0.2126, 0.7152, 0.0722);
+    const float EPSILON = 1e-4;
 
-    vec3 c0 = texelFetch(uSourceTex, pixCoord + ivec2(0, 0), 0).rgb;
-    vec3 c1 = texelFetch(uSourceTex, pixCoord + ivec2(1, 0), 0).rgb;
-    vec3 c2 = texelFetch(uSourceTex, pixCoord + ivec2(0, 1), 0).rgb;
-    vec3 c3 = texelFetch(uSourceTex, pixCoord + ivec2(1, 1), 0).rgb;
+    ivec2 srcSize = textureSize(uSourceTex, 0);
+    ivec2 base = 2 * ivec2(gl_FragCoord.xy);
 
-    float l0 = dot(c0, vec3(0.2127, 0.7152, 0.0722));
-    float l1 = dot(c1, vec3(0.2127, 0.7152, 0.0722));
-    float l2 = dot(c2, vec3(0.2127, 0.7152, 0.0722));
-    float l3 = dot(c3, vec3(0.2127, 0.7152, 0.0722));
+    ivec2 p0 = min(base + ivec2(0, 0), srcSize - 1);
+    ivec2 p1 = min(base + ivec2(1, 0), srcSize - 1);
+    ivec2 p2 = min(base + ivec2(0, 1), srcSize - 1);
+    ivec2 p3 = min(base + ivec2(1, 1), srcSize - 1);
 
-    float avgLog = (log(l0 + 0.0001) + log(l1 + 0.0001)
-                  + log(l2 + 0.0001) + log(l3 + 0.0001)) * 0.25;
+    vec3 c0 = texelFetch(uSourceTex, p0, 0).rgb;
+    vec3 c1 = texelFetch(uSourceTex, p1, 0).rgb;
+    vec3 c2 = texelFetch(uSourceTex, p2, 0).rgb;
+    vec3 c3 = texelFetch(uSourceTex, p3, 0).rgb;
 
-    FragColor = vec4(avgLog, 0.0, 0.0, 1.0);
+    float l0 = max(dot(c0, LUMA), EPSILON);
+    float l1 = max(dot(c1, LUMA), EPSILON);
+    float l2 = max(dot(c2, LUMA), EPSILON);
+    float l3 = max(dot(c3, LUMA), EPSILON);
+
+    FragColor = 0.25 * (log(l0) + log(l1) + log(l2) + log(l3));
 }

--- a/shaders/prepare/luminance.frag
+++ b/shaders/prepare/luminance.frag
@@ -1,0 +1,38 @@
+#version 330 core
+
+uniform sampler2D uSourceTex;
+
+out vec4 FragColor;
+
+void main()
+{
+    ivec2 pixCoord = 2 * ivec2(gl_FragCoord.xy);
+
+#ifdef LUMINANCE_COMPUTE
+    vec3 c0 = texelFetch(uSourceTex, pixCoord + ivec2(0, 0), 0).rgb;
+    vec3 c1 = texelFetch(uSourceTex, pixCoord + ivec2(1, 0), 0).rgb;
+    vec3 c2 = texelFetch(uSourceTex, pixCoord + ivec2(0, 1), 0).rgb;
+    vec3 c3 = texelFetch(uSourceTex, pixCoord + ivec2(1, 1), 0).rgb;
+
+    float l0 = dot(c0, vec3(0.2127, 0.7152, 0.0722));
+    float l1 = dot(c1, vec3(0.2127, 0.7152, 0.0722));
+    float l2 = dot(c2, vec3(0.2127, 0.7152, 0.0722));
+    float l3 = dot(c3, vec3(0.2127, 0.7152, 0.0722));
+
+    float avgLog = (log(l0 + 0.0001) + log(l1 + 0.0001)
+                  + log(l2 + 0.0001) + log(l3 + 0.0001)) * 0.25;
+
+    FragColor = vec4(avgLog, 0.0, 0.0, 1.0);
+
+#else // LUMINANCE_DOWNSAMPLE
+    float l0 = texelFetch(uSourceTex, pixCoord + ivec2(0, 0), 0).r;
+    float l1 = texelFetch(uSourceTex, pixCoord + ivec2(1, 0), 0).r;
+    float l2 = texelFetch(uSourceTex, pixCoord + ivec2(0, 1), 0).r;
+    float l3 = texelFetch(uSourceTex, pixCoord + ivec2(1, 1), 0).r;
+
+    float avg = (l0 + l1 + l2 + l3) * 0.25;
+
+    FragColor = vec4(avg, 0.0, 0.0, 1.0);
+
+#endif
+}

--- a/src/common/r3d_math.h
+++ b/src/common/r3d_math.h
@@ -28,6 +28,9 @@
 #   endif
 #endif
 
+#define R3D_LOG2     0.6931471805599453f
+#define R3D_LOG018  -1.7147984280919266f
+
 #define R3D_SRGB_ALPHA                  (0.055f)
 #define R3D_SRGB_INV_ALPHA              (1.0f / 1.055f)
 #define R3D_SRGB_GAMMA                  (2.4f)

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -42,6 +42,7 @@
 #include <shaders/bloom_down.frag.h>
 #include <shaders/bloom_up.frag.h>
 #include <shaders/luminance.frag.h>
+#include <shaders/exposure_adapt.frag.h>
 #include <shaders/smaa_blending_weigths.vert.h>
 #include <shaders/smaa_blending_weigths.frag.h>
 #include <shaders/smaa_edge_detection.vert.h>
@@ -568,6 +569,26 @@ bool r3d_shader_load_prepare_luminance_downsample(r3d_shader_custom_t* custom)
 
     USE_SHADER(luminanceDownsample);
     SET_SAMPLER(luminanceDownsample, uSourceTex, R3D_SHADER_SAMPLER_BUFFER_LUMINANCE);
+
+    return true;
+}
+
+bool r3d_shader_load_prepare_exposure_adapt(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_prepare_exposure_adapt_t, prepare, exposureAdapt);
+
+    LOAD_SHADER(exposureAdapt, SCREEN_VERT, EXPOSURE_ADAPT_FRAG);
+
+    GET_LOCATION(exposureAdapt, uDeltaTime);
+    GET_LOCATION(exposureAdapt, uMinLogLum);
+    GET_LOCATION(exposureAdapt, uMaxLogLum);
+    GET_LOCATION(exposureAdapt, uSpeedUp);
+    GET_LOCATION(exposureAdapt, uSpeedDown);
+    GET_LOCATION(exposureAdapt, uExposureCompLog);
+
+    USE_SHADER(exposureAdapt);
+    SET_SAMPLER(exposureAdapt, uMeasuredLogLumTex, R3D_SHADER_SAMPLER_BUFFER_LUMINANCE);
+    SET_SAMPLER(exposureAdapt, uPrevAutoExposureTex, R3D_SHADER_SAMPLER_BUFFER_EXPOSURE);
 
     return true;
 }
@@ -1389,10 +1410,9 @@ bool r3d_shader_load_post_auto_exposure(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_post_auto_exposure_t, post, autoExposure);
     LOAD_SHADER(autoExposure, SCREEN_VERT, AUTO_EXPOSURE_FRAG);
 
-    GET_LOCATION(autoExposure, uExposure);
-
     USE_SHADER(autoExposure);
     SET_SAMPLER(autoExposure, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
+    SET_SAMPLER(autoExposure, uExposureTex, R3D_SHADER_SAMPLER_BUFFER_EXPOSURE);
 
     return true;
 }

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -41,6 +41,7 @@
 #include <shaders/dof_blur.frag.h>
 #include <shaders/bloom_down.frag.h>
 #include <shaders/bloom_up.frag.h>
+#include <shaders/luminance.frag.h>
 #include <shaders/smaa_blending_weigths.vert.h>
 #include <shaders/smaa_blending_weigths.frag.h>
 #include <shaders/smaa_edge_detection.vert.h>
@@ -65,6 +66,7 @@
 #include <shaders/fog.frag.h>
 #include <shaders/dof.frag.h>
 #include <shaders/bloom.frag.h>
+#include <shaders/auto_exposure.frag.h>
 #include <shaders/screen.frag.h>
 #include <shaders/output.frag.h>
 #include <shaders/fxaa.frag.h>
@@ -536,6 +538,36 @@ bool r3d_shader_load_prepare_bloom_up(r3d_shader_custom_t* custom)
 
     USE_SHADER(bloomUp);
     SET_SAMPLER(bloomUp, uTexture, R3D_SHADER_SAMPLER_BUFFER_BLOOM);
+
+    return true;
+}
+
+bool r3d_shader_load_prepare_luminance_compute(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_prepare_luminance_compute_t, prepare, luminanceCompute);
+
+    const char* FS_DEFINES[] = {"LUMINANCE_COMPUTE"};
+    char* fsCode = inject_defines(LUMINANCE_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
+
+    LOAD_SHADER(luminanceCompute, SCREEN_VERT, fsCode);
+
+    USE_SHADER(luminanceCompute);
+    SET_SAMPLER(luminanceCompute, uSourceTex, R3D_SHADER_SAMPLER_BUFFER_LUMINANCE);
+
+    return true;
+}
+
+bool r3d_shader_load_prepare_luminance_downsample(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_prepare_luminance_downsample_t, prepare, luminanceDownsample);
+
+    const char* FS_DEFINES[] = {"LUMINANCE_DOWNSAMPLE"};
+    char* fsCode = inject_defines(LUMINANCE_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
+
+    LOAD_SHADER(luminanceDownsample, SCREEN_VERT, fsCode);
+
+    USE_SHADER(luminanceDownsample);
+    SET_SAMPLER(luminanceDownsample, uSourceTex, R3D_SHADER_SAMPLER_BUFFER_LUMINANCE);
 
     return true;
 }
@@ -1348,6 +1380,19 @@ bool r3d_shader_load_post_bloom(r3d_shader_custom_t* custom)
 
     SET_SAMPLER(bloom, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
     SET_SAMPLER(bloom, uBloomTex, R3D_SHADER_SAMPLER_BUFFER_BLOOM);
+
+    return true;
+}
+
+bool r3d_shader_load_post_auto_exposure(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_post_auto_exposure_t, post, autoExposure);
+    LOAD_SHADER(autoExposure, SCREEN_VERT, AUTO_EXPOSURE_FRAG);
+
+    GET_LOCATION(autoExposure, uExposure);
+
+    USE_SHADER(autoExposure);
+    SET_SAMPLER(autoExposure, uSceneTex, R3D_SHADER_SAMPLER_BUFFER_SCENE);
 
     return true;
 }

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -543,32 +543,13 @@ bool r3d_shader_load_prepare_bloom_up(r3d_shader_custom_t* custom)
     return true;
 }
 
-bool r3d_shader_load_prepare_luminance_compute(r3d_shader_custom_t* custom)
+bool r3d_shader_load_prepare_luminance(r3d_shader_custom_t* custom)
 {
-    DECL_SHADER(r3d_shader_prepare_luminance_compute_t, prepare, luminanceCompute);
+    DECL_SHADER(r3d_shader_prepare_luminance_t, prepare, luminance);
+    LOAD_SHADER(luminance, SCREEN_VERT, LUMINANCE_FRAG);
 
-    const char* FS_DEFINES[] = {"LUMINANCE_COMPUTE"};
-    char* fsCode = inject_defines(LUMINANCE_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
-
-    LOAD_SHADER(luminanceCompute, SCREEN_VERT, fsCode);
-
-    USE_SHADER(luminanceCompute);
-    SET_SAMPLER(luminanceCompute, uSourceTex, R3D_SHADER_SAMPLER_BUFFER_LUMINANCE);
-
-    return true;
-}
-
-bool r3d_shader_load_prepare_luminance_downsample(r3d_shader_custom_t* custom)
-{
-    DECL_SHADER(r3d_shader_prepare_luminance_downsample_t, prepare, luminanceDownsample);
-
-    const char* FS_DEFINES[] = {"LUMINANCE_DOWNSAMPLE"};
-    char* fsCode = inject_defines(LUMINANCE_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
-
-    LOAD_SHADER(luminanceDownsample, SCREEN_VERT, fsCode);
-
-    USE_SHADER(luminanceDownsample);
-    SET_SAMPLER(luminanceDownsample, uSourceTex, R3D_SHADER_SAMPLER_BUFFER_LUMINANCE);
+    USE_SHADER(luminance);
+    SET_SAMPLER(luminance, uSourceTex, R3D_SHADER_SAMPLER_BUFFER_LUMINANCE);
 
     return true;
 }

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -353,9 +353,10 @@ typedef enum {
     R3D_SHADER_SAMPLER_BUFFER_DOF_COC       = 32,
     R3D_SHADER_SAMPLER_BUFFER_DOF           = 33,
     R3D_SHADER_SAMPLER_BUFFER_BLOOM         = 34,
-    R3D_SHADER_SAMPLER_BUFFER_SMAA_EDGES    = 35,
-    R3D_SHADER_SAMPLER_BUFFER_SMAA_BLEND    = 36,
-    R3D_SHADER_SAMPLER_BUFFER_SCENE         = 37,
+    R3D_SHADER_SAMPLER_BUFFER_LUMINANCE     = 35,
+    R3D_SHADER_SAMPLER_BUFFER_SMAA_EDGES    = 36,
+    R3D_SHADER_SAMPLER_BUFFER_SMAA_BLEND    = 37,
+    R3D_SHADER_SAMPLER_BUFFER_SCENE         = 38,
 
     // Unamed for special passes
     R3D_SHADER_SAMPLER_SOURCE_1D_0          = 40,
@@ -407,6 +408,7 @@ static const GLenum R3D_MOD_SHADER_SAMPLER_TYPES[R3D_SHADER_SAMPLER_COUNT] =
     [R3D_SHADER_SAMPLER_BUFFER_DOF_COC]         = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_DOF]             = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_BLOOM]           = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_LUMINANCE]       = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_SMAA_EDGES]      = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_SMAA_BLEND]      = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_SCENE]           = GL_TEXTURE_2D,
@@ -732,6 +734,16 @@ typedef struct {
 
 typedef struct {
     GLuint id;
+    r3d_shader_uniform_sampler_t uSourceTex;
+} r3d_shader_prepare_luminance_compute_t;
+
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uSourceTex;
+} r3d_shader_prepare_luminance_downsample_t;
+
+typedef struct {
+    GLuint id;
     r3d_shader_uniform_sampler_t uSceneTex;
 } r3d_shader_prepare_smaa_edge_detection_t;
 
@@ -1048,6 +1060,12 @@ typedef struct {
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSceneTex;
+    r3d_shader_uniform_float_t uExposure;
+} r3d_shader_post_auto_exposure_t;
+
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uSceneTex;
     r3d_shader_uniform_sampler_t uNormalTex;
     r3d_shader_uniform_sampler_t uDepthTex;
 } r3d_shader_post_screen_t;
@@ -1181,6 +1199,8 @@ extern struct r3d_mod_shader {
         r3d_shader_prepare_dof_blur_t dofBlur;
         r3d_shader_prepare_bloom_down_t bloomDown;
         r3d_shader_prepare_bloom_up_t bloomUp;
+        r3d_shader_prepare_luminance_compute_t luminanceCompute;
+        r3d_shader_prepare_luminance_downsample_t luminanceDownsample;
         r3d_shader_prepare_smaa_edge_detection_t smaaEdgeDetection[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_prepare_smaa_blending_weights_t smaaBlendingWeights[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_prepare_cubemap_from_equirectangular_t cubemapFromEquirectangular;
@@ -1215,6 +1235,7 @@ extern struct r3d_mod_shader {
     struct {
         r3d_shader_post_dof_t dof;
         r3d_shader_post_bloom_t bloom;
+        r3d_shader_post_auto_exposure_t autoExposure;
         r3d_shader_post_output_t output;
         r3d_shader_post_fxaa_t fxaa[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_post_smaa_t smaa[R3D_ANTI_ALIASING_PRESET_COUNT];
@@ -1255,6 +1276,8 @@ bool r3d_shader_load_prepare_dof_down(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_dof_blur(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_bloom_down(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_bloom_up(r3d_shader_custom_t* custom);
+bool r3d_shader_load_prepare_luminance_compute(r3d_shader_custom_t* custom);
+bool r3d_shader_load_prepare_luminance_downsample(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_smaa_edge_detection_low(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_smaa_edge_detection_medium(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_smaa_edge_detection_high(r3d_shader_custom_t* custom);
@@ -1284,6 +1307,7 @@ bool r3d_shader_load_deferred_compose(r3d_shader_custom_t* custom);
 bool r3d_shader_load_deferred_fog(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_dof(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_bloom(r3d_shader_custom_t* custom);
+bool r3d_shader_load_post_auto_exposure(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_screen(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_output(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_fxaa_low(r3d_shader_custom_t* custom);
@@ -1323,6 +1347,8 @@ static const struct r3d_shader_loader {
         r3d_shader_loader_func dofBlur;
         r3d_shader_loader_func bloomDown;
         r3d_shader_loader_func bloomUp;
+        r3d_shader_loader_func luminanceCompute;
+        r3d_shader_loader_func luminanceDownsample;
         r3d_shader_loader_func smaaEdgeDetection[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_loader_func smaaBlendingWeights[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_loader_func cubemapFromEquirectangular;
@@ -1358,6 +1384,7 @@ static const struct r3d_shader_loader {
     struct {
         r3d_shader_loader_func dof;
         r3d_shader_loader_func bloom;
+        r3d_shader_loader_func autoExposure;
         r3d_shader_loader_func screen;
         r3d_shader_loader_func output;
         r3d_shader_loader_func fxaa[R3D_ANTI_ALIASING_PRESET_COUNT];
@@ -1394,6 +1421,8 @@ static const struct r3d_shader_loader {
         .dofBlur = r3d_shader_load_prepare_dof_blur,
         .bloomDown = r3d_shader_load_prepare_bloom_down,
         .bloomUp = r3d_shader_load_prepare_bloom_up,
+        .luminanceCompute = r3d_shader_load_prepare_luminance_compute,
+        .luminanceDownsample = r3d_shader_load_prepare_luminance_downsample,
         .smaaEdgeDetection[0] = r3d_shader_load_prepare_smaa_edge_detection_low,
         .smaaEdgeDetection[1] = r3d_shader_load_prepare_smaa_edge_detection_medium,
         .smaaEdgeDetection[2] = r3d_shader_load_prepare_smaa_edge_detection_high,
@@ -1432,6 +1461,7 @@ static const struct r3d_shader_loader {
     .post = {
         .dof = r3d_shader_load_post_dof,
         .bloom = r3d_shader_load_post_bloom,
+        .autoExposure = r3d_shader_load_post_auto_exposure,
         .screen = r3d_shader_load_post_screen,
         .output = r3d_shader_load_post_output,
         .fxaa[0] = r3d_shader_load_post_fxaa_low,

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -737,12 +737,7 @@ typedef struct {
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSourceTex;
-} r3d_shader_prepare_luminance_compute_t;
-
-typedef struct {
-    GLuint id;
-    r3d_shader_uniform_sampler_t uSourceTex;
-} r3d_shader_prepare_luminance_downsample_t;
+} r3d_shader_prepare_luminance_t;
 
 typedef struct {
     GLuint id;
@@ -1213,8 +1208,7 @@ extern struct r3d_mod_shader {
         r3d_shader_prepare_dof_blur_t dofBlur;
         r3d_shader_prepare_bloom_down_t bloomDown;
         r3d_shader_prepare_bloom_up_t bloomUp;
-        r3d_shader_prepare_luminance_compute_t luminanceCompute;
-        r3d_shader_prepare_luminance_downsample_t luminanceDownsample;
+        r3d_shader_prepare_luminance_t luminance;
         r3d_shader_prepare_exposure_adapt_t exposureAdapt;
         r3d_shader_prepare_smaa_edge_detection_t smaaEdgeDetection[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_prepare_smaa_blending_weights_t smaaBlendingWeights[R3D_ANTI_ALIASING_PRESET_COUNT];
@@ -1291,8 +1285,7 @@ bool r3d_shader_load_prepare_dof_down(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_dof_blur(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_bloom_down(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_bloom_up(r3d_shader_custom_t* custom);
-bool r3d_shader_load_prepare_luminance_compute(r3d_shader_custom_t* custom);
-bool r3d_shader_load_prepare_luminance_downsample(r3d_shader_custom_t* custom);
+bool r3d_shader_load_prepare_luminance(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_exposure_adapt(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_smaa_edge_detection_low(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_smaa_edge_detection_medium(r3d_shader_custom_t* custom);
@@ -1363,8 +1356,7 @@ static const struct r3d_shader_loader {
         r3d_shader_loader_func dofBlur;
         r3d_shader_loader_func bloomDown;
         r3d_shader_loader_func bloomUp;
-        r3d_shader_loader_func luminanceCompute;
-        r3d_shader_loader_func luminanceDownsample;
+        r3d_shader_loader_func luminance;
         r3d_shader_loader_func exposureAdapt;
         r3d_shader_loader_func smaaEdgeDetection[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_loader_func smaaBlendingWeights[R3D_ANTI_ALIASING_PRESET_COUNT];
@@ -1438,8 +1430,7 @@ static const struct r3d_shader_loader {
         .dofBlur = r3d_shader_load_prepare_dof_blur,
         .bloomDown = r3d_shader_load_prepare_bloom_down,
         .bloomUp = r3d_shader_load_prepare_bloom_up,
-        .luminanceCompute = r3d_shader_load_prepare_luminance_compute,
-        .luminanceDownsample = r3d_shader_load_prepare_luminance_downsample,
+        .luminance = r3d_shader_load_prepare_luminance,
         .exposureAdapt = r3d_shader_load_prepare_exposure_adapt,
         .smaaEdgeDetection[0] = r3d_shader_load_prepare_smaa_edge_detection_low,
         .smaaEdgeDetection[1] = r3d_shader_load_prepare_smaa_edge_detection_medium,

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -354,9 +354,10 @@ typedef enum {
     R3D_SHADER_SAMPLER_BUFFER_DOF           = 33,
     R3D_SHADER_SAMPLER_BUFFER_BLOOM         = 34,
     R3D_SHADER_SAMPLER_BUFFER_LUMINANCE     = 35,
-    R3D_SHADER_SAMPLER_BUFFER_SMAA_EDGES    = 36,
-    R3D_SHADER_SAMPLER_BUFFER_SMAA_BLEND    = 37,
-    R3D_SHADER_SAMPLER_BUFFER_SCENE         = 38,
+    R3D_SHADER_SAMPLER_BUFFER_EXPOSURE      = 36,
+    R3D_SHADER_SAMPLER_BUFFER_SMAA_EDGES    = 37,
+    R3D_SHADER_SAMPLER_BUFFER_SMAA_BLEND    = 38,
+    R3D_SHADER_SAMPLER_BUFFER_SCENE         = 39,
 
     // Unamed for special passes
     R3D_SHADER_SAMPLER_SOURCE_1D_0          = 40,
@@ -409,6 +410,7 @@ static const GLenum R3D_MOD_SHADER_SAMPLER_TYPES[R3D_SHADER_SAMPLER_COUNT] =
     [R3D_SHADER_SAMPLER_BUFFER_DOF]             = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_BLOOM]           = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_LUMINANCE]       = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_EXPOSURE]        = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_SMAA_EDGES]      = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_SMAA_BLEND]      = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_SCENE]           = GL_TEXTURE_2D,
@@ -744,6 +746,18 @@ typedef struct {
 
 typedef struct {
     GLuint id;
+    r3d_shader_uniform_sampler_t uMeasuredLogLumTex;
+    r3d_shader_uniform_sampler_t uPrevAutoExposureTex;
+    r3d_shader_uniform_float_t uDeltaTime;
+    r3d_shader_uniform_float_t uMinLogLum;
+    r3d_shader_uniform_float_t uMaxLogLum;
+    r3d_shader_uniform_float_t uSpeedUp;
+    r3d_shader_uniform_float_t uSpeedDown;
+    r3d_shader_uniform_float_t uExposureCompLog;
+} r3d_shader_prepare_exposure_adapt_t;
+
+typedef struct {
+    GLuint id;
     r3d_shader_uniform_sampler_t uSceneTex;
 } r3d_shader_prepare_smaa_edge_detection_t;
 
@@ -1060,7 +1074,7 @@ typedef struct {
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSceneTex;
-    r3d_shader_uniform_float_t uExposure;
+    r3d_shader_uniform_sampler_t uExposureTex;
 } r3d_shader_post_auto_exposure_t;
 
 typedef struct {
@@ -1201,6 +1215,7 @@ extern struct r3d_mod_shader {
         r3d_shader_prepare_bloom_up_t bloomUp;
         r3d_shader_prepare_luminance_compute_t luminanceCompute;
         r3d_shader_prepare_luminance_downsample_t luminanceDownsample;
+        r3d_shader_prepare_exposure_adapt_t exposureAdapt;
         r3d_shader_prepare_smaa_edge_detection_t smaaEdgeDetection[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_prepare_smaa_blending_weights_t smaaBlendingWeights[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_prepare_cubemap_from_equirectangular_t cubemapFromEquirectangular;
@@ -1278,6 +1293,7 @@ bool r3d_shader_load_prepare_bloom_down(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_bloom_up(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_luminance_compute(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_luminance_downsample(r3d_shader_custom_t* custom);
+bool r3d_shader_load_prepare_exposure_adapt(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_smaa_edge_detection_low(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_smaa_edge_detection_medium(r3d_shader_custom_t* custom);
 bool r3d_shader_load_prepare_smaa_edge_detection_high(r3d_shader_custom_t* custom);
@@ -1349,6 +1365,7 @@ static const struct r3d_shader_loader {
         r3d_shader_loader_func bloomUp;
         r3d_shader_loader_func luminanceCompute;
         r3d_shader_loader_func luminanceDownsample;
+        r3d_shader_loader_func exposureAdapt;
         r3d_shader_loader_func smaaEdgeDetection[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_loader_func smaaBlendingWeights[R3D_ANTI_ALIASING_PRESET_COUNT];
         r3d_shader_loader_func cubemapFromEquirectangular;
@@ -1423,6 +1440,7 @@ static const struct r3d_shader_loader {
         .bloomUp = r3d_shader_load_prepare_bloom_up,
         .luminanceCompute = r3d_shader_load_prepare_luminance_compute,
         .luminanceDownsample = r3d_shader_load_prepare_luminance_downsample,
+        .exposureAdapt = r3d_shader_load_prepare_exposure_adapt,
         .smaaEdgeDetection[0] = r3d_shader_load_prepare_smaa_edge_detection_low,
         .smaaEdgeDetection[1] = r3d_shader_load_prepare_smaa_edge_detection_medium,
         .smaaEdgeDetection[2] = r3d_shader_load_prepare_smaa_edge_detection_high,

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -96,6 +96,7 @@ static const target_config_t TARGET_CONFIG[] = {
     [R3D_TARGET_BLOOM]       = { FORMAT_RGB16F,  0.5f, GL_LINEAR_MIPMAP_LINEAR, GL_LINEAR,  0, {0} },
     [R3D_TARGET_SMAA_EDGES]  = { FORMAT_RG8,     1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SMAA_BLEND]  = { FORMAT_RGBA8,   1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
+    [R3D_TARGET_LUMINANCE]   = { FORMAT_R16F,    0.5f, GL_NEAREST,              GL_NEAREST, 0, {0} },
     [R3D_TARGET_SCENE_0]     = { FORMAT_RGB16F,  1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SCENE_1]     = { FORMAT_RGB16F,  1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
 };

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -13,6 +13,7 @@
 #include <assert.h>
 
 #include "../common/r3d_helper.h"
+#include "../common/r3d_math.h"
 
 // ========================================
 // MODULE STATE
@@ -97,6 +98,8 @@ static const target_config_t TARGET_CONFIG[] = {
     [R3D_TARGET_SMAA_EDGES]  = { FORMAT_RG8,     1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SMAA_BLEND]  = { FORMAT_RGBA8,   1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_LUMINANCE]   = { FORMAT_R16F,    0.5f, GL_NEAREST,              GL_NEAREST, 0, {0} },
+    [R3D_TARGET_EXPOSURE_0]  = { FORMAT_RG16F,   0.0f, GL_NEAREST,              GL_NEAREST, 1, {1.0f, R3D_LOG018, 0.0f, 1.0f} },
+    [R3D_TARGET_EXPOSURE_1]  = { FORMAT_RG16F,   0.0f, GL_NEAREST,              GL_NEAREST, 1, {1.0f, R3D_LOG018, 0.0f, 1.0f} },
     [R3D_TARGET_SCENE_0]     = { FORMAT_RGB16F,  1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SCENE_1]     = { FORMAT_RGB16F,  1.0f, GL_LINEAR,               GL_LINEAR,  1, {0} },
 };
@@ -272,6 +275,7 @@ int r3d_target_get_num_levels(r3d_target_t target)
 {
     const target_config_t* config = &TARGET_CONFIG[target];
     if (config->numLevels > 0) return config->numLevels;
+    if (config->resolutionFactor <= 0.0f) return 1;
 
     int w = (int)((float)R3D_MOD_TARGET.resW * config->resolutionFactor);
     int h = (int)((float)R3D_MOD_TARGET.resH * config->resolutionFactor);
@@ -281,6 +285,12 @@ int r3d_target_get_num_levels(r3d_target_t target)
 void r3d_target_get_resolution(int* w, int* h, r3d_target_t target, int level)
 {
     const target_config_t* config = &TARGET_CONFIG[target];
+
+    if (config->resolutionFactor <= 0.0f) {
+        if (w) *w = 1;
+        if (h) *h = 1;
+        return;
+    }
 
     if (w) *w = (int)((float)R3D_MOD_TARGET.resW * config->resolutionFactor);
     if (h) *h = (int)((float)R3D_MOD_TARGET.resH * config->resolutionFactor);
@@ -294,6 +304,12 @@ void r3d_target_get_resolution(int* w, int* h, r3d_target_t target, int level)
 void r3d_target_get_texel_size(float* w, float* h, r3d_target_t target, int level)
 {
     const target_config_t* config = &TARGET_CONFIG[target];
+
+    if (config->resolutionFactor <= 0.0f) {
+        if (w) *w = 1.0f;
+        if (h) *h = 1.0f;
+        return;
+    }
 
     if (w) *w = R3D_MOD_TARGET.txlW / config->resolutionFactor;
     if (h) *h = R3D_MOD_TARGET.txlH / config->resolutionFactor;
@@ -437,10 +453,22 @@ void r3d_target_gen_mipmap(r3d_target_t target)
     glBindTexture(GL_TEXTURE_2D, 0);
 }
 
+bool r3d_target_exists(r3d_target_t target)
+{
+    return (r3d_target_get_or_null(target) != 0);
+}
+
 GLuint r3d_target_get(r3d_target_t target)
 {
     assert(target > R3D_TARGET_INVALID && target < R3D_TARGET_COUNT);
     assert(R3D_MOD_TARGET.targetLoaded[target]);
+    return R3D_MOD_TARGET.targetTextures[target];
+}
+
+GLuint r3d_target_get_or_null(r3d_target_t target)
+{
+    if (target <= R3D_TARGET_INVALID || target >= R3D_TARGET_COUNT) return 0;
+    if (!R3D_MOD_TARGET.targetLoaded[target]) return 0;
     return R3D_MOD_TARGET.targetTextures[target];
 }
 
@@ -461,13 +489,6 @@ GLuint r3d_target_get_all_levels(r3d_target_t target)
     assert(target > R3D_TARGET_INVALID && target < R3D_TARGET_COUNT);
     int maxLevel = r3d_target_get_num_levels(target) - 1;
     r3d_target_set_read_levels(target, 0, maxLevel);
-    return R3D_MOD_TARGET.targetTextures[target];
-}
-
-GLuint r3d_target_get_or_null(r3d_target_t target)
-{
-    if (target <= R3D_TARGET_INVALID || target >= R3D_TARGET_COUNT) return 0;
-    if (!R3D_MOD_TARGET.targetLoaded[target]) return 0;
     return R3D_MOD_TARGET.targetTextures[target];
 }
 

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -445,7 +445,7 @@ void r3d_target_set_read_levels(r3d_target_t target, int baseLevel, int maxLevel
 
 void r3d_target_gen_mipmap(r3d_target_t target)
 {
-    GLuint id = r3d_target_get(target);
+    GLuint id = r3d_target_get_all_levels(target);
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, id);

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -46,6 +46,8 @@ typedef enum {
     R3D_TARGET_SMAA_EDGES,      //< Full - Mip 1 - RG8
     R3D_TARGET_SMAA_BLEND,      //< Full - Mip 1 - RGBA8
     R3D_TARGET_LUMINANCE,       //< Half - Mip N - R16F
+    R3D_TARGET_EXPOSURE_0,      //< 1x1  - Mip 1 - RG16F
+    R3D_TARGET_EXPOSURE_1,      //< 1x1  - Mip 1 - RG16F
     R3D_TARGET_SCENE_0,         //< Full - Mip 1 - RGB16F
     R3D_TARGET_SCENE_1,         //< Full - Mip 1 - RGB16F
     R3D_TARGET_COUNT
@@ -298,11 +300,23 @@ void r3d_target_set_read_levels(r3d_target_t target, int baseLevel, int maxLevel
 void r3d_target_gen_mipmap(r3d_target_t target);
 
 /*
+ * Returns whether the requested target has a valid texture ID.
+ * Returns false if the target has not been created yet or if the enum is invalid.
+ */
+bool r3d_target_exists(r3d_target_t target);
+
+/*
  * Returns the texture ID corresponding to the requested target.
  * Asserts that the requested target has been created and if the target enum is valid.
  * If not created yet, it means we never bound this target, so it would be empty.
  */
 GLuint r3d_target_get(r3d_target_t target);
+
+/*
+ * Returns the texture ID corresponding to the requested target.
+ * Or returns 0 if the target has not been created or if the enum is invalid.
+ */
+GLuint r3d_target_get_or_null(r3d_target_t target);
 
 /*
  * Returns the texture ID corresponding to the requested target and sampling level.
@@ -323,12 +337,6 @@ GLuint r3d_target_get_levels(r3d_target_t target, int baseLevel, int maxLevel);
  * If not created yet, it means we never bound this target, so it would be empty.
  */
 GLuint r3d_target_get_all_levels(r3d_target_t target);
-
-/*
- * Returns the texture ID corresponding to the requested target.
- * Or returns 0 if the target has not been created or if the enum is invalid.
- */
-GLuint r3d_target_get_or_null(r3d_target_t target);
 
 /*
  * Blits the provided targets to the specified FBO.

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -45,6 +45,7 @@ typedef enum {
     R3D_TARGET_BLOOM,           //< Half - Mip N - RGB16F
     R3D_TARGET_SMAA_EDGES,      //< Full - Mip 1 - RG8
     R3D_TARGET_SMAA_BLEND,      //< Full - Mip 1 - RGBA8
+    R3D_TARGET_LUMINANCE,       //< Half - Mip N - R16F
     R3D_TARGET_SCENE_0,         //< Full - Mip 1 - RGB16F
     R3D_TARGET_SCENE_1,         //< Full - Mip 1 - RGB16F
     R3D_TARGET_COUNT

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -18,7 +18,6 @@
 #include "./r3d_core_state.h"
 
 #include "./common/r3d_helper.h"
-#include "./common/r3d_half.h"
 #include "./common/r3d_pass.h"
 #include "./common/r3d_math.h"
 

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -2376,12 +2376,15 @@ r3d_target_t pass_post_bloom(r3d_target_t sceneTarget)
 
 r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget)
 {
+    r3d_target_t sceneSource = r3d_target_swap_scene(sceneTarget);
+    GLuint sceneSourceID = r3d_target_get(sceneSource);
+
     /* --- Build log-luminance pyramid --- */
 
     R3D_TARGET_BIND_LEVEL(0, R3D_TARGET_LUMINANCE);
 
     R3D_SHADER_USE(prepare.luminanceCompute);
-    R3D_SHADER_BIND_SAMPLER(prepare.luminanceCompute, uSourceTex, r3d_target_get(sceneTarget));
+    R3D_SHADER_BIND_SAMPLER(prepare.luminanceCompute, uSourceTex, sceneSourceID);
     R3D_RENDER_SCREEN();
 
     int numLevels = r3d_target_get_num_levels(R3D_TARGET_LUMINANCE);
@@ -2399,56 +2402,52 @@ r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget)
         R3D_RENDER_SCREEN();
     }
 
-    /* --- Read average log-luminance --- */
-
-    static const float MIDDLE_GRAY     = 0.18f;
-    static const float LOG_MIDDLE_GRAY = -1.7147984280919266f; // log(0.18)
-    static const float LOG_2           =  0.6931471805599453f; // log(2)
-
-    static float adaptedLogLum = LOG_MIDDLE_GRAY;
-
-    r3d_half_t halfMeasuredLogLum = 0;
-
-    glBindTexture(GL_TEXTURE_2D, r3d_target_get(R3D_TARGET_LUMINANCE));
-    glGetTexImage(GL_TEXTURE_2D, numLevels - 1, GL_RED, GL_HALF_FLOAT, &halfMeasuredLogLum);
-
-    float measuredLogLum = r3d_half_to_float(halfMeasuredLogLum);
-
-    /* --- Clamp measured luminance range in EV --- */
+    /* --- Update auto-exposure history on GPU --- */
 
     const R3D_EnvAutoExposure *autoExposure = &R3D.environment.autoExposure;
 
-    float minLogLum = LOG_MIDDLE_GRAY + autoExposure->minEV * LOG_2;
-    float maxLogLum = LOG_MIDDLE_GRAY + autoExposure->maxEV * LOG_2;
-
-    measuredLogLum = Clamp(measuredLogLum, minLogLum, maxLogLum);
-
-    /* --- Adapt exposure over time --- */
-
     float timeConstant = fmaxf(autoExposure->adaptationSpeed, 1e-3f);
 
-    float speedUp   = 3.0f / timeConstant; // adapt faster to brighter scenes
-    float speedDown = 1.0f / timeConstant; // adapt slower to darker scenes
+    float minLogLum = R3D_LOG018 + autoExposure->minEV * R3D_LOG2;
+    float maxLogLum = R3D_LOG018 + autoExposure->maxEV * R3D_LOG2;
 
-    float speed = (measuredLogLum > adaptedLogLum) ? speedUp : speedDown;
-    float blend = 1.0f - expf(-GetFrameTime() * speed);
+    float speedUp = 3.0f / timeConstant;
+    float speedDown = 1.0f / timeConstant;
 
-    adaptedLogLum = Lerp(adaptedLogLum, measuredLogLum, blend);
+    float exposureCompLog = autoExposure->exposureCompensation * R3D_LOG2;
 
-    /* --- Convert adapted luminance to exposure --- */
+    static r3d_target_t EXPOSURE_DST = R3D_TARGET_EXPOSURE_0;
+    static r3d_target_t EXPOSURE_SRC = R3D_TARGET_EXPOSURE_1;
 
-    float compensation = exp2f(autoExposure->exposureCompensation);
-    float exposure = expf(LOG_MIDDLE_GRAY - adaptedLogLum) * compensation;
+    if (!r3d_target_exists(EXPOSURE_SRC)) {
+        R3D_TARGET_CLEAR(false, EXPOSURE_SRC);
+    }
+
+    R3D_TARGET_BIND(false, EXPOSURE_DST);
+
+    R3D_SHADER_USE(prepare.exposureAdapt);
+
+    R3D_SHADER_SET_FLOAT(prepare.exposureAdapt, uDeltaTime, GetFrameTime());
+    R3D_SHADER_SET_FLOAT(prepare.exposureAdapt, uMinLogLum, minLogLum);
+    R3D_SHADER_SET_FLOAT(prepare.exposureAdapt, uMaxLogLum, maxLogLum);
+    R3D_SHADER_SET_FLOAT(prepare.exposureAdapt, uSpeedUp, speedUp);
+    R3D_SHADER_SET_FLOAT(prepare.exposureAdapt, uSpeedDown, speedDown);
+    R3D_SHADER_SET_FLOAT(prepare.exposureAdapt, uExposureCompLog, exposureCompLog);
+
+    R3D_SHADER_BIND_SAMPLER(prepare.exposureAdapt, uMeasuredLogLumTex, r3d_target_get_level(R3D_TARGET_LUMINANCE, numLevels - 1));
+    R3D_SHADER_BIND_SAMPLER(prepare.exposureAdapt, uPrevAutoExposureTex, r3d_target_get(EXPOSURE_SRC));
+
+    R3D_RENDER_SCREEN();
+
+    SWAP(r3d_target_t, EXPOSURE_DST, EXPOSURE_SRC);
 
     /* --- Apply exposure --- */
-
-    GLuint sceneSourceID = r3d_target_get(sceneTarget);
 
     R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
 
     R3D_SHADER_USE(post.autoExposure);
-    R3D_SHADER_SET_FLOAT(post.autoExposure, uExposure, exposure);
     R3D_SHADER_BIND_SAMPLER(post.autoExposure, uSceneTex, sceneSourceID);
+    R3D_SHADER_BIND_SAMPLER(post.autoExposure, uExposureTex, r3d_target_get(EXPOSURE_SRC));
     R3D_RENDER_SCREEN();
 
     return sceneTarget;
@@ -2564,7 +2563,7 @@ r3d_target_t pass_post_smaa(r3d_target_t sceneTarget)
 
 void blit_to_screen(r3d_target_t source)
 {
-    if (r3d_target_get_or_null(source) == 0) {
+    if (!r3d_target_exists(source)) {
         return;
     }
 
@@ -2669,7 +2668,7 @@ void blit_to_screen(r3d_target_t source)
 
 void visualize_to_screen(r3d_target_t source)
 {
-    if (r3d_target_get_or_null(source) == 0) {
+    if (!r3d_target_exists(source)) {
         return;
     }
 
@@ -2745,7 +2744,7 @@ void cleanup_after_render(void)
 
 #ifndef NDEBUG
     for (int iTarget = 0; iTarget < R3D_TARGET_COUNT; iTarget++) {
-        if (r3d_target_get_or_null(iTarget) != 0) {
+        if (r3d_target_exists(iTarget)) {
             r3d_target_set_read_levels(iTarget, 0, r3d_target_get_num_levels(iTarget) - 1);
         }
     }

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -2382,24 +2382,11 @@ r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget)
 
     R3D_TARGET_BIND_LEVEL(0, R3D_TARGET_LUMINANCE);
 
-    R3D_SHADER_USE(prepare.luminanceCompute);
-    R3D_SHADER_BIND_SAMPLER(prepare.luminanceCompute, uSourceTex, sceneSourceID);
+    R3D_SHADER_USE(prepare.luminance);
+    R3D_SHADER_BIND_SAMPLER(prepare.luminance, uSourceTex, sceneSourceID);
     R3D_RENDER_SCREEN();
 
-    int numLevels = r3d_target_get_num_levels(R3D_TARGET_LUMINANCE);
-
-    R3D_SHADER_USE(prepare.luminanceDownsample);
-
-    for (int dstLevel = 1; dstLevel < numLevels; dstLevel++) {
-        R3D_SHADER_BIND_SAMPLER(
-            prepare.luminanceDownsample,
-            uSourceTex,
-            r3d_target_get_level(R3D_TARGET_LUMINANCE, dstLevel - 1)
-        );
-
-        R3D_TARGET_BIND_LEVEL(dstLevel, R3D_TARGET_LUMINANCE);
-        R3D_RENDER_SCREEN();
-    }
+    r3d_target_gen_mipmap(R3D_TARGET_LUMINANCE);
 
     /* --- Update auto-exposure history on GPU --- */
 
@@ -2433,7 +2420,9 @@ r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget)
     R3D_SHADER_SET_FLOAT(prepare.exposureAdapt, uSpeedDown, speedDown);
     R3D_SHADER_SET_FLOAT(prepare.exposureAdapt, uExposureCompLog, exposureCompLog);
 
-    R3D_SHADER_BIND_SAMPLER(prepare.exposureAdapt, uMeasuredLogLumTex, r3d_target_get_level(R3D_TARGET_LUMINANCE, numLevels - 1));
+    int lumNumLevels = r3d_target_get_num_levels(R3D_TARGET_LUMINANCE);
+
+    R3D_SHADER_BIND_SAMPLER(prepare.exposureAdapt, uMeasuredLogLumTex, r3d_target_get_level(R3D_TARGET_LUMINANCE, lumNumLevels - 1));
     R3D_SHADER_BIND_SAMPLER(prepare.exposureAdapt, uPrevAutoExposureTex, r3d_target_get(EXPOSURE_SRC));
 
     R3D_RENDER_SCREEN();

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -18,6 +18,7 @@
 #include "./r3d_core_state.h"
 
 #include "./common/r3d_helper.h"
+#include "./common/r3d_half.h"
 #include "./common/r3d_pass.h"
 #include "./common/r3d_math.h"
 
@@ -95,6 +96,7 @@ static void pass_scene_background(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_setup(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_dof(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_bloom(r3d_target_t sceneTarget);
+static r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_screen(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_output(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_fxaa(r3d_target_t sceneTarget);
@@ -256,6 +258,10 @@ void R3D_End(void)
 
     if (R3D.environment.bloom.mode != R3D_BLOOM_DISABLED) {
         sceneTarget = pass_post_bloom(sceneTarget);
+    }
+
+    if (R3D.environment.autoExposure.enabled) {
+        sceneTarget = pass_post_auto_exposure(sceneTarget);
     }
 
     sceneTarget = pass_post_screen(sceneTarget);
@@ -2363,6 +2369,86 @@ r3d_target_t pass_post_bloom(r3d_target_t sceneTarget)
     R3D_SHADER_SET_INT(post.bloom, uBloomMode, R3D.environment.bloom.mode);
     R3D_SHADER_SET_FLOAT(post.bloom, uBloomIntensity, R3D.environment.bloom.intensity);
 
+    R3D_RENDER_SCREEN();
+
+    return sceneTarget;
+}
+
+r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget)
+{
+    /* --- Build log-luminance pyramid --- */
+
+    R3D_TARGET_BIND_LEVEL(0, R3D_TARGET_LUMINANCE);
+
+    R3D_SHADER_USE(prepare.luminanceCompute);
+    R3D_SHADER_BIND_SAMPLER(prepare.luminanceCompute, uSourceTex, r3d_target_get(sceneTarget));
+    R3D_RENDER_SCREEN();
+
+    int numLevels = r3d_target_get_num_levels(R3D_TARGET_LUMINANCE);
+
+    R3D_SHADER_USE(prepare.luminanceDownsample);
+
+    for (int dstLevel = 1; dstLevel < numLevels; dstLevel++) {
+        R3D_SHADER_BIND_SAMPLER(
+            prepare.luminanceDownsample,
+            uSourceTex,
+            r3d_target_get_level(R3D_TARGET_LUMINANCE, dstLevel - 1)
+        );
+
+        R3D_TARGET_BIND_LEVEL(dstLevel, R3D_TARGET_LUMINANCE);
+        R3D_RENDER_SCREEN();
+    }
+
+    /* --- Read average log-luminance --- */
+
+    static const float MIDDLE_GRAY     = 0.18f;
+    static const float LOG_MIDDLE_GRAY = -1.7147984280919266f; // log(0.18)
+    static const float LOG_2           =  0.6931471805599453f; // log(2)
+
+    static float adaptedLogLum = LOG_MIDDLE_GRAY;
+
+    r3d_half_t halfMeasuredLogLum = 0;
+
+    glBindTexture(GL_TEXTURE_2D, r3d_target_get(R3D_TARGET_LUMINANCE));
+    glGetTexImage(GL_TEXTURE_2D, numLevels - 1, GL_RED, GL_HALF_FLOAT, &halfMeasuredLogLum);
+
+    float measuredLogLum = r3d_half_to_float(halfMeasuredLogLum);
+
+    /* --- Clamp measured luminance range in EV --- */
+
+    const R3D_EnvAutoExposure *autoExposure = &R3D.environment.autoExposure;
+
+    float minLogLum = LOG_MIDDLE_GRAY + autoExposure->minEV * LOG_2;
+    float maxLogLum = LOG_MIDDLE_GRAY + autoExposure->maxEV * LOG_2;
+
+    measuredLogLum = Clamp(measuredLogLum, minLogLum, maxLogLum);
+
+    /* --- Adapt exposure over time --- */
+
+    float timeConstant = fmaxf(autoExposure->adaptationSpeed, 1e-3f);
+
+    float speedUp   = 3.0f / timeConstant; // adapt faster to brighter scenes
+    float speedDown = 1.0f / timeConstant; // adapt slower to darker scenes
+
+    float speed = (measuredLogLum > adaptedLogLum) ? speedUp : speedDown;
+    float blend = 1.0f - expf(-GetFrameTime() * speed);
+
+    adaptedLogLum = Lerp(adaptedLogLum, measuredLogLum, blend);
+
+    /* --- Convert adapted luminance to exposure --- */
+
+    float compensation = exp2f(autoExposure->exposureCompensation);
+    float exposure = expf(LOG_MIDDLE_GRAY - adaptedLogLum) * compensation;
+
+    /* --- Apply exposure --- */
+
+    GLuint sceneSourceID = r3d_target_get(sceneTarget);
+
+    R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
+
+    R3D_SHADER_USE(post.autoExposure);
+    R3D_SHADER_SET_FLOAT(post.autoExposure, uExposure, exposure);
+    R3D_SHADER_BIND_SAMPLER(post.autoExposure, uSceneTex, sceneSourceID);
     R3D_RENDER_SCREEN();
 
     return sceneTarget;

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -2392,13 +2392,14 @@ r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget)
 
     const R3D_EnvAutoExposure *autoExposure = &R3D.environment.autoExposure;
 
-    float timeConstant = fmaxf(autoExposure->adaptationSpeed, 1e-3f);
-
     float minLogLum = R3D_LOG018 + autoExposure->minEV * R3D_LOG2;
     float maxLogLum = R3D_LOG018 + autoExposure->maxEV * R3D_LOG2;
 
-    float speedUp = 3.0f / timeConstant;
-    float speedDown = 1.0f / timeConstant;
+    float timeToBright = fmaxf(autoExposure->adaptationToBright, 1e-3f);
+    float timeToDark   = fmaxf(autoExposure->adaptationToDark,   1e-3f);
+
+    float speedUp   = 1.0f / timeToBright;
+    float speedDown = 1.0f / timeToDark;
 
     float exposureCompLog = autoExposure->exposureCompensation * R3D_LOG2;
 


### PR DESCRIPTION
## Summary

Adds auto exposure as a post-processing pass.

The effect computes average scene log-luminance, adapts exposure over time, and applies the resulting exposure factor during composition.

## API Changes

Adds `R3D_EnvAutoExposure` to `R3D_Environment`.

User-facing parameters:

- `minEV` / `maxEV`: clamp the measured scene luminance range in EV stops, relative to middle gray.
- `exposureCompensation`: artistic exposure offset in EV stops.
- `adaptationToBright`: adaptation time constant when scene luminance increases.
- `adaptationToDark`: adaptation time constant when scene luminance decreases.
- `enabled`: enables/disables auto exposure.

Default values are conservative and intended to avoid strong artistic bias:

```c
.autoExposure = {
    .minEV = -1.0f,
    .maxEV =  1.0f,
    .exposureCompensation = 0.0f,
    .adaptationToBright = 0.5f,
    .adaptationToDark   = 1.0f,
},
```

## Implementation

The pass works in three steps:

1. **Log-luminance generation**

   The HDR scene is converted to log-luminance at half resolution. Four source pixels are averaged per output pixel using geometric mean luminance:

   ```c
   avgLog = average(log(max(luminance, epsilon)))
   ```

2. **Luminance reduction**

   The log-luminance texture mip chain is generated with `glGenerateMipmap`, reducing the image down to a final `1x1` mip containing the average log-luminance.

3. **Temporal adaptation**

   Exposure history is stored in two `1x1` ping-pong textures:

   - `.r`: final exposure value
   - `.g`: adapted log-luminance history

   The measured log-luminance is clamped using the user EV range:

   ```c
   minLogLum = log(0.18) + minEV * log(2)
   maxLogLum = log(0.18) + maxEV * log(2)
   ```

   Adaptation uses framerate-independent exponential smoothing:

   ```c
   blend = 1.0 - exp(-dt * speed)
   ```

   with separate time constants for adaptation toward brighter and darker scenes. Dark adaptation is intentionally slower by default.

   Final exposure is computed as:

   ```c
   exposure = exp(log(0.18) - adaptedLogLum + exposureCompensation * log(2))
   ```

The final composition pass samples the exposure texture and applies the exposure factor to the HDR scene.

## Notes

The current implementation uses a single temporal exposure history. Auto exposure should currently only be active for one continuous begin/end scene render path. Using it across multiple independent scene passes or multiple scenes in the same frame may produce incorrect adaptation history. This is a temporary limitation.

See this discussion: https://github.com/Bigfoot71/r3d/discussions/288
