### PR TITLE
Added hooks for screen shaders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ set(R3D_CONFIG_DEFAULTS
     R3D_MAX_SHADER_CODE_LENGTH          16384
     R3D_MAX_SHADER_SAMPLERS             4
     R3D_MAX_SHADER_UNIFORMS             16
-    R3D_MAX_SCREEN_SHADERS              8
+    R3D_MAX_SCREEN_SHADERS              4
     R3D_ENABLE_TRACELOG                 1
 )
 

--- a/examples/shader.c
+++ b/examples/shader.c
@@ -36,7 +36,7 @@ int main(void)
 
     // Load a screen shader
     R3D_ScreenShader* shader = R3D_LoadScreenShader(RESOURCES_PATH "shaders/screen.glsl");
-    R3D_SetScreenShaderChain(&shader, 1);
+    R3D_SetScreenShaderChain(R3D_SCREEN_SHADER_STAGE_OUTPUT, &shader, 1);
 
     // Set screen custom unforms
     R3D_SetScreenShaderUniform(shader, "u_time_scale", (float[]){2.5f});

--- a/include/r3d/r3d_screen_shader.h
+++ b/include/r3d/r3d_screen_shader.h
@@ -24,6 +24,39 @@
 typedef struct R3D_ShaderCustom R3D_ScreenShader;
 
 // ========================================
+// ENUM TYPES
+// ========================================
+
+/**
+ * @brief Screen shader execution stage.
+ *
+ * Screen shaders are custom fullscreen post-processing passes inserted at
+ * specific points of the frame.
+ *
+ * The SCENE stage runs before built-in post-processing and receives
+ * scene-referred HDR linear color. It is an advanced stage: effects
+ * may affect bloom, auto exposure, and all later passes.
+ *
+ * The POST stage runs after built-in HDR post-processing, but before output
+ * conversion. It still receives scene-referred HDR linear color.
+ *
+ * The OUTPUT stage runs after tonemapping/output conversion, but before
+ * anti-aliasing. It receives display-referred LDR color and is suitable for
+ * most artistic image effects.
+ *
+ * The FINAL stage runs after anti-aliasing, before the final blit. It receives
+ * the final display-referred image and is suitable for overlays, grain,
+ * scanlines, sharpening, fades, and debug visualization.
+ */
+typedef enum R3D_ScreenShaderStage {
+    R3D_SCREEN_SHADER_STAGE_SCENE,  ///< Before built-in post-processing; advanced HDR scene stage.
+    R3D_SCREEN_SHADER_STAGE_POST,   ///< After built-in HDR post-processing, before output conversion.
+    R3D_SCREEN_SHADER_STAGE_OUTPUT, ///< After output conversion, before anti-aliasing.
+    R3D_SCREEN_SHADER_STAGE_FINAL,  ///< After anti-aliasing, before final blit.
+    R3D_SCREEN_SHADER_STAGE_COUNT,  ///< Number of screen shader stages.
+} R3D_ScreenShaderStage;
+
+// ========================================
 // PUBLIC API
 // ========================================
 
