### PR TITLE
Volumetric Fog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,9 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/deferred/lighting.frag"
     "${R3D_ROOT_PATH}/shaders/deferred/compose.frag"
     "${R3D_ROOT_PATH}/shaders/deferred/fog.frag"
+    "${R3D_ROOT_PATH}/shaders/deferred/vfog_transmittance.frag"
+    "${R3D_ROOT_PATH}/shaders/deferred/vfog_radiance.frag"
+    "${R3D_ROOT_PATH}/shaders/deferred/vfog_compose.frag"
     # Post
     "${R3D_ROOT_PATH}/shaders/post/dof.frag"
     "${R3D_ROOT_PATH}/shaders/post/bloom.frag"

--- a/include/r3d/r3d_environment.h
+++ b/include/r3d/r3d_environment.h
@@ -104,11 +104,23 @@
         },                                              \
         .fog = {                                        \
             .mode = R3D_FOG_DISABLED,                   \
-            .color = {255, 255, 255, 255},              \
+            .color = WHITE,                             \
             .start = 1.0f,                              \
             .end = 50.0f,                               \
             .density = 0.05f,                           \
             .skyAffect = 0.5f,                          \
+        },                                              \
+        .volumetricFog = {                              \
+            .scatteringDensity = 0.01f,                 \
+            .absortionDensity = 0.03f,                  \
+            .scatteringColor = WHITE,                   \
+            .anisotropy = 0.5f,                         \
+            .emissionColor = WHITE,                     \
+            .emissionEnergy = 0.0f,                     \
+            .skyAffect = 0.5f,                          \
+            .length = 50.0f,                            \
+            .stepSize = 1.0f,                           \
+            .enabled = false,                           \
         },                                              \
         .dof = {                                        \
             .mode = R3D_DOF_DISABLED,                   \
@@ -283,7 +295,7 @@ typedef struct R3D_EnvSSR {
 } R3D_EnvSSR;
 
 /**
- * @brief Fog atmospheric effect settings.
+ * @brief Atmospheric fog effect settings.
  */
 typedef struct R3D_EnvFog {
     R3D_Fog mode;           ///< Fog distribution mode (default: R3D_FOG_DISABLED)
@@ -293,6 +305,22 @@ typedef struct R3D_EnvFog {
     float density;          ///< Exponential modes: fog thickness factor (default: 0.05)
     float skyAffect;        ///< Fog influence on skybox [0-1] (default: 0.5)
 } R3D_EnvFog;
+
+/**
+ * @brief Volumetric fog effect settings.
+ */
+typedef struct R3D_VolumetricFog {
+    float scatteringDensity;    ///< Light scattering thickness; higher = more visible light rays (default: 0.01)
+    float absortionDensity;     ///< Light absorption thickness; higher = darker scene (default: 0.03)
+    Color scatteringColor;      ///< Tint color of scattered light rays (default: WHITE)
+    float anisotropy;           ///< Scattering direction: 0 = uniform, >0 = forward (haze), <0 = backward (default: 0.5)
+    Color emissionColor;        ///< Color emitted by the fog regardless of lighting (default: WHITE)
+    float emissionEnergy;       ///< Emission brightness; 0 disables emission (default: 0.0)
+    float skyAffect;            ///< Fog influence on the skybox [0-1] (default: 0.5)
+    float length;               ///< Maximum fog render distance in world units (default: 50.0)
+    float stepSize;             ///< Ray-march step size; smaller = higher quality, lower performance (default: 1.0)
+    bool enabled;               ///< Enables or disables the volumetric fog (default: false)
+} R3D_VolumetricFog;
 
 /**
  * @brief Depth of Field (DoF) camera focus settings.
@@ -379,6 +407,7 @@ typedef struct R3D_Environment {
     R3D_EnvSSGI         ssgi;           ///< Screen space global illumination
     R3D_EnvSSR          ssr;            ///< Screen space reflections
     R3D_EnvFog          fog;            ///< Atmospheric fog
+    R3D_VolumetricFog   volumetricFog;  ///< Volumetric fog
     R3D_EnvDoF          dof;            ///< Depth of field focus effect
     R3D_EnvBloom        bloom;          ///< Bloom glow effect
     R3D_EnvAutoExposure autoExposure;   ///< Auto exposure effect

--- a/shaders/deferred/fog.frag
+++ b/shaders/deferred/fog.frag
@@ -8,6 +8,7 @@
 
 #version 330 core
 
+#include "../include/blocks/view.glsl"
 #include "../include/blocks/fog.glsl"
 
 noperspective in vec2 vTexCoord;
@@ -17,5 +18,5 @@ out vec4 FragColor;
 void main()
 {
     float depth = texelFetch(uDepthTex, ivec2(gl_FragCoord.xy), 0).r;
-    FragColor = FogColorAlpha(depth);
+    FragColor = FogColorAlpha(depth, uView.far);
 }

--- a/shaders/deferred/vfog_compose.frag
+++ b/shaders/deferred/vfog_compose.frag
@@ -1,0 +1,87 @@
+/* vfog_compose.frag -- Fragment shader for volumetric fog radiance composition
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+/* === Varyings === */
+
+noperspective in vec2 vTexCoord;
+
+/* === Uniforms === */
+
+uniform sampler2D uRadianceTex;
+uniform sampler2D uDepthTex;
+
+/* === Fragments === */
+
+out vec4 FragRadiance;
+
+/* === Helper Functions === */
+
+vec4 Upsample(sampler2D source, vec2 texCoord, ivec2 size, float refDepth, float depthSharpness)
+{
+    ivec2 maxCoord = size - ivec2(1);
+
+    vec2 pixLow = texCoord * vec2(size) - 0.5;
+    vec2 base = floor(pixLow);
+    vec2 f = pixLow - base;
+
+    ivec2 p00 = clamp(ivec2(base),               ivec2(0), maxCoord);
+    ivec2 p10 = clamp(ivec2(base) + ivec2(1, 0), ivec2(0), maxCoord);
+    ivec2 p01 = clamp(ivec2(base) + ivec2(0, 1), ivec2(0), maxCoord);
+    ivec2 p11 = clamp(ivec2(base) + ivec2(1, 1), ivec2(0), maxCoord);
+
+    vec4 w = vec4(
+        (1.0 - f.x) * (1.0 - f.y),
+        f.x         * (1.0 - f.y),
+        (1.0 - f.x) * f.y,
+        f.x         * f.y
+    );
+
+    vec4 d = vec4(
+        texelFetch(uDepthTex, p00, 1).r,
+        texelFetch(uDepthTex, p10, 1).r,
+        texelFetch(uDepthTex, p01, 1).r,
+        texelFetch(uDepthTex, p11, 1).r
+    );
+    w *= exp(-abs(d - vec4(refDepth)) * depthSharpness);
+
+    float invWSum = 1.0 / max(w.x + w.y + w.z + w.w, 1e-5);
+
+    return (
+        texelFetch(source, p00, 0) * w.x +
+        texelFetch(source, p10, 0) * w.y +
+        texelFetch(source, p01, 0) * w.z +
+        texelFetch(source, p11, 0) * w.w
+    ) * invWSum;
+}
+
+vec4 SampleRotated(sampler2D source, vec2 texCoord)
+{
+    ivec2 size = textureSize(source, 0);
+    vec2 t = 1.0 / vec2(size);
+
+    // Fetch reference depth and sharpness once for all 4 upsample calls
+    float refDepth = texelFetch(uDepthTex, ivec2(gl_FragCoord.xy), 0).r;
+    float depthSharpness = 1.0 / max(refDepth * 0.1, 0.05);
+
+    // Rotated grid offsets (26.57°) to break up the half-res 2x2 block pattern
+    vec4 c0 = Upsample(source, texCoord + vec2( t.x,        t.y * 0.5), size, refDepth, depthSharpness);
+    vec4 c1 = Upsample(source, texCoord + vec2(-t.x * 0.5,  t.y      ), size, refDepth, depthSharpness);
+    vec4 c2 = Upsample(source, texCoord + vec2(-t.x,       -t.y * 0.5), size, refDepth, depthSharpness);
+    vec4 c3 = Upsample(source, texCoord + vec2( t.x * 0.5, -t.y      ), size, refDepth, depthSharpness);
+
+    return (c0 + c1 + c2 + c3) * 0.25;
+}
+
+/* === Main Function === */
+
+void main()
+{
+    FragRadiance = SampleRotated(uRadianceTex, vTexCoord);
+}

--- a/shaders/deferred/vfog_radiance.frag
+++ b/shaders/deferred/vfog_radiance.frag
@@ -1,0 +1,136 @@
+/* vfog_radiance.frag -- Fragment shader of volumetric fog radiance
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+/* === Extensions === */
+
+#extension GL_ARB_texture_cube_map_array : enable
+
+/* === Includes === */
+
+#include "../include/math.glsl"
+
+/* === Varyings === */
+
+noperspective in vec2 vTexCoord;
+
+/* === Uniforms === */
+
+uniform sampler2D uDepthTex;
+
+uniform sampler2DArrayShadow uShadowDirTex;
+uniform sampler2DArrayShadow uShadowSpotTex;
+uniform samplerCubeArrayShadow uShadowOmniTex;
+
+uniform float uStepSize;
+uniform float uLength;
+uniform float uScatteringDensity;
+uniform float uAbsortionDensity;
+uniform vec3  uScatteringColor;
+uniform float uAnisotropy;
+uniform float uSkyAffect;
+
+/* === Blocks === */
+
+#define L_SHADOW_IMPL
+#include "../include/blocks/light.glsl"
+#include "../include/blocks/view.glsl"
+
+/* === Fragments === */
+
+out vec3 FragRadiance;
+
+/* === Helper Functions === */
+
+float PhaseFunction_Schlick(vec3 w0, vec3 w1)
+{
+    // Both vectors assumed normalized; skip length division
+    float cosTheta = dot(w0, w1);
+    float nom = 1.0 - uAnisotropy * uAnisotropy;
+    float denom = 4.0 * M_PI * (1.0 + uAnisotropy * cosTheta) * (1.0 + uAnisotropy * cosTheta);
+    return nom / denom;
+}
+
+/* === Main Function === */
+
+void main()
+{
+    ivec2 pixCoord = ivec2(gl_FragCoord.xy);
+
+    float depth = texelFetch(uDepthTex, pixCoord, 0).r;
+    vec3 P = V_GetWorldPosition(vTexCoord, depth);
+
+    vec3 rayDir = normalize(P - uView.position);
+    float rayDist = min(length(P - uView.position), uLength);
+
+    vec3 marchPos = uView.position;
+    vec3 deltaStep = rayDir * uStepSize;
+    vec3 fragToCameraNorm = -rayDir; // view direction along the ray
+
+    // Jitter starting position to break up banding, adjust ray length to avoid overshooting
+    float jitter = M_HashIGN(gl_FragCoord.xy);
+    marchPos += deltaStep * jitter;
+    rayDist -= uStepSize * jitter;
+
+    vec3 radiance = vec3(0.0);
+    float transmittance = 1.0;
+
+    // Extinction coefficient and per-step transmittance factor (constant along the ray)
+    float sigmaT = uScatteringDensity + uAbsortionDensity;
+    float transmittanceStep = exp(-sigmaT * uStepSize);
+
+    // Precalculate constant terms
+    vec3 lightColor = uLight.color * uLight.energy;
+    mat2 diskRot = L_ShadowDebandingMatrix(gl_FragCoord.xy);
+    bool hasShadow = uLight.shadowLayer >= 0 && uLight.shadowOpacity != 0.0;
+
+    for (float l = 0; l < rayDist; l += uStepSize)
+    {
+        // Compute light direction and distance at each march step
+        vec3 Ldelta = uLight.position - marchPos;
+        float Ldist = length(Ldelta);
+        vec3 L = (uLight.type == LIGHT_DIR) ? -uLight.direction : Ldelta / max(Ldist, 1e-4);
+
+        // Shadow visibility at current march position
+        float visibility = 1.0;
+        if (hasShadow) {
+            switch (uLight.type) {
+            case LIGHT_DIR:  visibility *= L_SampleShadowDir(marchPos, depth, 1.0, diskRot); break;
+            case LIGHT_SPOT: visibility *= L_SampleShadowSpot(marchPos, 1.0, diskRot); break;
+            case LIGHT_OMNI: visibility *= L_SampleShadowOmni(marchPos, 1.0, diskRot); break;
+            }
+        }
+
+        // Range attenuation (omni and spot only)
+        if (uLight.type != LIGHT_DIR) {
+            float atten = pow(1.0 - clamp(Ldist / uLight.range, 0.0, 1.0), uLight.falloff);
+            visibility *= atten;
+        }
+
+        // Angular attenuation (spot only)
+        if (uLight.type == LIGHT_SPOT) {
+            float theta   = dot(L, -uLight.direction);
+            float epsilon = uLight.innerCutOff - uLight.outerCutOff;
+            visibility   *= smoothstep(0.0, 1.0, (theta - uLight.outerCutOff) / epsilon);
+        }
+
+        // In-scattering: phase function * scattering coefficient * incident radiance
+        float phase = PhaseFunction_Schlick(L, fragToCameraNorm);
+        vec3 Li = uScatteringDensity * uScatteringColor * phase * lightColor * visibility;
+
+        // Accumulate transmittance then integrate radiance (order matters)
+        transmittance *= transmittanceStep;
+        radiance += Li * transmittance * uStepSize;
+
+        marchPos += deltaStep;
+    }
+
+    // Attenuate contribution on sky pixels
+    FragRadiance = (depth >= uView.far) ? radiance * uSkyAffect : radiance;
+}

--- a/shaders/deferred/vfog_transmittance.frag
+++ b/shaders/deferred/vfog_transmittance.frag
@@ -1,0 +1,61 @@
+/* vfog_transmittance.frag -- Fragment shader of volumetric fog transmittance
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+/* === Includes === */
+
+#include "../include/math.glsl"
+
+/* === Varyings === */
+
+noperspective in vec2 vTexCoord;
+
+/* === Uniforms === */
+
+uniform sampler2D uDepthTex;
+
+uniform float uStepSize;
+uniform float uLength;
+uniform float uScatteringDensity;
+uniform float uAbsortionDensity;
+uniform vec3  uEmissionColor;
+uniform float uEmissionEnergy;
+uniform float uSkyAffect;
+
+/* === Blocks === */
+
+#include "../include/blocks/view.glsl"
+
+/* === Fragments === */
+
+out vec4 FragColor; // rgb = emission, a = transmittance (composed via blend mode)
+
+/* === Main Function === */
+
+void main()
+{
+    float depth = texelFetch(uDepthTex, ivec2(gl_FragCoord.xy), 0).r;
+    float rayDist = min(depth, uLength);
+
+    // Analytic transmittance over the full ray distance
+    float sigmaT = uScatteringDensity + uAbsortionDensity;
+    float transmittance = exp(-sigmaT * rayDist);
+
+    // Emission fills the volume proportionally to extinction
+    float extinction = 1.0 - transmittance;
+    vec3 emission = uEmissionColor * (uEmissionEnergy * extinction);
+
+    // Scale effect on sky pixels
+    if (depth >= uView.far) {
+        transmittance = mix(1.0, transmittance, uSkyAffect);  // 0 = no effect, 1 = full effect
+        emission *= uSkyAffect;                               // mix(vec3(0), emission, t) == emission * t
+    }
+
+    FragColor = vec4(emission, transmittance);
+}

--- a/shaders/include/blocks/fog.glsl
+++ b/shaders/include/blocks/fog.glsl
@@ -55,23 +55,17 @@ float FogFactor(float dist)
     return 0.0; // FOG_DISABLED
 }
 
-vec4 FogColorAlpha(float dist)
+vec4 FogColorAlpha(float depth, float far)
 {
-    return vec4(uFog.color, FogFactor(dist));
+    return vec4(uFog.color, (depth >= far) ? uFog.skyAffect : FogFactor(depth));
 }
 
-vec3 FogColorMix(vec3 color, float dist)
+vec3 FogColorMix(vec3 color, float depth)
 {
-    return mix(color, uFog.color, FogFactor(dist));
+    return mix(color, uFog.color, FogFactor(depth));
 }
 
-vec4 FogColorMix(vec4 color, float dist)
+vec4 FogColorMix(vec4 color, float depth)
 {
-    return vec4(mix(color.rgb, uFog.color, FogFactor(dist)), color.a);
-}
-
-vec3 FogSkyMix(vec3 sky)
-{
-    if (uFog.mode == FOG_DISABLED) return sky;
-    return mix(sky, uFog.color, uFog.skyAffect);
+    return vec4(mix(color.rgb, uFog.color, FogFactor(depth)), color.a);
 }

--- a/shaders/scene/skybox.frag
+++ b/shaders/scene/skybox.frag
@@ -10,7 +10,6 @@
 
 /* === Includes === */
 
-#include "../include/blocks/fog.glsl"
 #include "../include/math.glsl"
 
 /* === Varyings === */
@@ -35,5 +34,4 @@ void main()
     vec3 direction = normalize(vViewRay);
     direction = M_Rotate3D(direction, uRotation);
     FragColor = textureLod(uSkyMap, direction, uLod).rgb * uEnergy;
-    FragColor = FogSkyMix(FragColor);
 }

