### PR TITLE
Adds `orm.specular` parameter

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,12 +18,11 @@
 * [x] **Add shadow opacity parameter**
   Allows controlling the transparency of shadows relative to the light.
 
-* [ ] **Add specular parameter in the ORM map**
-  Allows controlling specularity per material (in relation to metalness) instead of only through the lights.
+* [x] **Add specular parameter in the ORM map**
+  Controls the base reflectivity of non-metal materials (F0), allowing per-material adjustment instead of relying on a fixed value.
 
 ## **Ideas (Not Planned Yet)**
 
-* [ ] Investigate the integration of a velocity buffer and frame history, mainly for TAA and motion blur. The current begin/end rendering model makes this non-trivial.
 * [ ] Improve support for shadow/transparency interaction (e.g., colored shadows).
 * [ ] Implement Cascaded Shadow Maps (or alternative) for directional lights.
 * [ ] Make wiki pages for the repo, consider it for the release.

--- a/docs/shaders/surface_shader.md
+++ b/docs/shaders/surface_shader.md
@@ -192,6 +192,7 @@ Fragment-stage variables are pre-initialized with material values (unless `R3D_N
 | `OCCLUSION` | `float` | Ambient occlusion |
 | `ROUGHNESS` | `float` | Surface roughness (0 = smooth, 1 = rough) |
 | `METALNESS` | `float` | Metallic property (0 = dielectric, 1 = metal) |
+| `SPECULAR` | `float` | Base reflectivity of non-metal materials |
 | `FRAME_INDEX` | `int` | Index incremented at each frame |
 | `TIME` | `float` | Time provided by the raylib's `GetTime()` |
 
@@ -379,7 +380,7 @@ If you want to start with zero values and sample materials manually, define:
 #define R3D_NO_AUTO_FETCH
 ```
 
-This sets `ALBEDO`, `NORMAL_MAP`, and `OCCLUSION`/`ROUGHNESS`/`METALNESS` to zero.
+This sets `ALBEDO`, `NORMAL_MAP`, and `OCCLUSION`/`ROUGHNESS`/`METALNESS`/`SPECULAR` to zero.
 
 ### Manual Sampling Functions
 
@@ -387,7 +388,7 @@ This sets `ALBEDO`, `NORMAL_MAP`, and `OCCLUSION`/`ROUGHNESS`/`METALNESS` to zer
 vec4 SampleAlbedo(vec2 texCoord);
 vec3 SampleEmission(vec2 texCoord);
 vec3 SampleNormal(vec2 texCoord);
-vec3 SampleOrm(vec2 texCoord); // (Occlusion, Roughness, Metalness)
+vec4 SampleOrm(vec2 texCoord); // (Occlusion, Roughness, Metalness, Specular)
 ```
 
 ### Quick Auto-Fill
@@ -410,7 +411,7 @@ void fragment() {
     
     // Or sample individual textures
     // ALBEDO = SampleAlbedo(distorted_uv).rgb;
-    // vec3 orm = SampleOrm(distorted_uv);
+    // vec4 orm = SampleOrm(distorted_uv);
     // ROUGHNESS = orm.g;
 }
 ```

--- a/include/r3d/r3d_material.h
+++ b/include/r3d/r3d_material.h
@@ -50,6 +50,7 @@
             .occlusion = 1.0f,                          \
             .roughness = 1.0f,                          \
             .metalness = 0.0f,                          \
+            .specular  = 0.5f,                          \
         },                                              \
         .uvOffset = {0.0f, 0.0f},                       \
         .uvScale = {1.0f, 1.0f},                        \
@@ -207,6 +208,7 @@ typedef struct R3D_OrmMap {
     float occlusion;    ///< Occlusion multiplier (default: 1.0f)
     float roughness;    ///< Roughness multiplier (default: 1.0f)
     float metalness;    ///< Metalness multiplier (default: 0.0f)
+    float specular;     ///< Controls how reflective non-metal materials appear (default: 0.5f)
 } R3D_OrmMap;
 
 /**
@@ -459,9 +461,10 @@ R3DAPI void R3D_UnloadNormalMap(R3D_NormalMap map);
  * @param occlusion Occlusion multiplier.
  * @param roughness Roughness multiplier.
  * @param metalness Metalness multiplier.
+ * @param specular Base reflectivity multiplier for non-metal materials.
  * @return ORM map. Returns an empty map on failure.
  */
