### PR TITLE
Light and probe API redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ int main(void)
     // Setup lighting
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){-1, -1, -1});
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Camera setup
     Camera3D camera = {

--- a/examples/animation.c
+++ b/examples/animation.c
@@ -55,7 +55,7 @@ int main(void)
     // Setup lights with shadows
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){-1.0f, -1.0f, -1.0f});
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
     R3D_SetLightRange(light, 10.0f);
     R3D_EnableShadow(light);
 

--- a/examples/animtree.c
+++ b/examples/animtree.c
@@ -119,7 +119,7 @@ int main(void)
     // Setup lights with shadows
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){-1.0f, -1.0f, -1.0f});
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
     R3D_SetLightRange(light, 10.0f);
     R3D_EnableShadow(light);
 

--- a/examples/basic.c
+++ b/examples/basic.c
@@ -1,3 +1,4 @@
+#include "r3d/r3d_lighting.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 
@@ -20,9 +21,9 @@ int main(void)
 
     // Create light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
-    R3D_LightLookAt(light, (Vector3){0, 10, 5}, (Vector3){0});
+    R3D_SetLightTarget(light, (Vector3){0, 10, 5}, (Vector3){0});
     R3D_EnableShadow(light);
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Setup camera
     Camera3D camera = {

--- a/examples/basic.cpp
+++ b/examples/basic.cpp
@@ -20,9 +20,9 @@ int main()
 
     // Create light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
-    R3D_LightLookAt(light, {0, 10, 5}, {});
+    R3D_SetLightTarget(light, {0, 10, 5}, {});
     R3D_EnableShadow(light);
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Setup camera
     Camera3D camera = {};

--- a/examples/billboards.c
+++ b/examples/billboards.c
@@ -52,7 +52,7 @@ int main(void)
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){-1, -1, -1});
     R3D_EnableShadow(light);
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
     R3D_SetLightRange(light, 32.0f);
 
     // Setup camera

--- a/examples/decal.c
+++ b/examples/decal.c
@@ -44,7 +44,7 @@ int main(void)
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){ 0.5f, -1, -0.5f });
     R3D_EnableShadow(light);
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Setup camera
     Camera3D camera = (Camera3D){

--- a/examples/dof.c
+++ b/examples/dof.c
@@ -27,7 +27,7 @@ int main(void)
     // Create directional light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){0, -1, 0});
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Create sphere mesh and default material
     R3D_Mesh meshSphere = R3D_GenMeshSphere(0.2f, 64, 64);

--- a/examples/instanced.c
+++ b/examples/instanced.c
@@ -98,7 +98,7 @@ int main(void)
 
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){0, -1, 0});
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Setup camera
     Camera3D camera = {

--- a/examples/kinematics.c
+++ b/examples/kinematics.c
@@ -30,7 +30,7 @@ int main(void)
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3) {-1, -1, -1});
     R3D_SetLightRange(light, 16.0f);
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
     R3D_EnableShadow(light);
 
     // Load materials

--- a/examples/lights.c
+++ b/examples/lights.c
@@ -1,3 +1,4 @@
+#include "r3d/r3d_lighting.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 #include <stdlib.h>
@@ -44,7 +45,7 @@ int main(void)
         R3D_SetLightPosition(lights[i], (Vector3){randf(-50.0f, 50.0f), randf(1.0f, 5.0f), randf(-50.0f, 50.0f)});
         R3D_SetLightColor(lights[i], ColorFromHSV(randf(0.0f, 360.0f), 1.0f, 1.0f));
         R3D_SetLightRange(lights[i], randf(8.0f, 16.0f));
-        R3D_SetLightActive(lights[i], true);
+        R3D_EnableLight(lights[i]);
     }
 
     // Setup camera
@@ -73,7 +74,7 @@ int main(void)
         if (IsKeyDown(KEY_F)) {
             BeginMode3D(camera);
             for (int i = 0; i < NUM_LIGHTS; i++) {
-                R3D_DrawLightShape(lights[i]);
+                R3D_DrawLightDebug(lights[i]);
             }
             EndMode3D();
         }

--- a/examples/multiview.c
+++ b/examples/multiview.c
@@ -20,9 +20,9 @@ int main(void)
 
     // Create light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
-    R3D_LightLookAt(light, (Vector3){0, 10, 5}, (Vector3){0});
+    R3D_SetLightTarget(light, (Vector3){0, 10, 5}, (Vector3){0});
     R3D_EnableShadow(light);
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Setup cameras
     R3D_Camera cam0 = R3D_CAMERA_BASE;

--- a/examples/probe.c
+++ b/examples/probe.c
@@ -34,8 +34,8 @@ int main(void)
 
     // Create light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
-    R3D_LightLookAt(light, (Vector3){0, 10, 5}, (Vector3){0});
-    R3D_SetLightActive(light, true);
+    R3D_SetLightTarget(light, (Vector3){0, 10, 5}, (Vector3){0});
+    R3D_EnableLight(light);
     R3D_EnableShadow(light);
 
     // Create probe
@@ -43,7 +43,7 @@ int main(void)
     R3D_SetProbePosition(probe, (Vector3) {0, 1, 0});
     R3D_SetProbeShadows(probe, true);
     R3D_SetProbeFalloff(probe, 0.5f);