--- a/src/modules/r3d_driver.c
+++ b/src/modules/r3d_driver.c
@@ -105,6 +105,8 @@ typedef struct {
     pipeline_entry_t blendEquation;
     pipeline_entry_t blendSrcFactor;
     pipeline_entry_t blendDstFactor;
+    pipeline_entry_t blendSrcAlpha;
+    pipeline_entry_t blendDstAlpha;
     GLint viewport[4];
 } pipeline_cache_t;
 
@@ -346,6 +348,25 @@ void r3d_driver_set_stencil_mask(uint8_t mask)
     }
 }
 
+void r3d_driver_set_blend_func_separate(GLenum equation, GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha)
+{
+    if (CHECK_PIPE(blendEquation, enum, equation)) {
+        SET_PIPE(blendEquation, enum, equation);
+        glBlendEquation(equation);
+    }
+
+    bool rgbDirty   = CHECK_PIPE(blendSrcFactor, enum, srcRGB)  || CHECK_PIPE(blendDstFactor, enum, dstRGB);
+    bool alphaDirty = CHECK_PIPE(blendSrcAlpha,  enum, srcAlpha) || CHECK_PIPE(blendDstAlpha,  enum, dstAlpha);
+
+    if (rgbDirty || alphaDirty) {
+        SET_PIPE(blendSrcFactor, enum, srcRGB);
+        SET_PIPE(blendDstFactor, enum, dstRGB);
+        SET_PIPE(blendSrcAlpha,  enum, srcAlpha);
+        SET_PIPE(blendDstAlpha,  enum, dstAlpha);
+        glBlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+    }
+}
+
 void r3d_driver_set_blend_func(GLenum equation, GLenum srcFactor, GLenum dstFactor)
 {
     if (CHECK_PIPE(blendEquation, enum, equation)) {
@@ -353,9 +374,14 @@ void r3d_driver_set_blend_func(GLenum equation, GLenum srcFactor, GLenum dstFact
         glBlendEquation(equation);
     }
 
-    if (CHECK_PIPE(blendSrcFactor, enum, srcFactor) || CHECK_PIPE(blendDstFactor, enum, dstFactor)) {
+    if (CHECK_PIPE(blendSrcFactor, enum, srcFactor) || CHECK_PIPE(blendDstFactor, enum, dstFactor)
+    ||  CHECK_PIPE(blendSrcAlpha,  enum, srcFactor) || CHECK_PIPE(blendDstAlpha,  enum, dstFactor))
+    {
         SET_PIPE(blendSrcFactor, enum, srcFactor);
         SET_PIPE(blendDstFactor, enum, dstFactor);
+        SET_PIPE(blendSrcAlpha,  enum, srcFactor);
+        SET_PIPE(blendDstAlpha,  enum, dstFactor);
+        // glBlendFunc est équivalent à glBlendFuncSeparate avec src/dst identiques pour rgb et alpha
         glBlendFunc(srcFactor, dstFactor);
     }
 }

--- a/src/modules/r3d_driver.c
+++ b/src/modules/r3d_driver.c
@@ -381,7 +381,6 @@ void r3d_driver_set_blend_func(GLenum equation, GLenum srcFactor, GLenum dstFact
         SET_PIPE(blendDstFactor, enum, dstFactor);
         SET_PIPE(blendSrcAlpha,  enum, srcFactor);
         SET_PIPE(blendDstAlpha,  enum, dstFactor);
-        // glBlendFunc est équivalent à glBlendFuncSeparate avec src/dst identiques pour rgb et alpha
         glBlendFunc(srcFactor, dstFactor);
     }
 }

--- a/src/modules/r3d_driver.h
+++ b/src/modules/r3d_driver.h
@@ -102,6 +102,11 @@ void r3d_driver_set_stencil_op(GLenum fail, GLenum zFail, GLenum zPass);
 void r3d_driver_set_stencil_mask(uint8_t mask);
 
 /*
+ * Sets separate blend factors for RGB and alpha channels.
+ */
+void r3d_driver_set_blend_func_separate(GLenum equation, GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha);
+
+/*
  * Sets the blend equation and blend factors.
  */
 void r3d_driver_set_blend_func(GLenum equation, GLenum srcFactor, GLenum dstFactor);

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -65,6 +65,9 @@
 #include <shaders/lighting.frag.h>
 #include <shaders/compose.frag.h>
 #include <shaders/fog.frag.h>
+#include <shaders/vfog_transmittance.frag.h>
+#include <shaders/vfog_radiance.frag.h>
+#include <shaders/vfog_compose.frag.h>
 #include <shaders/dof.frag.h>
 #include <shaders/bloom.frag.h>
 #include <shaders/auto_exposure.frag.h>
@@ -1365,6 +1368,64 @@ bool r3d_shader_load_deferred_fog(r3d_shader_custom_t* custom)
     return true;
 }
 