-R3DAPI R3D_OrmMap R3D_LoadOrmMap(const char* fileName, float occlusion, float roughness, float metalness);
+R3DAPI R3D_OrmMap R3D_LoadOrmMap(const char* fileName, float occlusion, float roughness, float metalness, float specular);
 
 /**
  * @brief Load a combined ORM (Occlusion-Roughness-Metalness) map from memory.
@@ -474,10 +477,11 @@ R3DAPI R3D_OrmMap R3D_LoadOrmMap(const char* fileName, float occlusion, float ro
  * @param occlusion Occlusion multiplier.
  * @param roughness Roughness multiplier.
  * @param metalness Metalness multiplier.
+ * @param specular Base reflectivity multiplier for non-metal materials.
  * @return ORM map. Returns an empty map on failure.
  */
 R3DAPI R3D_OrmMap R3D_LoadOrmMapFromMemory(const char* fileType, const void* fileData, int dataSize,
-                                           float occlusion, float roughness, float metalness);
+                                           float occlusion, float roughness, float metalness, float specular);
 
 /**
  * @brief Unload an ORM map texture.

--- a/shaders/deferred/ambient.frag
+++ b/shaders/deferred/ambient.frag
@@ -55,7 +55,7 @@ layout(location = 1) out vec4 FragSpecular;
 void main()
 {
     vec3 albedo = texelFetch(uAlbedoTex, ivec2(gl_FragCoord.xy), 0).rgb;
-    vec3 orm = texelFetch(uOrmTex, ivec2(gl_FragCoord).xy, 0).rgb;
+    vec4 orm = texelFetch(uOrmTex, ivec2(gl_FragCoord).xy, 0);
     float ssao = texture(uSsaoTex, vTexCoord).r;
     vec4 ssil = texture(uSsilTex, vTexCoord);
     vec4 ssgi = texture(uSsgiTex, vTexCoord);
@@ -64,7 +64,7 @@ void main()
     orm.x *= pow(ssil.a, uSsilAoPower); 
     orm.x *= pow(ssao, uSsaoPower);
 
-    vec3 F0 = PBR_ComputeF0(orm.z, 0.5, albedo);
+    vec3 F0 = PBR_ComputeF0(orm.z, orm.w, albedo);
     vec3 kD = albedo * (1.0 - orm.z);
 
     vec3 P = V_GetWorldPosition(uDepthTex, ivec2(gl_FragCoord.xy));
@@ -74,7 +74,7 @@ void main()
 
     vec3 diffuse = vec3(0.0);
     vec3 specular = vec3(0.0);
-    E_ComputeAmbientAndProbes(diffuse, specular, kD, orm, F0, P, N, V, NdotV);
+    E_ComputeAmbientAndProbes(diffuse, specular, kD, orm.rgb, F0, P, N, V, NdotV);
 
     vec3 gi = ssgi.rgb * uSsgiIntensity;
     gi += ssil.rgb * uSsilIntensity;

--- a/shaders/deferred/compose.frag
+++ b/shaders/deferred/compose.frag
@@ -41,10 +41,10 @@ void main()
     vec3 diffuse = texelFetch(uDiffuseTex, ivec2(gl_FragCoord.xy), 0).rgb;
     vec3 specular = texelFetch(uSpecularTex, ivec2(gl_FragCoord.xy), 0).rgb;
 
-    vec3 orm = texelFetch(uOrmTex, ivec2(gl_FragCoord).xy, 0).rgb;
+    vec4 orm = texelFetch(uOrmTex, ivec2(gl_FragCoord).xy, 0);
     vec4 ssr = textureLod(uSsrTex, vTexCoord, orm.y * uSsrNumLevels);
 
-    vec3 F0 = PBR_ComputeF0(orm.z, 0.5, albedo);
+    vec3 F0 = PBR_ComputeF0(orm.z, orm.w, albedo);
     vec3 kS_approx = F0 * (1.0 - orm.y * 0.5);
 
     FragColor = diffuse + mix(specular, kS_approx * ssr.rgb, ssr.a);

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -53,13 +53,13 @@ void main()
     /* Sample albedo and ORM texture and extract values */
 
     vec3 albedo = texelFetch(uAlbedoTex, pixCoord, 0).rgb;