-    R3D_SetProbeActive(probe, true);
+    R3D_EnableProbe(probe);
 
     // Setup camera
     Camera3D camera = {

--- a/examples/resize.c
+++ b/examples/resize.c
@@ -26,7 +26,7 @@ int main(void)
     // Setup directional light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){0, 0, -1});
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Setup camera
     Camera3D camera = {

--- a/examples/shader.c
+++ b/examples/shader.c
@@ -43,9 +43,9 @@ int main(void)
 
     // Create light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
-    R3D_LightLookAt(light, (Vector3){0, 10, 5}, (Vector3){0});
+    R3D_SetLightTarget(light, (Vector3){0, 10, 5}, (Vector3){0});
     R3D_EnableShadow(light);
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Setup camera
     Camera3D camera = {

--- a/examples/sponza.c
+++ b/examples/sponza.c
@@ -1,3 +1,4 @@
+#include "r3d/r3d_lighting.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 
@@ -32,10 +33,10 @@ int main(void)
     for (int i = 0; i < 2; i++) {
         lights[i] = R3D_CreateLight(R3D_LIGHT_OMNI);
         R3D_SetLightPosition(lights[i], (Vector3) {i ? -10.0f : 10.0f, 20.0f, 0.0f});
-        R3D_SetLightActive(lights[i], true);
-        R3D_SetLightEnergy(lights[i], 8.0f);
         R3D_SetShadowUpdateMode(lights[i], R3D_SHADOW_UPDATE_MANUAL);
+        R3D_SetLightEnergy(lights[i], 8.0f);
         R3D_EnableShadow(lights[i]);
+        R3D_EnableLight(lights[i]);
     }
 
     // Setup camera

--- a/examples/sprite.c
+++ b/examples/sprite.c
@@ -40,10 +40,10 @@ int main(void)
 
     // Setup spotlight
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
-    R3D_LightLookAt(light, (Vector3){0,10,10}, (Vector3){0});
+    R3D_SetLightTarget(light, (Vector3){0,10,10}, (Vector3){0});
     R3D_SetLightRange(light, 64.0f);
     R3D_EnableShadow(light);
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Setup camera
     Camera3D camera = {

--- a/examples/stencil.c
+++ b/examples/stencil.c
@@ -63,9 +63,9 @@ int main(void)
     R3D_ENVIRONMENT_SET(ambient.color, (Color){10, 10, 15, 255});
 
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
-    R3D_LightLookAt(light, (Vector3){4, 8, 5}, (Vector3){0});
+    R3D_SetLightTarget(light, (Vector3){4, 8, 5}, (Vector3){0});
     R3D_SetShadowSoftness(light, 8.0f);
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
     R3D_EnableShadow(light);
 
     Camera3D camera = {

--- a/examples/sun.c
+++ b/examples/sun.c
@@ -45,7 +45,7 @@ int main(void)
     // Create directional light with shadows
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_DIR);
     R3D_SetLightDirection(light, (Vector3){-1, -1, -1});
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
     R3D_SetLightRange(light, 16.0f);
     R3D_SetShadowSoftness(light, 2.0f);
     R3D_EnableShadow(light);

--- a/examples/to_texture.c
+++ b/examples/to_texture.c
@@ -20,9 +20,9 @@ int main(void)
 
     // Create light
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
-    R3D_LightLookAt(light, (Vector3){0, 10, 5}, (Vector3){0});
+    R3D_SetLightTarget(light, (Vector3){0, 10, 5}, (Vector3){0});
     R3D_EnableShadow(light);
-    R3D_SetLightActive(light, true);
+    R3D_EnableLight(light);
 
     // Render texture
     RenderTexture target = LoadRenderTexture(1024, 512);

--- a/examples/transparency.c
+++ b/examples/transparency.c
@@ -44,8 +44,8 @@ int main(void)
     // Setup lighting
     R3D_ENVIRONMENT_SET(ambient.color, (Color){10, 10, 10, 255});
     R3D_Light light = R3D_CreateLight(R3D_LIGHT_SPOT);
-    R3D_LightLookAt(light, (Vector3){0, 10, 5}, (Vector3){0});
-    R3D_SetLightActive(light, true);
+    R3D_SetLightTarget(light, (Vector3){0, 10, 5}, (Vector3){0});
+    R3D_EnableLight(light);
     R3D_EnableShadow(light);
 
     // Main loop

--- a/include/r3d/r3d_lighting.h
+++ b/include/r3d/r3d_lighting.h
@@ -99,7 +99,7 @@ R3DAPI void R3D_DestroyLight(R3D_Light id);
  * @param id The ID of the light to check.
  * @return True if the light exists, false otherwise.
  */
-R3DAPI bool R3D_IsLightExist(R3D_Light id);
+R3DAPI bool R3D_IsLightValid(R3D_Light id);
 
 /**
  * @brief Gets the type of a light.
@@ -112,34 +112,37 @@ R3DAPI bool R3D_IsLightExist(R3D_Light id);
 R3DAPI R3D_LightType R3D_GetLightType(R3D_Light id);
 
 /**
- * @brief Checks if a light is active.
+ * @brief Returns whether a light is currently enabled.
  *
- * This function checks whether the specified light is currently active (enabled or disabled).
- *
- * @param id The ID of the light to check.
- * @return True if the light is active, false otherwise.
+ * @param id The ID of the light to query.
+ * @return True if the light is enabled, false otherwise.
  */
-R3DAPI bool R3D_IsLightActive(R3D_Light id);
+R3DAPI bool R3D_IsLightEnabled(R3D_Light id);
 
 /**
- * @brief Toggles the state of a light (active or inactive).
- *
- * This function toggles the state of the specified light, turning it on if it is off,
- * or off if it is on.
+ * @brief Toggles a light between enabled and disabled states.
  *
  * @param id The ID of the light to toggle.
  */
 R3DAPI void R3D_ToggleLight(R3D_Light id);
 
 /**
- * @brief Sets the active state of a light.
+ * @brief Enables a light.
  *
- * This function allows manually turning a light on or off by specifying its active state.
+ * Has no effect if the light is already enabled.
  *
- * @param id The ID of the light to set the active state for.
- * @param active True to activate the light, false to deactivate it.
+ * @param id The ID of the light to enable.
  */
-R3DAPI void R3D_SetLightActive(R3D_Light id, bool active);
+R3DAPI void R3D_EnableLight(R3D_Light id);
+
+/**
+ * @brief Disables a light.
+ *
+ * Has no effect if the light is already disabled.
+ *
+ * @param id The ID of the light to disable.
+ */
+R3DAPI void R3D_DisableLight(R3D_Light id);
 
 /**
  * @brief Gets the color of a light.
@@ -251,7 +254,7 @@ R3DAPI void R3D_SetLightDirection(R3D_Light id, Vector3 direction);
  * @param position The position to set for the light.
  * @param target The point the light should look at.
  */
-R3DAPI void R3D_LightLookAt(R3D_Light id, Vector3 position, Vector3 target);
+R3DAPI void R3D_SetLightTarget(R3D_Light id, Vector3 position, Vector3 target);
 
 /**
  * @brief Gets the energy level of a light.
@@ -320,74 +323,59 @@ R3DAPI float R3D_GetLightRange(R3D_Light id);
 R3DAPI void R3D_SetLightRange(R3D_Light id, float range);
 
 /**
- * @brief Gets the attenuation factor of a light.
+ * @brief Gets the falloff exponent of a light.
  *
- * This function retrieves the attenuation factor of the specified light.
- * Attenuation controls how the intensity of a light decreases with distance.
- * Only applicable to spot lights or omni-lights.
+ * Controls the shape of the attenuation curve over the light's range.
+ * A value of 1.0 produces a linear falloff, 2.0 a quadratic (more physically
+ * plausible) falloff, and higher values concentrate the light closer to the source.
+ * Only applicable to spot lights and omni-lights.
  *
  * @param id The ID of the light.
- * @return The attenuation factor of the light.
+ * @return The falloff exponent of the light.
  */
-R3DAPI float R3D_GetLightAttenuation(R3D_Light id);
+R3DAPI float R3D_GetLightFalloff(R3D_Light id);
 
 /**
- * @brief Sets the attenuation factor of a light.
+ * @brief Sets the falloff exponent of a light.
  *
- * This function sets the attenuation factor of the specified light.
- * A higher attenuation value causes the light to lose intensity more quickly as the distance increases.
- * For a realistic effect, an attenuation factor of 2.0f is typically used.
- * Only applicable to spot lights or omni-lights.
+ * Controls the shape of the attenuation curve over the light's range.
+ * A value of 1.0 produces a linear falloff, 2.0 a quadratic (more physically
+ * plausible) falloff, and higher values concentrate the light closer to the source.
+ * Values of 0.0 or below are clamped to 1.0.
+ * Only applicable to spot lights and omni-lights.
  *
  * @param id The ID of the light.
- * @param attenuation The new attenuation factor to set for the light.
+ * @param falloff The falloff exponent to set. Typical range is [0.5, 4.0].
  */
-R3DAPI void R3D_SetLightAttenuation(R3D_Light id, float attenuation);
+R3DAPI void R3D_SetLightFalloff(R3D_Light id, float falloff);
 
 /**
- * @brief Gets the inner cutoff angle of a spotlight.
+ * @brief Gets the inner and outer cone angles of a spot light.
  *
- * This function retrieves the inner cutoff angle of a spotlight.
- * The inner cutoff defines the cone of light where the light is at full intensity.
+ * The inner angle defines the region of full intensity, and the outer angle
+ * defines where the light fully fades out. The transition between the two
+ * produces a soft edge. Both angles are in degrees.
+ * Only applicable to spot lights.
  *
  * @param id The ID of the light.
- * @return The inner cutoff angle in degrees of the spotlight.
+ * @param inner Pointer to receive the inner cone angle, in degrees. May be NULL.
+ * @param outer Pointer to receive the outer cone angle, in degrees. May be NULL.
  */
-R3DAPI float R3D_GetLightInnerCutOff(R3D_Light id);
+R3DAPI void R3D_GetLightAngle(R3D_Light id, float* inner, float* outer);
 
 /**
- * @brief Sets the inner cutoff angle of a spotlight.
+ * @brief Sets the inner and outer cone angles of a spot light.
  *
- * This function sets the inner cutoff angle of a spotlight.
- * The inner cutoff angle defines the cone where the light is at full intensity.
- * Anything outside this cone starts to fade.
- *
- * @param id The ID of the light.
- * @param degrees The new inner cutoff angle in degrees.
- */
-R3DAPI void R3D_SetLightInnerCutOff(R3D_Light id, float degrees);
-
-/**
- * @brief Gets the outer cutoff angle of a spotlight.
- *
- * This function retrieves the outer cutoff angle of a spotlight.
- * The outer cutoff defines the outer boundary of the light's cone, where the light starts to fade.
+ * The inner angle defines the region of full intensity, and the outer angle
+ * defines where the light fully fades out. The transition between the two
+ * produces a soft edge. Both angles are in degrees and must satisfy inner <= outer.
+ * Only applicable to spot lights.
  *
  * @param id The ID of the light.
- * @return The outer cutoff angle in degrees of the spotlight.
+ * @param inner The inner cone half-angle, in degrees.
+ * @param outer The outer cone half-angle, in degrees.
  */
-R3DAPI float R3D_GetLightOuterCutOff(R3D_Light id);
-
-/**
- * @brief Sets the outer cutoff angle of a spotlight.
- *
- * This function sets the outer cutoff angle of a spotlight.
- * The outer cutoff defines the boundary of the light's cone where the light intensity starts to gradually decrease.
- *
- * @param id The ID of the light.
- * @param degrees The new outer cutoff angle in degrees.
- */
-R3DAPI void R3D_SetLightOuterCutOff(R3D_Light id, float degrees);
+R3DAPI void R3D_SetLightAngle(R3D_Light id, float inner, float outer);
 
 // ----------------------------------------
 // LIGHTING: Shadow Config Functions
@@ -455,28 +443,24 @@ R3DAPI R3D_ShadowUpdateMode R3D_GetShadowUpdateMode(R3D_Light id);
 R3DAPI void R3D_SetShadowUpdateMode(R3D_Light id, R3D_ShadowUpdateMode mode);
 
 /**
- * @brief Gets the frequency of shadow map updates for the interval update mode.
+ * @brief Gets the interval between shadow map updates in interval update mode.
  *
- * This function retrieves the frequency (in milliseconds) at which the shadow map should be updated when
- * the interval update mode is enabled. This function is only relevant if the shadow map update mode is set
- * to "Interval".
+ * Only relevant when the shadow update mode is set to @ref R3D_SHADOW_UPDATE_INTERVAL.
  *
  * @param id The ID of the light.
- * @return The frequency in milliseconds at which the shadow map is updated.
+ * @return The interval in seconds between shadow map updates.
  */
-R3DAPI int R3D_GetShadowUpdateFrequency(R3D_Light id);
+R3DAPI float R3D_GetShadowUpdateInterval(R3D_Light id);
 
 /**
- * @brief Sets the frequency of shadow map updates for the interval update mode.
+ * @brief Sets the interval between shadow map updates in interval update mode.
  *
- * This function sets the frequency (in milliseconds) at which the shadow map should be updated when
- * the interval update mode is enabled. This function is only relevant if the shadow map update mode is set
- * to "Interval".
+ * Only relevant when the shadow update mode is set to @ref R3D_SHADOW_UPDATE_INTERVAL.
  *
  * @param id The ID of the light.
- * @param msec The frequency in milliseconds at which to update the shadow map.
+ * @param seconds The interval in seconds between shadow map updates.
  */
-R3DAPI void R3D_SetShadowUpdateFrequency(R3D_Light id, int msec);
+R3DAPI void R3D_SetShadowUpdateInterval(R3D_Light id, float seconds);
 
 /**
  * @brief Forces an immediate update of the shadow map during the next rendering pass.
@@ -630,7 +614,7 @@ R3DAPI BoundingBox R3D_GetLightBoundingBox(R3D_Light light);
  *
  * @param id The ID of the light.
  */
-R3DAPI void R3D_DrawLightShape(R3D_Light id);
+R3DAPI void R3D_DrawLightDebug(R3D_Light id);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/r3d/r3d_lighting.h
+++ b/include/r3d/r3d_lighting.h
@@ -368,7 +368,8 @@ R3DAPI void R3D_GetLightAngle(R3D_Light id, float* inner, float* outer);
  *
  * The inner angle defines the region of full intensity, and the outer angle
  * defines where the light fully fades out. The transition between the two
- * produces a soft edge. Both angles are in degrees and must satisfy inner <= outer.
+ * produces a soft edge. Both angles are in degrees. If inner exceeds outer,
+ * the two values are swapped automatically.
  * Only applicable to spot lights.
  *
  * @param id The ID of the light.

--- a/include/r3d/r3d_probe.h
+++ b/include/r3d/r3d_probe.h
@@ -81,12 +81,12 @@ R3DAPI R3D_Probe R3D_CreateProbe(R3D_ProbeFlags flags);
 R3DAPI void R3D_DestroyProbe(R3D_Probe id);
 
 /**
- * @brief Returns whether a probe exists.
+ * @brief Returns whether a probe ID is valid and allocated.
  *
  * @param id Probe ID.
- * @return true if the probe is valid and allocated, otherwise false.
+ * @return true if the probe exists, otherwise false.
  */
-R3DAPI bool R3D_IsProbeExist(R3D_Probe id);
+R3DAPI bool R3D_IsProbeValid(R3D_Probe id);
 
 /**
  * @brief Returns the probe flags.
@@ -97,22 +97,42 @@ R3DAPI bool R3D_IsProbeExist(R3D_Probe id);
 R3DAPI R3D_ProbeFlags R3D_GetProbeFlags(R3D_Probe id);
 
 /**
- * @brief Returns whether a probe is currently active.
+ * @brief Returns whether a probe is currently enabled.
  *
- * Inactive probes do not contribute to lighting.
+ * Disabled probes do not contribute to lighting.
  *
  * @param id Probe ID.
- * @return true if active, otherwise false.
+ * @return true if the probe is enabled, otherwise false.
  */
-R3DAPI bool R3D_IsProbeActive(R3D_Probe id);
+R3DAPI bool R3D_IsProbeEnabled(R3D_Probe id);
 
 /**
- * @brief Enables or disables a probe.
+ * @brief Toggles a probe between enabled and disabled states.
+ *
+ * Re-enabling a probe schedules a scene capture on the next frame.
  *
  * @param id Probe ID.
- * @param active Set to true to enable the probe.
  */
-R3DAPI void R3D_SetProbeActive(R3D_Probe id, bool active);
+R3DAPI void R3D_ToggleProbe(R3D_Probe id);
+
+/**
+ * @brief Enables a probe.
+ *
+ * Schedules a scene capture on the next frame.
+ * Has no effect if the probe is already enabled.
+ *
+ * @param id Probe ID.
+ */
+R3DAPI void R3D_EnableProbe(R3D_Probe id);
+
+/**
+ * @brief Disables a probe.
+ *
+ * Has no effect if the probe is already disabled.
+ *
+ * @param id Probe ID.
+ */
+R3DAPI void R3D_DisableProbe(R3D_Probe id);
 
 /**
  * @brief Gets the probe update mode.

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -113,8 +113,8 @@ void main()
     float shadow = 1.0;
 
     if (uLight.type != LIGHT_DIR) {
-        float atten = 1.0 - clamp(Ldist / uLight.range, 0.0, 1.0);
-        shadow *= atten * uLight.attenuation;
+        float atten = pow(1.0 - clamp(Ldist / uLight.range, 0.0, 1.0), uLight.falloff);
+        shadow *= atten;
     }
 
     if (uLight.type == LIGHT_SPOT) {

--- a/shaders/include/blocks/light.glsl
+++ b/shaders/include/blocks/light.glsl
@@ -59,7 +59,7 @@ struct Light {
     float range;
     float near;
     float far;
-    float attenuation;
+    float falloff;
     float innerCutOff;
     float outerCutOff;
     float shadowSoftness;

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -146,8 +146,8 @@ void main()
         float shadow = 1.0;
 
         if (light.type != LIGHT_DIR) {
-            float atten = 1.0 - clamp(Ldist / light.range, 0.0, 1.0);
-            shadow *= atten * light.attenuation;
+            float atten = pow(1.0 - clamp(Ldist / light.range, 0.0, 1.0), light.falloff);
+            shadow *= atten;
         }
 
         if (light.type == LIGHT_SPOT) {

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -214,8 +214,8 @@ static bool init_light(r3d_light_t* light, R3D_LightType type)
         .shadowUpdate = R3D_SHADOW_UPDATE_INTERVAL,
         .shadowShouldBeUpdated = true,
         .matrixShouldBeUpdated = true,
-        .shadowFrequencySec = 0.016f,
-        .shadowTimerSec = 0.0f
+        .shadowUpdateInterval = 0.016f,
+        .shadowUpdateTimer = 0.0f
     };
 
     light->shadowLayer = -1;
@@ -230,7 +230,7 @@ static bool init_light(r3d_light_t* light, R3D_LightType type)
     light->specular = 0.5f;
     light->energy = 1.0f;
     light->range = 50.0f;
-    light->attenuation = 1.0f;
+    light->falloff = 1.0f;
     light->innerCutOff = cosf(22.5f * DEG2RAD);
     light->outerCutOff = cosf(45.0f * DEG2RAD);
 
@@ -267,9 +267,9 @@ static void update_light_shadow_state(r3d_light_t* light)
         break;
     case R3D_SHADOW_UPDATE_INTERVAL:
         if (!light->state.shadowShouldBeUpdated) {
-            light->state.shadowTimerSec += GetFrameTime();
-            if (light->state.shadowTimerSec >= light->state.shadowFrequencySec) {
-                light->state.shadowTimerSec -= light->state.shadowFrequencySec;
+            light->state.shadowUpdateTimer += GetFrameTime();
+            if (light->state.shadowUpdateTimer >= light->state.shadowUpdateInterval) {
+                light->state.shadowUpdateTimer -= light->state.shadowUpdateInterval;
                 light->state.shadowShouldBeUpdated = true;
             }
         }

--- a/src/modules/r3d_light.h
+++ b/src/modules/r3d_light.h
@@ -42,8 +42,8 @@ static const int R3D_LIGHT_SHADOW_SIZE[] = {
 
 typedef struct {
     R3D_ShadowUpdateMode shadowUpdate;
-    float shadowFrequencySec;
-    float shadowTimerSec;
+    float shadowUpdateInterval;
+    float shadowUpdateTimer;
     bool shadowShouldBeUpdated;
     bool matrixShouldBeUpdated;
 } r3d_light_state_t;
@@ -66,7 +66,7 @@ typedef struct {
     float range;                // Maximum distance (spot/omni)
     float near;                 // Near plane for shadow projection
     float far;                  // Far plane for shadow projection
-    float attenuation;          // Additional attenuation (spot/omni)
+    float falloff;              // Distance falloff factor (spot/omni)
     float innerCutOff;          // Spot light inner cutoff angle
     float outerCutOff;          // Spot light outer cutoff angle
     float shadowSoftness;       // Softness factor for penumbra

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -532,7 +532,7 @@ typedef struct {
     alignas(4) float range;
     alignas(4) float near;
     alignas(4) float far;
-    alignas(4) float attenuation;
+    alignas(4) float falloff;
     alignas(4) float innerCutOff;
     alignas(4) float outerCutOff;
     alignas(4) float shadowSoftness;

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -726,7 +726,7 @@ void upload_light_array_block_for_mesh(const r3d_render_call_t* call, bool shado
         data->range = light->range;
         data->near = light->near;
         data->far = light->far;
-        data->attenuation = light->attenuation;
+        data->falloff = light->falloff;
         data->innerCutOff = light->innerCutOff;
         data->outerCutOff = light->outerCutOff;
         data->shadowSoftness = light->shadowSoftness;
@@ -2053,7 +2053,7 @@ void pass_deferred_lights(void)
             .range = light->range,
             .near = light->near,
             .far = light->far,
-            .attenuation = light->attenuation,
+            .falloff = light->falloff,
             .innerCutOff = light->innerCutOff,
             .outerCutOff = light->outerCutOff,
             .shadowSoftness = light->shadowSoftness,

--- a/src/r3d_lighting.c
+++ b/src/r3d_lighting.c
@@ -241,6 +241,12 @@ void R3D_SetLightAngle(R3D_Light id, float inner, float outer)
         return;
     }
 
+    if (inner > outer) {
+        float tmp = inner;
+        inner = outer;
+        outer = tmp;
+    }
+
     float i = cosf(inner * DEG2RAD);
     float o = cosf(outer * DEG2RAD);
 

--- a/src/r3d_lighting.c
+++ b/src/r3d_lighting.c
@@ -1,4 +1,4 @@
-/* r3d_lighting.h -- R3D Lighting Module.
+/* r3d_lighting.c -- R3D Lighting Module.
  *
  * Copyright (c) 2025-2026 Le Juez Victor
  *
@@ -42,7 +42,7 @@ void R3D_DestroyLight(R3D_Light id)
     r3d_light_delete(id);
 }
 
-bool R3D_IsLightExist(R3D_Light id)
+bool R3D_IsLightValid(R3D_Light id)
 {
     return r3d_light_is_valid(id);
 }
@@ -53,7 +53,7 @@ R3D_LightType R3D_GetLightType(R3D_Light id)
     return light->type;
 }
 
-bool R3D_IsLightActive(R3D_Light id)
+bool R3D_IsLightEnabled(R3D_Light id)
 {
     GET_LIGHT_OR_RETURN(light, id, false);
     return light->enabled;
@@ -69,19 +69,22 @@ void R3D_ToggleLight(R3D_Light id)
     }
 }
 
-void R3D_SetLightActive(R3D_Light id, bool active)
+void R3D_EnableLight(R3D_Light id)
 {
     GET_LIGHT_OR_RETURN(light, id);
+    if (light->enabled) return;
 
-    if (light->enabled == active) {
-        return;
-    }
-
-    if (active && light->shadowLayer >= 0) {
+    if (light->shadowLayer >= 0) {
         light->state.shadowShouldBeUpdated = true;
     }
+    light->enabled = true;
+}
 
-    light->enabled = active;
+void R3D_DisableLight(R3D_Light id)
+{
+    GET_LIGHT_OR_RETURN(light, id);
+    if (!light->enabled) return;
+    light->enabled = false;
 }
 
 Color R3D_GetLightColor(R3D_Light id)
@@ -153,7 +156,7 @@ void R3D_SetLightDirection(R3D_Light id, Vector3 direction)
     light->direction = Vector3Normalize(direction);
 }
 
-void R3D_LightLookAt(R3D_Light id, Vector3 position, Vector3 target)
+void R3D_SetLightTarget(R3D_Light id, Vector3 position, Vector3 target)
 {
     GET_LIGHT_OR_RETURN(light, id);
 
@@ -206,55 +209,53 @@ void R3D_SetLightRange(R3D_Light id, float range)
     light->range = range;
 }
 
-float R3D_GetLightAttenuation(R3D_Light id)
+float R3D_GetLightFalloff(R3D_Light id)
 {
     GET_LIGHT_OR_RETURN(light, id, 0);
-    return 1.0f / light->attenuation;
+    return light->falloff;
 }
 
-void R3D_SetLightAttenuation(R3D_Light id, float attenuation)
+void R3D_SetLightFalloff(R3D_Light id, float falloff)
 {
     GET_LIGHT_OR_RETURN(light, id);
     if (light->type == R3D_LIGHT_DIR) {
-        R3D_TRACELOG(LOG_WARNING, "Can't set attenuation for light [ID %i]; it's directional and doesn't have attenuation", id);
+        R3D_TRACELOG(LOG_WARNING, "Can't set falloff for light [ID %i]; it's directional and doesn't have falloff", id);
         return;
     }
-    light->attenuation = (attenuation > 1e-4f) ? 1.0f / attenuation : 10000.0f;
+    light->falloff = Clamp(falloff, 0.0f, 1.0f);
 }
 
-float R3D_GetLightInnerCutOff(R3D_Light id)
-{
-    GET_LIGHT_OR_RETURN(light, id, 0);
-    return acosf(light->innerCutOff) * RAD2DEG;
-}
-
-void R3D_SetLightInnerCutOff(R3D_Light id, float degrees)
-{
-    GET_LIGHT_OR_RETURN(light, id);
-    if (light->type == R3D_LIGHT_DIR || light->type == R3D_LIGHT_OMNI) {
-        R3D_TRACELOG(LOG_WARNING, "Can't set inner cutoff for light [ID %i]; it's directional or omni and doesn't have angle attenuation", id);
-        return;
-    }
-    light->innerCutOff = cosf(degrees * DEG2RAD);
-}
-
-float R3D_GetLightOuterCutOff(R3D_Light id)
-{
-    GET_LIGHT_OR_RETURN(light, id, 0);
-    return acosf(light->outerCutOff) * RAD2DEG;
-}
-
-void R3D_SetLightOuterCutOff(R3D_Light id, float degrees)
+void R3D_GetLightAngle(R3D_Light id, float* inner, float* outer)
 {
     GET_LIGHT_OR_RETURN(light, id);
 
+    if (inner) *inner = acosf(light->innerCutOff) * RAD2DEG;
+    if (outer) *outer = acosf(light->outerCutOff) * RAD2DEG;
+}
+
+void R3D_SetLightAngle(R3D_Light id, float inner, float outer)
+{
+    GET_LIGHT_OR_RETURN(light, id);
     if (light->type == R3D_LIGHT_DIR || light->type == R3D_LIGHT_OMNI) {
-        R3D_TRACELOG(LOG_WARNING, "Can't set outer cutoff for light [ID %i]; it's directional or omni and doesn't have angle attenuation", id);
+        R3D_TRACELOG(LOG_WARNING, "Can't set angle for light [ID %i]; it's directional or omni and doesn't have angle attenuation", id);
         return;
     }
 
-    light->state.matrixShouldBeUpdated = true;
-    light->outerCutOff = cosf(degrees * DEG2RAD);
+    float i = cosf(inner * DEG2RAD);
+    float o = cosf(outer * DEG2RAD);
+
+    if (fabsf(o - light->outerCutOff) > 1e-4f) {
+        light->state.matrixShouldBeUpdated = true;
+    }
+
+    light->innerCutOff = i;
+    light->outerCutOff = o;
+}
+
+bool R3D_IsShadowEnabled(R3D_Light id)
+{
+    GET_LIGHT_OR_RETURN(light, id, false);
+    return light->shadowLayer >= 0;
 }
 
 void R3D_EnableShadow(R3D_Light id)
@@ -272,12 +273,6 @@ void R3D_DisableShadow(R3D_Light id)
     r3d_light_disable_shadows(light);
 }
 
-bool R3D_IsShadowEnabled(R3D_Light id)
-{
-    GET_LIGHT_OR_RETURN(light, id, false);
-    return light->shadowLayer >= 0;
-}
-
 R3D_ShadowUpdateMode R3D_GetShadowUpdateMode(R3D_Light id)
 {
     GET_LIGHT_OR_RETURN(light, id, 0);
@@ -290,16 +285,16 @@ void R3D_SetShadowUpdateMode(R3D_Light id, R3D_ShadowUpdateMode mode)
     light->state.shadowUpdate = mode;
 }
 
-int R3D_GetShadowUpdateFrequency(R3D_Light id)
+float R3D_GetShadowUpdateInterval(R3D_Light id)
 {
-    GET_LIGHT_OR_RETURN(light, id, 0);
-    return (int)(light->state.shadowFrequencySec * 1000);
+    GET_LIGHT_OR_RETURN(light, id, 0.0f);
+    return light->state.shadowUpdateInterval;
 }
 
-void R3D_SetShadowUpdateFrequency(R3D_Light id, int msec)
+void R3D_SetShadowUpdateInterval(R3D_Light id, float sec)
 {
     GET_LIGHT_OR_RETURN(light, id);
-    light->state.shadowFrequencySec = (float)msec / 1000;
+    light->state.shadowUpdateInterval = sec;
 }
 
 void R3D_UpdateShadowMap(R3D_Light id)
@@ -398,7 +393,7 @@ BoundingBox R3D_GetLightBoundingBox(R3D_Light id)
     return light->aabb;
 }
 
-void R3D_DrawLightShape(R3D_Light id)
+void R3D_DrawLightDebug(R3D_Light id)
 {
     GET_LIGHT_OR_RETURN(light, id);
 

--- a/src/r3d_probe.c
+++ b/src/r3d_probe.c
@@ -41,31 +41,47 @@ void R3D_DestroyProbe(R3D_Probe id)
     r3d_env_probe_delete(id);
 }
 
-bool R3D_IsProbeExist(R3D_Probe id)
+bool R3D_IsProbeValid(R3D_Probe id)
 {
     return r3d_env_probe_is_valid(id);
 }
 
-R3D_ProbeFlags R3D_GetProbeType(R3D_Probe id)
+R3D_ProbeFlags R3D_GetProbeFlags(R3D_Probe id)
 {
     GET_PROBE_OR_RETURN(probe, id, 0);
     return probe->flags;
 }
 
-bool R3D_IsProbeActive(R3D_Probe id)
+bool R3D_IsProbeEnabled(R3D_Probe id)
 {
     GET_PROBE_OR_RETURN(probe, id, 0);
     return probe->enabled;
 }
 
-void R3D_SetProbeActive(R3D_Probe id, bool active)
+void R3D_ToggleProbe(R3D_Probe id)
 {
     GET_PROBE_OR_RETURN(probe, id);
+    probe->enabled = !probe->enabled;
 
-    if (probe->enabled == active) return;
-    if (active) probe->state.sceneShouldBeUpdated = true;
+    if (probe->enabled) {
+        probe->state.sceneShouldBeUpdated = true;
+    }
+}
 
-    probe->enabled = active;
+void R3D_EnableProbe(R3D_Probe id)
+{
+    GET_PROBE_OR_RETURN(probe, id);
+    if (probe->enabled) return;
+
+    probe->state.sceneShouldBeUpdated = true;
+    probe->enabled = true;
+}
+
+void R3D_DisableProbe(R3D_Probe id)
+{
+    GET_PROBE_OR_RETURN(probe, id);
+    if (!probe->enabled) return;
+    probe->enabled = false;
 }
 
 R3D_ProbeUpdateMode R3D_GetProbeUpdateMode(R3D_Probe id)
@@ -155,9 +171,5 @@ float R3D_GetProbeFalloff(R3D_Probe id)
 void R3D_SetProbeFalloff(R3D_Probe id, float falloff)
 {
     GET_PROBE_OR_RETURN(probe, id);
-
-    if (probe->falloff != falloff) {
-        probe->state.sceneShouldBeUpdated = true;
-        probe->falloff = falloff;
-    }
+    probe->falloff = falloff;
 }


### PR DESCRIPTION
## Overview

As we approach the final release, the public API will undergo a series of
breaking changes to ensure consistency, clarity and long-term stability.

This PR is the first step of that process, focusing on the lighting and
probe modules.

## Changes

### Naming

- `R3D_IsLightExist` -> `R3D_IsLightValid`
- `R3D_IsLightActive` -> `R3D_IsLightEnabled`
- `R3D_SetLightActive(id, bool)` -> `R3D_EnableLight(id)` / `R3D_DisableLight(id)`
- `R3D_LightLookAt` -> `R3D_SetLightTarget`
- `R3D_GetLightAttenuation` / `R3D_SetLightAttenuation` -> `R3D_GetLightFalloff` / `R3D_SetLightFalloff`
- `R3D_GetShadowUpdateFrequency` / `R3D_SetShadowUpdateFrequency` -> `R3D_GetShadowUpdateInterval` / `R3D_SetShadowUpdateInterval`
- `R3D_DrawLightShape` -> `R3D_DrawLightDebug`
- `R3D_IsProbeExist` -> `R3D_IsProbeValid`
- `R3D_IsProbeActive` -> `R3D_IsProbeEnabled`
- `R3D_SetProbeActive(id, bool)` -> `R3D_EnableProbe(id)` / `R3D_DisableProbe(id)`

### Spot light cone angles

`SetLightInnerCutOff` and `SetLightOuterCutOff` have been merged into a single
call to lighten the API and prevent invalid states where `inner > outer`:

```c
void R3D_SetLightAngle(R3D_Light id, float inner, float outer); // degrees
void R3D_GetLightAngle(R3D_Light id, float* inner, float* outer);
```

### Shadow update interval

Now expressed as a `float` in seconds instead of an `int` in milliseconds,
consistent with `GetFrameTime()`.

### Distance attenuation model

The attenuation formula has been replaced by a power curve:

```glsl
// Before
float atten = (1.0 - clamp(Ldist / light.range, 0.0, 1.0)) * light.attenuation;

// After
float atten = pow(1.0 - clamp(Ldist / light.range, 0.0, 1.0), light.falloff);
```

The falloff exponent is now stored and exposed directly without inversion.
A value of `1.0` is linear, `2.0` is quadratic. Values at or below `0.0`
are clamped to `1.0`.

**Existing attenuation values are not compatible and must be reviewed.**