+bool r3d_shader_load_deferred_vfog_transmittance(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_deferred_vfog_transmittance_t, deferred, vfogTransmittance);
+    LOAD_SHADER(vfogTransmittance, SCREEN_VERT, VFOG_TRANSMITTANCE_FRAG);
+
+    SET_UNIFORM_BUFFER(vfogTransmittance, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
+
+    GET_LOCATION(vfogTransmittance, uStepSize);
+    GET_LOCATION(vfogTransmittance, uLength);
+    GET_LOCATION(vfogTransmittance, uScatteringDensity);
+    GET_LOCATION(vfogTransmittance, uAbsortionDensity);
+    GET_LOCATION(vfogTransmittance, uEmissionColor);
+    GET_LOCATION(vfogTransmittance, uEmissionEnergy);
+    GET_LOCATION(vfogTransmittance, uSkyAffect);
+
+    USE_SHADER(vfogTransmittance);
+    SET_SAMPLER(vfogTransmittance, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+
+    return true;
+}
+
+bool r3d_shader_load_deferred_vfog_radiance(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_deferred_vfog_radiance_t, deferred, vfogRadiance);
+    LOAD_SHADER(vfogRadiance, SCREEN_VERT, VFOG_RADIANCE_FRAG);
+
+    SET_UNIFORM_BUFFER(vfogRadiance, LightBlock, R3D_SHADER_BLOCK_SLOT_LIGHT);
+    SET_UNIFORM_BUFFER(vfogRadiance, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
+
+    GET_LOCATION(vfogRadiance, uStepSize);
+    GET_LOCATION(vfogRadiance, uLength);
+    GET_LOCATION(vfogRadiance, uScatteringDensity);
+    GET_LOCATION(vfogRadiance, uAbsortionDensity);
+    GET_LOCATION(vfogRadiance, uScatteringColor);
+    GET_LOCATION(vfogRadiance, uAnisotropy);
+    GET_LOCATION(vfogRadiance, uSkyAffect);
+
+    USE_SHADER(vfogRadiance);
+    SET_SAMPLER(vfogRadiance, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+    SET_SAMPLER(vfogRadiance, uShadowDirTex, R3D_SHADER_SAMPLER_SHADOW_DIR);
+    SET_SAMPLER(vfogRadiance, uShadowSpotTex, R3D_SHADER_SAMPLER_SHADOW_SPOT);
+    SET_SAMPLER(vfogRadiance, uShadowOmniTex, R3D_SHADER_SAMPLER_SHADOW_OMNI);
+
+    return true;
+}
+
+bool r3d_shader_load_deferred_vfog_compose(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_deferred_vfog_compose_t, deferred, vfogCompose);
+    LOAD_SHADER(vfogCompose, SCREEN_VERT, VFOG_COMPOSE_FRAG);
+
+    USE_SHADER(vfogCompose);
+    SET_SAMPLER(vfogCompose, uRadianceTex, R3D_SHADER_SAMPLER_BUFFER_VFOG_RAD);
+    SET_SAMPLER(vfogCompose, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+
+    return true;
+}
+
 bool r3d_shader_load_post_dof(r3d_shader_custom_t* custom)
 {
     DECL_SHADER(r3d_shader_post_dof_t, post, dof);
@@ -1671,6 +1732,9 @@ void r3d_shader_quit()
     UNLOAD_SHADER(deferred.lighting);
     UNLOAD_SHADER(deferred.compose);
     UNLOAD_SHADER(deferred.fog);
+    UNLOAD_SHADER(deferred.vfogTransmittance);
+    UNLOAD_SHADER(deferred.vfogRadiance);
+    UNLOAD_SHADER(deferred.vfogCompose);
 
     UNLOAD_SHADER(post.dof);
     UNLOAD_SHADER(post.bloom);

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -964,8 +964,6 @@ bool r3d_shader_load_scene_skybox(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_scene_skybox_t, scene, skybox);
     LOAD_SHADER(skybox, SKYBOX_VERT, SKYBOX_FRAG);
 
-    SET_UNIFORM_BUFFER(skybox, FogBlock, R3D_SHADER_BLOCK_SLOT_FOG);
-
     GET_LOCATION(skybox, uMatInvView);
     GET_LOCATION(skybox, uMatInvProj);
     GET_LOCATION(skybox, uRotation);
@@ -1361,6 +1359,7 @@ bool r3d_shader_load_deferred_fog(r3d_shader_custom_t* custom)
     LOAD_SHADER(fog, SCREEN_VERT, FOG_FRAG);
 
     SET_UNIFORM_BUFFER(fog, FogBlock, R3D_SHADER_BLOCK_SLOT_FOG);
+    SET_UNIFORM_BUFFER(fog, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
 
     USE_SHADER(fog);
     SET_SAMPLER(fog, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -346,24 +346,25 @@ typedef enum {
     R3D_SHADER_SAMPLER_BUFFER_DIFFUSE       = 25,
     R3D_SHADER_SAMPLER_BUFFER_SPECULAR      = 26,
     R3D_SHADER_SAMPLER_BUFFER_SELECTOR      = 27,
-    R3D_SHADER_SAMPLER_BUFFER_SSAO          = 28,
-    R3D_SHADER_SAMPLER_BUFFER_SSIL          = 29,
-    R3D_SHADER_SAMPLER_BUFFER_SSGI          = 30,
-    R3D_SHADER_SAMPLER_BUFFER_SSR           = 31,
-    R3D_SHADER_SAMPLER_BUFFER_DOF_COC       = 32,
-    R3D_SHADER_SAMPLER_BUFFER_DOF           = 33,
-    R3D_SHADER_SAMPLER_BUFFER_BLOOM         = 34,
-    R3D_SHADER_SAMPLER_BUFFER_LUMINANCE     = 35,
-    R3D_SHADER_SAMPLER_BUFFER_EXPOSURE      = 36,
-    R3D_SHADER_SAMPLER_BUFFER_SMAA_EDGES    = 37,
-    R3D_SHADER_SAMPLER_BUFFER_SMAA_BLEND    = 38,
-    R3D_SHADER_SAMPLER_BUFFER_SCENE         = 39,
+    R3D_SHADER_SAMPLER_BUFFER_VFOG_RAD      = 28,
+    R3D_SHADER_SAMPLER_BUFFER_SSAO          = 29,
+    R3D_SHADER_SAMPLER_BUFFER_SSIL          = 30,
+    R3D_SHADER_SAMPLER_BUFFER_SSGI          = 31,
+    R3D_SHADER_SAMPLER_BUFFER_SSR           = 32,
+    R3D_SHADER_SAMPLER_BUFFER_DOF_COC       = 33,
+    R3D_SHADER_SAMPLER_BUFFER_DOF           = 34,
+    R3D_SHADER_SAMPLER_BUFFER_BLOOM         = 35,
+    R3D_SHADER_SAMPLER_BUFFER_LUMINANCE     = 36,
+    R3D_SHADER_SAMPLER_BUFFER_EXPOSURE      = 37,
+    R3D_SHADER_SAMPLER_BUFFER_SMAA_EDGES    = 38,
+    R3D_SHADER_SAMPLER_BUFFER_SMAA_BLEND    = 39,
+    R3D_SHADER_SAMPLER_BUFFER_SCENE         = 40,
 
     // Unamed for special passes
-    R3D_SHADER_SAMPLER_SOURCE_1D_0          = 40,
-    R3D_SHADER_SAMPLER_SOURCE_2D_0          = 41,
-    R3D_SHADER_SAMPLER_SOURCE_2D_1          = 42,
-    R3D_SHADER_SAMPLER_SOURCE_CUBE_0        = 43,
+    R3D_SHADER_SAMPLER_SOURCE_1D_0          = 41,
+    R3D_SHADER_SAMPLER_SOURCE_2D_0          = 42,
+    R3D_SHADER_SAMPLER_SOURCE_2D_1          = 43,
+    R3D_SHADER_SAMPLER_SOURCE_CUBE_0        = 44,
 
     // Custom samplers
     R3D_SHADER_SAMPLER_CUSTOM_1D            = 45,
@@ -402,6 +403,7 @@ static const GLenum R3D_MOD_SHADER_SAMPLER_TYPES[R3D_SHADER_SAMPLER_COUNT] =
     [R3D_SHADER_SAMPLER_BUFFER_SPECULAR]        = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_SELECTOR]        = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_GEOM_NORMAL]     = GL_TEXTURE_2D,
+    [R3D_SHADER_SAMPLER_BUFFER_VFOG_RAD]        = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_SSAO]            = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_SSIL]            = GL_TEXTURE_2D,
     [R3D_SHADER_SAMPLER_BUFFER_SSGI]            = GL_TEXTURE_2D,
@@ -1061,6 +1063,39 @@ typedef struct {
 
 typedef struct {
     GLuint id;
+    r3d_shader_uniform_sampler_t uDepthTex;
+    r3d_shader_uniform_float_t uStepSize;
+    r3d_shader_uniform_float_t uLength;
+    r3d_shader_uniform_float_t uScatteringDensity;
+    r3d_shader_uniform_float_t uAbsortionDensity;
+    r3d_shader_uniform_col3_t uEmissionColor;
+    r3d_shader_uniform_float_t uEmissionEnergy;
+    r3d_shader_uniform_float_t uSkyAffect;
+} r3d_shader_deferred_vfog_transmittance_t;
+
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uDepthTex;
+    r3d_shader_uniform_sampler_t uShadowDirTex;
+    r3d_shader_uniform_sampler_t uShadowSpotTex;
+    r3d_shader_uniform_sampler_t uShadowOmniTex;
+    r3d_shader_uniform_float_t uStepSize;
+    r3d_shader_uniform_float_t uLength;
+    r3d_shader_uniform_float_t uScatteringDensity;
+    r3d_shader_uniform_float_t uAbsortionDensity;
+    r3d_shader_uniform_col3_t uScatteringColor;
+    r3d_shader_uniform_float_t uAnisotropy;
+    r3d_shader_uniform_float_t uSkyAffect;
+} r3d_shader_deferred_vfog_radiance_t;
+
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uRadianceTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
+} r3d_shader_deferred_vfog_compose_t;
+
+typedef struct {
+    GLuint id;
     r3d_shader_uniform_sampler_t uSceneTex;
     r3d_shader_uniform_sampler_t uBlurTex;
 } r3d_shader_post_dof_t;
@@ -1245,6 +1280,9 @@ extern struct r3d_mod_shader {
         r3d_shader_deferred_lighting_t lighting;
         r3d_shader_deferred_compose_t compose;
         r3d_shader_deferred_fog_t fog;
+        r3d_shader_deferred_vfog_transmittance_t vfogTransmittance;
+        r3d_shader_deferred_vfog_radiance_t vfogRadiance;
+        r3d_shader_deferred_vfog_compose_t vfogCompose;
     } deferred;
 
     // Post shaders
@@ -1321,6 +1359,9 @@ bool r3d_shader_load_deferred_ambient(r3d_shader_custom_t* custom);
 bool r3d_shader_load_deferred_lighting(r3d_shader_custom_t* custom);
 bool r3d_shader_load_deferred_compose(r3d_shader_custom_t* custom);
 bool r3d_shader_load_deferred_fog(r3d_shader_custom_t* custom);
+bool r3d_shader_load_deferred_vfog_transmittance(r3d_shader_custom_t* custom);
+bool r3d_shader_load_deferred_vfog_radiance(r3d_shader_custom_t* custom);
+bool r3d_shader_load_deferred_vfog_compose(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_dof(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_bloom(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_auto_exposure(r3d_shader_custom_t* custom);
@@ -1394,6 +1435,9 @@ static const struct r3d_shader_loader {
         r3d_shader_loader_func lighting;
         r3d_shader_loader_func compose;
         r3d_shader_loader_func fog;
+        r3d_shader_loader_func vfogTransmittance;
+        r3d_shader_loader_func vfogRadiance;
+        r3d_shader_loader_func vfogCompose;
      } deferred;
 
     // Post shaders
@@ -1472,6 +1516,9 @@ static const struct r3d_shader_loader {
         .lighting = r3d_shader_load_deferred_lighting,
         .compose = r3d_shader_load_deferred_compose,
         .fog = r3d_shader_load_deferred_fog,
+        .vfogTransmittance = r3d_shader_load_deferred_vfog_transmittance,
+        .vfogRadiance = r3d_shader_load_deferred_vfog_radiance,
+        .vfogCompose = r3d_shader_load_deferred_vfog_compose,
     },
 
     .post = {

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -84,6 +84,7 @@ static const target_config_t TARGET_CONFIG[] = {
     [R3D_TARGET_SPECULAR]    = { FORMAT_RGB16F,  1.0f, GL_NEAREST,              GL_NEAREST, 2, {0} },
     [R3D_TARGET_GEOM_NORMAL] = { FORMAT_RG16,    1.0f, GL_NEAREST,              GL_NEAREST, 1, {0} },
     [R3D_TARGET_SELECTOR]    = { FORMAT_R8UI,    0.5f, GL_NEAREST,              GL_NEAREST, 2, {0} },
+    [R3D_TARGET_VFOG_RAD]    = { FORMAT_RGB16F,  0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSAO_0]      = { FORMAT_R8,      0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSAO_1]      = { FORMAT_R8,      0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },
     [R3D_TARGET_SSIL_0]      = { FORMAT_RGBA16F, 0.5f, GL_LINEAR,               GL_LINEAR,  1, {0} },

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -32,6 +32,7 @@ typedef enum {
     R3D_TARGET_SPECULAR,        //< Full - Mip 2 - RGB16F
     R3D_TARGET_GEOM_NORMAL,     //< Full - Mip 1 - RG16
     R3D_TARGET_SELECTOR,        //< Half - Mip 2 - R8UI
+    R3D_TARGET_VFOG_RAD,        //< Half - Mip 1 - RGB16F
     R3D_TARGET_SSAO_0,          //< Half - Mip 1 - R8
     R3D_TARGET_SSAO_1,          //< Half - Mip 1 - R8
     R3D_TARGET_SSIL_0,          //< Half - Mip 1 - RGBA16F

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -88,6 +88,7 @@ static void pass_deferred_lights(void);
 static void pass_deferred_ambient(r3d_target_t ssaoSource, r3d_target_t ssilSource, r3d_target_t ssgiSource);
 static void pass_deferred_compose(r3d_target_t sceneTarget, r3d_target_t ssrSource);
 static void pass_deferred_fog(r3d_target_t sceneTarget);
+static void pass_deferred_volumetric_fog(r3d_target_t sceneTarget);
 
 static void pass_scene_forward(r3d_target_t sceneTarget);
 static void pass_scene_background(r3d_target_t sceneTarget);
@@ -214,9 +215,10 @@ void R3D_End(void)
         bool ssil = R3D.environment.ssil.enabled;
         bool ssgi = R3D.environment.ssgi.enabled;
         bool ssr = R3D.environment.ssr.enabled;
+        bool vfog = R3D.environment.volumetricFog.enabled;
         bool dof = R3D.environment.dof.mode;
 
-        if (ssao || ssil || ssgi || ssr || dof) {
+        if (ssao || ssil || ssgi || ssr || vfog || dof) {
             pass_prepare_depth_pyramid();
         }
 
@@ -242,6 +244,10 @@ void R3D_End(void)
     /* --- Then background and transparent rendering --- */
 
     pass_scene_background(sceneTarget);
+
+    if (R3D.environment.volumetricFog.enabled) {
+        pass_deferred_volumetric_fog(sceneTarget);
+    }
 
     if (r3d_render_has_forward() || r3d_render_has_prepass()) {
         pass_scene_forward(sceneTarget);
@@ -2153,6 +2159,99 @@ void pass_deferred_fog(r3d_target_t sceneTarget)
     R3D_SHADER_USE(deferred.fog);
 
     R3D_SHADER_BIND_SAMPLER(deferred.fog, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 0));
+    R3D_RENDER_SCREEN();
+}
+
+void pass_deferred_volumetric_fog(r3d_target_t sceneTarget)
+{
+    r3d_driver_disable(GL_STENCIL_TEST);
+    r3d_driver_disable(GL_DEPTH_TEST);
+    r3d_driver_disable(GL_CULL_FACE);
+
+    /* --- Apply transmittance --- */
+
+    r3d_driver_enable(GL_BLEND);
+    r3d_driver_set_blend_func_separate(GL_FUNC_ADD, GL_ONE, GL_SRC_ALPHA, GL_ZERO, GL_ONE);
+
+    R3D_TARGET_BIND(false, sceneTarget);
+
+    R3D_SHADER_USE(deferred.vfogTransmittance);
+    R3D_SHADER_BIND_SAMPLER(deferred.vfogTransmittance, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 0));
+    R3D_SHADER_SET_FLOAT(deferred.vfogTransmittance, uStepSize, R3D.environment.volumetricFog.stepSize);
+    R3D_SHADER_SET_FLOAT(deferred.vfogTransmittance, uLength, R3D.environment.volumetricFog.length);
+    R3D_SHADER_SET_FLOAT(deferred.vfogTransmittance, uScatteringDensity, R3D.environment.volumetricFog.scatteringDensity);
+    R3D_SHADER_SET_FLOAT(deferred.vfogTransmittance, uAbsortionDensity, R3D.environment.volumetricFog.absortionDensity);
+    R3D_SHADER_SET_COL3(deferred.vfogTransmittance, uEmissionColor, R3D.colorSpace, R3D.environment.volumetricFog.emissionColor);
+    R3D_SHADER_SET_FLOAT(deferred.vfogTransmittance, uEmissionEnergy, R3D.environment.volumetricFog.emissionEnergy);
+    R3D_SHADER_SET_FLOAT(deferred.vfogTransmittance, uSkyAffect, R3D.environment.volumetricFog.skyAffect);
+
+    R3D_RENDER_SCREEN();
+
+    /* --- Accumulate radiance in half resolution --- */
+
+    r3d_driver_enable(GL_SCISSOR_TEST);
+    r3d_driver_enable(GL_BLEND);
+    r3d_driver_set_blend_func(GL_FUNC_ADD, GL_ONE, GL_ONE);
+
+    R3D_TARGET_CLEAR(false, R3D_TARGET_VFOG_RAD);
+
+    R3D_SHADER_USE(deferred.vfogRadiance);
+    R3D_SHADER_BIND_SAMPLER(deferred.vfogRadiance, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 1));
+    R3D_SHADER_SET_FLOAT(deferred.vfogRadiance, uStepSize, R3D.environment.volumetricFog.stepSize);
+    R3D_SHADER_SET_FLOAT(deferred.vfogRadiance, uLength, R3D.environment.volumetricFog.length);
+    R3D_SHADER_SET_FLOAT(deferred.vfogRadiance, uScatteringDensity, R3D.environment.volumetricFog.scatteringDensity);
+    R3D_SHADER_SET_FLOAT(deferred.vfogRadiance, uAbsortionDensity, R3D.environment.volumetricFog.absortionDensity);
+    R3D_SHADER_SET_COL3(deferred.vfogRadiance, uScatteringColor, R3D.colorSpace, R3D.environment.volumetricFog.scatteringColor);
+    R3D_SHADER_SET_FLOAT(deferred.vfogRadiance, uAnisotropy, R3D.environment.volumetricFog.anisotropy);
+    R3D_SHADER_SET_FLOAT(deferred.vfogRadiance, uSkyAffect, R3D.environment.volumetricFog.skyAffect);
+
+    R3D_LIGHT_FOR_EACH_VISIBLE(light)
+    {
+        r3d_rect_t dst = {0, 0, R3D_TARGET_SIZE_W/2, R3D_TARGET_SIZE_H/2};
+        if (light->type != R3D_LIGHT_DIR) {
+            dst = r3d_light_get_screen_rect(light, &R3D.viewState.viewProj, dst.w, dst.h);
+            if (memcmp(&dst, &(r3d_rect_t){0}, sizeof(r3d_rect_t)) == 0) continue;
+        }
+        glScissor(dst.x, dst.y, dst.w, dst.h);
+
+        r3d_shader_block_light_t data = {
+            .viewProj = MatrixTranspose(light->viewProj[0]),
+            .color = light->color,
+            .position = light->position,
+            .direction = light->direction,
+            .specular = light->specular,
+            .energy = light->energy,
+            .range = light->range,
+            .near = light->near,
+            .far = light->far,
+            .falloff = light->falloff,
+            .innerCutOff = light->innerCutOff,
+            .outerCutOff = light->outerCutOff,
+            .shadowSoftness = light->shadowSoftness,
+            .shadowOpacity = light->shadowOpacity,
+            .shadowDepthBias = light->shadowDepthBias,
+            .shadowSlopeBias = light->shadowSlopeBias,
+            .shadowLayer = light->shadowLayer,
+            .type = light->type,
+        };
+        r3d_shader_set_uniform_block(R3D_SHADER_BLOCK_LIGHT, &data, true);
+
+        R3D_RENDER_SCREEN();
+    }
+
+    r3d_driver_disable(GL_SCISSOR_TEST);
+
+    /* --- Compose radiance to the scene --- */
+
+    R3D_TARGET_BIND(false, sceneTarget);
+    R3D_SHADER_USE(deferred.vfogCompose);
+
+    r3d_driver_enable(GL_BLEND);
+    r3d_driver_set_blend_func(GL_FUNC_ADD, GL_ONE, GL_ONE);
+
+    R3D_SHADER_BIND_SAMPLER(deferred.vfogCompose, uRadianceTex, r3d_target_get_level(R3D_TARGET_VFOG_RAD, 0));
+    R3D_SHADER_BIND_SAMPLER(deferred.vfogCompose, uDepthTex, r3d_target_get_levels(R3D_TARGET_DEPTH, 0, 1));
+
     R3D_RENDER_SCREEN();
 }
 

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -229,10 +229,6 @@ void R3D_End(void)
 
         if (ssr) ssrSource = pass_prepare_ssr();
         pass_deferred_compose(sceneTarget, ssrSource);
-
-        if (R3D.environment.fog.mode != R3D_FOG_DISABLED) {
-            pass_deferred_fog(sceneTarget);
-        }
     }
     else {
         int numLevels = r3d_target_get_num_levels(R3D_TARGET_DEPTH);
@@ -241,9 +237,13 @@ void R3D_End(void)
         }
     }
 
-    /* --- Then background and transparent rendering --- */
+    /* --- Then background/fog and transparent rendering --- */
 
     pass_scene_background(sceneTarget);
+
+    if (R3D.environment.fog.mode != R3D_FOG_DISABLED) {
+        pass_deferred_fog(sceneTarget);
+    }
 
     if (R3D.environment.volumetricFog.enabled) {
         pass_deferred_volumetric_fog(sceneTarget);
@@ -2146,11 +2146,8 @@ void pass_deferred_compose(r3d_target_t sceneTarget, r3d_target_t ssrSource)
 void pass_deferred_fog(r3d_target_t sceneTarget)
 {
     r3d_driver_disable(GL_STENCIL_TEST);
+    r3d_driver_disable(GL_DEPTH_TEST);
     r3d_driver_disable(GL_CULL_FACE);
-
-    r3d_driver_enable(GL_DEPTH_TEST);
-    r3d_driver_set_depth_func(GL_GREATER);
-    r3d_driver_set_depth_mask(GL_FALSE);
 
     r3d_driver_enable(GL_BLEND);
     r3d_driver_set_blend_func(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -2307,7 +2304,6 @@ void pass_scene_background(r3d_target_t sceneTarget)
     r3d_driver_set_depth_mask(GL_FALSE);
 
     const R3D_EnvBackground* bg = &R3D.environment.background;
-    const R3D_EnvFog* fog = &R3D.environment.fog;
 
     if (bg->sky.texture != 0) {
         R3D_SHADER_USE(scene.skybox);
@@ -2320,11 +2316,9 @@ void pass_scene_background(r3d_target_t sceneTarget)
         R3D_SHADER_SET_MAT4(scene.skybox, uMatInvProj, R3D.viewState.invProj);
     }
     else {
-        Vector3 bgColor = r3d_color_to_linear_scaled_vec3(bg->color, R3D.colorSpace, bg->energy);
-        if (fog->mode != R3D_FOG_DISABLED) {
-            Vector3 fogColor = r3d_color_to_linear_vec3(fog->color, R3D.colorSpace);
-            bgColor = Vector3Lerp(bgColor, fogColor, fog->skyAffect);
-        }
+        Vector3 bgColor = r3d_color_to_linear_scaled_vec3(
+            bg->color, R3D.colorSpace, bg->energy
+        );
         R3D_SHADER_USE(scene.background);
         R3D_SHADER_SET_VEC4(scene.background, uColor, (Vector4) {bgColor.x, bgColor.y, bgColor.z, 1.0f});
     }


### PR DESCRIPTION
## Overview

This PR adds a physically-based volumetric fog effect to R3D,
computed at half resolution via multiple passes for performance.

The effect simulates how light scatters through fog or haze, supporting all
three light types (directional, spot, omni) including shadow-casting lights.
Each light contributes visible rays and glow through the volume, with an
anisotropy parameter to control whether light scatters evenly or favors a
particular direction.

The pipeline consists of three passes:

- **Transmittance**: analytical extinction applied directly to the scene via
  hardware blending, with optional emission color to tint the fog volume
  independently of lighting.
- **Radiance**: per-light ray-marching at half resolution, accumulated
  additively into a shared buffer using scissor-culled draw calls.
- **Composition**: depth-aware bilateral upsampling with rotated-grid filtering
  to reconstruct the radiance buffer at full resolution without too much visible
  half-resolution artifacts.

**Current limitation:** volumetric fog is applied to opaque geometry and the
skybox only. Transparent objects are not yet supported, as doing so requires
additional pipeline considerations to handle correctly and efficiently. As a
temporary workaround, setting `emissionEnergy` and `absortionDensity` to zero
alongside an atmospheric fog can provide an acceptable result in scenes where
transparent object interaction is a concern.

The atmospheric fog pipeline has also been revised; skybox-specific fog logic
has been removed from the background pass, and atmospheric fog for both opaque
geometry and the background is now applied in a single pass after the background
and before transparent objects, like how volumetric fog is composed.

## Changes

- Added `R3D_VolumetricFog` struct to `R3D_Environment` in the public API.