-    vec3 orm = texelFetch(uOrmTex, pixCoord, 0).rgb;
+    vec4 orm = texelFetch(uOrmTex, pixCoord, 0);
     float roughness = orm.g;
     float metalness = orm.b;
 
     /* Compute F0 (reflectance at normal incidence) based on the metallic factor */
 
-    vec3 F0 = PBR_ComputeF0(metalness, 0.5, albedo);
+    vec3 F0 = PBR_ComputeF0(metalness, orm.w, albedo);
 
     /* Get position and normal in world space */
 

--- a/shaders/include/user/scene.frag
+++ b/shaders/include/user/scene.frag
@@ -26,6 +26,7 @@ vec3 NORMAL_MAP = vec3(0.0);
 float OCCLUSION = 0.0;
 float ROUGHNESS = 0.0;
 float METALNESS = 0.0;
+float SPECULAR  = 0.0;
 
 /* === Built-In Globals === */
 
@@ -57,14 +58,15 @@ vec3 SampleNormal(vec2 texCoord)
     return normal;
 }
 
-vec3 SampleOrm(vec2 texCoord)
+vec4 SampleOrm(vec2 texCoord)
 {
-    vec3 ORM = vec3(0.0);
+    vec4 ORM = vec4(0.0);
 #if !defined(UNLIT) && !defined(PROBE_UNLIT) && !defined(DEPTH) && !defined(DEPTH_CUBE)
-    ORM = texture(uOrmMap, texCoord).rgb;
+    ORM = texture(uOrmMap, texCoord);
     ORM.x *= uOcclusion;
     ORM.y *= uRoughness;
     ORM.z *= uMetalness;
+    ORM.w  = uSpecular;
 #endif
     return ORM;
 }
@@ -82,6 +84,7 @@ void FetchMaterial(vec2 texCoord)
     OCCLUSION  = uOcclusion * ORM.x;
     ROUGHNESS  = uRoughness * ORM.y;
     METALNESS  = uMetalness * ORM.z;
+    SPECULAR   = uSpecular;
 #endif
 }
 
@@ -113,6 +116,7 @@ void SceneFragment(vec2 texCoord, mat3 tbn, float alphaCutoff)
     OCCLUSION  = uOcclusion * ORM.x;
     ROUGHNESS  = uRoughness * ORM.y;
     METALNESS  = uMetalness * ORM.z;
+    SPECULAR   = uSpecular;
 
 #endif // !R3D_NO_AUTO_FETCH && !UNLIT && !PROBE_UNLIT && !DEPTH && !DEPTH_CUBE
 #endif // !R3D_NO_AUTO_FETCH

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -47,6 +47,7 @@ uniform float uNormalScale;
 uniform float uOcclusion;
 uniform float uRoughness;
 uniform float uMetalness;
+uniform float uSpecular;
 
 uniform vec3 uViewPosition;
 
@@ -85,7 +86,7 @@ void main()
 
     /* Compute F0 (reflectance at normal incidence) and diffuse coefficient */
 
-    vec3 F0 = PBR_ComputeF0(METALNESS, 0.5, ALBEDO);
+    vec3 F0 = PBR_ComputeF0(METALNESS, SPECULAR, ALBEDO);
     vec3 kD = dielectric * ALBEDO;
 
     /* Sample normal map and compute final normal */
@@ -173,9 +174,9 @@ void main()
 
 #if defined(PROBE)
     if (uProbeInterior) E_ComputeAmbientColor(diff, kD, OCCLUSION);
-    else E_ComputeAmbientOnly(diff, spec, kD, ORM, F0, vPosition, N, V, NdotV);
+    else E_ComputeAmbientOnly(diff, spec, kD, ORM.rgb, F0, vPosition, N, V, NdotV);
 #else
-    E_ComputeAmbientAndProbes(diff, spec, kD, ORM, F0, vPosition, N, V, NdotV);
+    E_ComputeAmbientAndProbes(diff, spec, kD, ORM.rgb, F0, vPosition, N, V, NdotV);
 #endif
 
     /* Compute the final fragment color */

--- a/shaders/scene/geometry.frag
+++ b/shaders/scene/geometry.frag
@@ -36,13 +36,14 @@ uniform float uNormalScale;
 uniform float uOcclusion;
 uniform float uRoughness;
 uniform float uMetalness;
+uniform float uSpecular;
 
 /* === Fragments === */
 
 layout(location = 0) out vec3 FragAlbedo;
 layout(location = 1) out vec3 FragEmission;
 layout(location = 2) out vec2 FragNormal;