@@ -131,22 +164,23 @@ R3DAPI void R3D_SetScreenShaderUniform(R3D_ScreenShader* shader, const char* nam
 R3DAPI void R3D_SetScreenShaderSampler(R3D_ScreenShader* shader, const char* name, Texture texture);
 
 /**
- * @brief Sets the list of screen shaders to execute at the end of the frame.
+ * @brief Sets the screen shader chain for a given stage.
  *
- * The maximum number of shaders is defined by `R3D_MAX_SCREEN_SHADERS`. 
- * If the provided count exceeds this limit, a warning is emitted and only 
- * the first `R3D_MAX_SCREEN_SHADERS` shaders are used.
+ * Screen shaders are executed in the order provided. The maximum number of
+ * shaders per stage is `R3D_MAX_SCREEN_SHADERS`; extra entries are ignored
+ * and a warning is emitted.
  *
- * Shader pointers are copied internally, so the original array can be modified or freed after the call.
- * NULL entries are allowed safely within the list.
+ * Shader pointers are copied internally, so the original array may be modified
+ * or freed after the call. NULL entries are allowed and skipped safely.
  *
- * Calling this function resets all internal screen shaders before copying the new list.
- * To disable all screen shaders, call this function with `shaders = NULL` and/or `count = 0`.
+ * Calling this function replaces the previous chain for the selected stage.
+ * To clear a stage, pass `shaders = NULL` or `count = 0`.
  *
+ * @param stage Screen shader stage to configure.
  * @param shaders Array of pointers to R3D_ScreenShader objects.
  * @param count Number of shaders in the array.
  */
-R3DAPI void R3D_SetScreenShaderChain(R3D_ScreenShader** shaders, int count);
+R3DAPI void R3D_SetScreenShaderChain(R3D_ScreenShaderStage stage, R3D_ScreenShader** shaders, int count);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/r3d_core_state.h
+++ b/src/r3d_core_state.h
@@ -40,7 +40,9 @@ typedef struct {
  */
 extern struct r3d_core_state {
     RenderTexture screen;               //< Texture target (screen if null id)
-    R3D_ScreenShader* screenShaders[R3D_MAX_SCREEN_SHADERS]; //< Chain of screen shaders
+    R3D_ScreenShader* screenShaders     //< Chain of screen shaders
+        [R3D_SCREEN_SHADER_STAGE_COUNT]
+        [R3D_MAX_SCREEN_SHADERS];
     R3D_Environment environment;        //< Current environment settings
     R3D_Material material;              //< Default material to use
     r3d_core_view_t viewState;          //< Current view state

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -28,6 +28,7 @@
 #include "./modules/r3d_render.h"
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_env.h"
+#include "r3d/r3d_screen_shader.h"
 
 // ========================================
 // HELPER MACROS
@@ -96,7 +97,7 @@ static r3d_target_t pass_post_setup(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_dof(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_bloom(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget);
-static r3d_target_t pass_post_screen(r3d_target_t sceneTarget);
+static r3d_target_t pass_post_screen(R3D_ScreenShaderStage stage, r3d_target_t sceneTarget);
 static r3d_target_t pass_post_output(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_fxaa(r3d_target_t sceneTarget);
 static r3d_target_t pass_post_smaa(r3d_target_t sceneTarget);
@@ -250,6 +251,7 @@ void R3D_End(void)
     /* --- Applying effects over the scene and final blit --- */
 
     sceneTarget = pass_post_setup(sceneTarget);
+    sceneTarget = pass_post_screen(R3D_SCREEN_SHADER_STAGE_SCENE, sceneTarget);
 
     if (R3D.environment.dof.mode != R3D_DOF_DISABLED) {
         sceneTarget = pass_post_dof(sceneTarget);
@@ -263,8 +265,10 @@ void R3D_End(void)
         sceneTarget = pass_post_auto_exposure(sceneTarget);
     }
 
-    sceneTarget = pass_post_screen(sceneTarget);
+    sceneTarget = pass_post_screen(R3D_SCREEN_SHADER_STAGE_POST, sceneTarget);
     sceneTarget = pass_post_output(sceneTarget);
+
+    sceneTarget = pass_post_screen(R3D_SCREEN_SHADER_STAGE_OUTPUT, sceneTarget);
 
     switch (R3D.aaMode) {
     case R3D_ANTI_ALIASING_MODE_FXAA:
@@ -276,6 +280,8 @@ void R3D_End(void)
     default:
         break;
     }
+
+    sceneTarget = pass_post_screen(R3D_SCREEN_SHADER_STAGE_FINAL, sceneTarget);
 
     switch (R3D.outputMode) {
     case R3D_OUTPUT_SCENE: blit_to_screen(r3d_target_swap_scene(sceneTarget)); break;
@@ -2442,15 +2448,15 @@ r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget)
     return sceneTarget;
 }
 
-r3d_target_t pass_post_screen(r3d_target_t sceneTarget)
+r3d_target_t pass_post_screen(R3D_ScreenShaderStage stage, r3d_target_t sceneTarget)
 {
-    for (int i = 0; i < ARRAY_SIZE(R3D.screenShaders); i++)
+    for (int i = 0; i < ARRAY_SIZE(R3D.screenShaders[stage]); i++)
     {
-        R3D_ScreenShader* shader = R3D.screenShaders[i];
+        R3D_ScreenShader* shader = R3D.screenShaders[stage][i];
         if (shader == NULL) continue;
 
         R3D_TARGET_BIND_AND_SWAP_SCENE(sceneTarget);
-        R3D_SHADER_USE_CUSTOM(R3D.screenShaders[i], post.screen);
+        R3D_SHADER_USE_CUSTOM(R3D.screenShaders[stage][i], post.screen);
 
         R3D_SHADER_BIND_SAMPLER_CUSTOM(shader, post.screen, uSceneTex, r3d_target_get(sceneTarget));
         R3D_SHADER_BIND_SAMPLER_CUSTOM(shader, post.screen, uNormalTex, r3d_target_get(R3D_TARGET_NORMAL));

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -28,7 +28,6 @@
 #include "./modules/r3d_render.h"
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_env.h"
-#include "r3d/r3d_screen_shader.h"
 
 // ========================================
 // HELPER MACROS

--- a/src/r3d_screen_shader.c
+++ b/src/r3d_screen_shader.c
@@ -189,7 +189,7 @@ void R3D_SetScreenShaderSampler(R3D_ScreenShader* shader, const char* name, Text
 
 void R3D_SetScreenShaderChain(R3D_ScreenShaderStage stage, R3D_ScreenShader** shaders, int count)
 {
-    if (stage < 0 && stage >= R3D_SCREEN_SHADER_STAGE_COUNT) {
+    if (stage < 0 || stage >= R3D_SCREEN_SHADER_STAGE_COUNT) {
         R3D_TRACELOG(LOG_WARNING, "Invalid screen shader stage: %d", stage);
     }
 

--- a/src/r3d_screen_shader.c
+++ b/src/r3d_screen_shader.c
@@ -187,18 +187,30 @@ void R3D_SetScreenShaderSampler(R3D_ScreenShader* shader, const char* name, Text
     }
 }
 
-void R3D_SetScreenShaderChain(R3D_ScreenShader** shaders, int count)
+void R3D_SetScreenShaderChain(R3D_ScreenShaderStage stage, R3D_ScreenShader** shaders, int count)
 {
-    if (count > ARRAY_SIZE(R3D.screenShaders)) {
-        R3D_TRACELOG(LOG_WARNING, "Nombre de shader écran fournit à la chaine trop grand: %i / %i", count, ARRAY_SIZE(R3D.screenShaders));
-        count = ARRAY_SIZE(R3D.screenShaders);
+    if (stage < 0 && stage >= R3D_SCREEN_SHADER_STAGE_COUNT) {
+        R3D_TRACELOG(LOG_WARNING, "Invalid screen shader stage: %d", stage);
     }
 
-    memset(R3D.screenShaders, 0, sizeof(R3D.screenShaders));
+    size_t maxChain = ARRAY_SIZE(R3D.screenShaders[stage]);
+
+    if (count > (int)maxChain) {
+        R3D_TRACELOG(
+            LOG_WARNING,
+            "Too many screen shaders provided for chain: %d / %zu",
+            count,
+            maxChain
+        );
+
+        count = (int)maxChain;
+    }
+
+    memset(R3D.screenShaders[stage], 0, sizeof(R3D.screenShaders[stage]));
     if (shaders == NULL) return;
 
     for (int i = 0; i < count; i++) {
-        R3D.screenShaders[i] = shaders[i];
+        R3D.screenShaders[stage][i] = shaders[i];
     }
 }
 


### PR DESCRIPTION
## Summary

Adds staged screen shader chains.

Screen shaders can now be inserted at multiple points of the post-processing pipeline instead of only running at a single fixed point near the end of the frame.

## API Changes

Adds `R3D_ScreenShaderStage` to select where a screen shader chain runs:

* `R3D_SCREEN_SHADER_STAGE_SCENE`: before built-in post-processing.
* `R3D_SCREEN_SHADER_STAGE_POST`: after built-in HDR post-processing, before output conversion.
* `R3D_SCREEN_SHADER_STAGE_OUTPUT`: after output conversion, before anti-aliasing.
* `R3D_SCREEN_SHADER_STAGE_FINAL`: after anti-aliasing, before final blit.

Updates `R3D_SetScreenShaderChain` to take a stage:

```c
R3D_SetScreenShaderChain(R3D_ScreenShaderStage stage, R3D_ScreenShader** shaders, int count);
```

Also reduces the default `R3D_MAX_SCREEN_SHADERS` value from `8` to `4` per stage.