-layout(location = 3) out vec3 FragORM;
+layout(location = 3) out vec4 FragORM;
 layout(location = 4) out vec2 FragGeomNormal;
 layout(location = 5) out float FragDepth;
 
@@ -67,6 +68,6 @@ void main()
     FragEmission   = EMISSION;
     FragNormal     = M_EncodeOctahedral(N);
     FragGeomNormal = M_EncodeOctahedral(gN);
-    FragORM        = vec3(OCCLUSION, ROUGHNESS, METALNESS);
+    FragORM        = vec4(OCCLUSION, ROUGHNESS, METALNESS, SPECULAR);
     FragDepth      = vLinearDepth;
 }

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -804,6 +804,7 @@ bool r3d_shader_load_scene_geometry(r3d_shader_custom_t* custom)
     GET_LOCATION(geometry, uOcclusion);
     GET_LOCATION(geometry, uRoughness);
     GET_LOCATION(geometry, uMetalness);
+    GET_LOCATION(geometry, uSpecular);
 
     USE_SHADER(geometry);
 
@@ -871,6 +872,7 @@ bool r3d_shader_load_scene_forward(r3d_shader_custom_t* custom)
     GET_LOCATION(forward, uOcclusion);
     GET_LOCATION(forward, uRoughness);
     GET_LOCATION(forward, uMetalness);
+    GET_LOCATION(forward, uSpecular);
     GET_LOCATION(forward, uViewPosition);
 
     USE_SHADER(forward);
@@ -1130,6 +1132,7 @@ bool r3d_shader_load_scene_probe_forward(r3d_shader_custom_t* custom)
     GET_LOCATION(probeForward, uOcclusion);
     GET_LOCATION(probeForward, uRoughness);
     GET_LOCATION(probeForward, uMetalness);
+    GET_LOCATION(probeForward, uSpecular);
     GET_LOCATION(probeForward, uViewPosition);
     GET_LOCATION(probeForward, uProbeInterior);
 
@@ -1248,6 +1251,7 @@ bool r3d_shader_load_scene_decal(r3d_shader_custom_t* custom)
     GET_LOCATION(decal, uOcclusion);
     GET_LOCATION(decal, uRoughness);
     GET_LOCATION(decal, uMetalness);
+    GET_LOCATION(decal, uSpecular);
     GET_LOCATION(decal, uNormalThreshold);
     GET_LOCATION(decal, uFadeWidth);
     GET_LOCATION(decal, uApplyColor);

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -834,6 +834,7 @@ typedef struct {
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
     r3d_shader_uniform_float_t uMetalness;
+    r3d_shader_uniform_float_t uSpecular;
 } r3d_shader_scene_geometry_t;
 
 typedef struct {
@@ -863,6 +864,7 @@ typedef struct {
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
     r3d_shader_uniform_float_t uMetalness;
+    r3d_shader_uniform_float_t uSpecular;
     r3d_shader_uniform_vec3_t uViewPosition;
 } r3d_shader_scene_forward_t;
 
@@ -945,6 +947,7 @@ typedef struct {
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
     r3d_shader_uniform_float_t uMetalness;
+    r3d_shader_uniform_float_t uSpecular;
     r3d_shader_uniform_vec3_t uViewPosition;
     r3d_shader_uniform_int_t uProbeInterior;
 } r3d_shader_scene_probe_forward_t;
@@ -988,6 +991,7 @@ typedef struct {
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
     r3d_shader_uniform_float_t uMetalness;
+    r3d_shader_uniform_float_t uSpecular;
     r3d_shader_uniform_float_t uNormalThreshold;
     r3d_shader_uniform_float_t uFadeWidth;
     r3d_shader_uniform_int_t uApplyColor;

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -78,7 +78,7 @@ typedef struct {
 static const target_config_t TARGET_CONFIG[] = {
     [R3D_TARGET_ALBEDO]      = { FORMAT_RGB8,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
     [R3D_TARGET_NORMAL]      = { FORMAT_RG16,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
-    [R3D_TARGET_ORM]         = { FORMAT_RGB8,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
+    [R3D_TARGET_ORM]         = { FORMAT_RGBA8,   1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
     [R3D_TARGET_DEPTH]       = { FORMAT_R16F,    1.0f, GL_NEAREST,              GL_NEAREST, 2, {65504.0f, 65504.0f, 65504.0f, 65504.0f} },
     [R3D_TARGET_DIFFUSE]     = { FORMAT_RGB16F,  1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
     [R3D_TARGET_SPECULAR]    = { FORMAT_RGB16F,  1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -26,7 +26,7 @@ typedef enum {
     R3D_TARGET_INVALID = -1,
     R3D_TARGET_ALBEDO,          //< Full - Mip 2 - RGB8
     R3D_TARGET_NORMAL,          //< Full - Mip 2 - RG16
-    R3D_TARGET_ORM,             //< Full - Mip 2 - RGB8
+    R3D_TARGET_ORM,             //< Full - Mip 2 - RGBA8
     R3D_TARGET_DEPTH,           //< Full - Mip 2 - R16F
     R3D_TARGET_DIFFUSE,         //< Full - Mip 2 - RGB16F
     R3D_TARGET_SPECULAR,        //< Full - Mip 2 - RGB16F

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1037,6 +1037,7 @@ void raster_probe_forward(const r3d_render_call_t* call, const r3d_env_probe_t* 
     R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uOcclusion, material->orm.occlusion);
     R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uRoughness, material->orm.roughness);
     R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uMetalness, material->orm.metalness);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uSpecular, material->orm.specular);
 
     /* --- Set texcoord offset/scale --- */
 
@@ -1188,6 +1189,7 @@ void raster_geometry(const r3d_render_call_t* call, bool matchPrepass)
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uOcclusion, material->orm.occlusion);
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uRoughness, material->orm.roughness);
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uMetalness, material->orm.metalness);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uSpecular, material->orm.specular);
 
     /* --- Set misc material values --- */
 
@@ -1266,6 +1268,7 @@ void raster_decal(const r3d_render_call_t* call)
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uOcclusion, decal->orm.occlusion);
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uRoughness, decal->orm.roughness);
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uMetalness, decal->orm.metalness);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uSpecular, decal->orm.specular);
 
     /* --- Set misc material values --- */
 
@@ -1352,6 +1355,7 @@ void raster_forward(const r3d_render_call_t* call)
     R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uOcclusion, material->orm.occlusion);
     R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uRoughness, material->orm.roughness);
     R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uMetalness, material->orm.metalness);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uSpecular, material->orm.specular);
 
     /* --- Set texcoord offset/scale --- */
 

--- a/src/r3d_material.c
+++ b/src/r3d_material.c
@@ -179,24 +179,26 @@ void R3D_UnloadNormalMap(R3D_NormalMap map)
     R3D_UnloadTexture(map.texture);
 }
 
-R3D_OrmMap R3D_LoadOrmMap(const char* fileName, float occlusion, float roughness, float metalness)
+R3D_OrmMap R3D_LoadOrmMap(const char* fileName, float occlusion, float roughness, float metalness, float specular)
 {
     R3D_OrmMap map = {0};
     map.texture = R3D_LoadTexture(fileName, false);
     map.occlusion = occlusion;
     map.roughness = roughness;
     map.metalness = metalness;
+    map.specular = specular;
     return map;
 }
 
 R3D_OrmMap R3D_LoadOrmMapFromMemory(const char* fileType, const void* fileData, int dataSize,
-                                    float occlusion, float roughness, float metalness)
+                                    float occlusion, float roughness, float metalness, float specular)
 {
     R3D_OrmMap map = {0};
     map.texture = R3D_LoadTextureFromMemory(fileType, fileData, dataSize, false);
     map.occlusion = occlusion;
     map.roughness = roughness;
     map.metalness = metalness;
+    map.specular = specular;
     return map;
 }
 


### PR DESCRIPTION
## Summary

This PR adds a `specular` parameter to `R3D_OrmMap`, enabling per-material control over the base reflectivity (F0) of non-metal surfaces.

Previously, dielectric reflectivity used a fixed value globally.

---

## API Changes

### Added to `R3D_OrmMap`

```c
float specular;
```

Controls the base reflectivity of non-metal materials.
Default value: `0.5f`

### Updated functions

```c
R3D_LoadOrmMap(
    const char* fileName,
    float occlusion,
    float roughness,
    float metalness,
    float specular
);
```

```c
R3D_LoadOrmMapFromMemory(
    const char* fileType,
    const void* fileData,
    int dataSize,
    float occlusion,
    float roughness,
    float metalness,
    float specular
);
```
