### PR TITLE
Refactor: light and probe handle system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ add_library(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/src/common/r3d_anim.c"
     "${R3D_ROOT_PATH}/src/common/r3d_helper.c"
     "${R3D_ROOT_PATH}/src/common/r3d_image.c"
+    "${R3D_ROOT_PATH}/src/common/r3d_pool.c"
     "${R3D_ROOT_PATH}/src/common/r3d_pass.c"
     # Modules
     "${R3D_ROOT_PATH}/src/modules/r3d_texture.c"

--- a/include/r3d/r3d_lighting.h
+++ b/include/r3d/r3d_lighting.h
@@ -54,9 +54,9 @@ typedef enum R3D_ShadowUpdateMode {
  * @brief Unique identifier for an R3D light.
  *
  * ID type used to reference a light.
- * A negative value indicates an invalid light.
+ * A zero value indicates an invalid light.
  */
-typedef int32_t R3D_Light;
+typedef uint32_t R3D_Light;
 
 // ========================================
 // PUBLIC API

--- a/include/r3d/r3d_probe.h
+++ b/include/r3d/r3d_probe.h
@@ -50,9 +50,10 @@ typedef enum R3D_ProbeUpdateMode {
 /**
  * @brief Unique identifier for an R3D probe.
  *
- * Negative values indicate an invalid probe.
+ * ID type used to reference a probe.
+ * A zero value indicates an invalid probe.
  */
-typedef int32_t R3D_Probe;
+typedef uint32_t R3D_Probe;
 
 // ========================================
 // PUBLIC API

--- a/src/common/r3d_pool.c
+++ b/src/common/r3d_pool.c
@@ -1,0 +1,150 @@
+/* r3d_pool.c -- Generic contiguous object pool with versioned handles.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#include "./r3d_pool.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#define POOL_MAX_GEN 0xFFFFu // 65535; gen wraps 65535 -> 1, never 0
+
+// ========================================
+// INTERNAL HELPERS
+// ========================================
+
+static inline size_t pool_total_size(uint32_t capacity, uint32_t objSize)
+{
+    return sizeof(r3d_pool_t)
+        + capacity * sizeof(uint16_t) // gens
+        + capacity * sizeof(uint16_t) // gensRef
+        + capacity * sizeof(uint16_t) // freeStack
+        + (size_t)capacity * objSize; // objects
+}
+
+static inline void pool_set_pointers(r3d_pool_t* pool, uint32_t capacity)
+{
+    uint8_t* base = (uint8_t*)pool + sizeof(r3d_pool_t);
+    pool->gens = (uint16_t*)base;
+    pool->gensRef = pool->gens + capacity;
+    pool->freeStack = pool->gensRef + capacity;
+    pool->objects = (void*)(pool->freeStack + capacity);
+}
+
+// ========================================
+// POOL FUNCTIONS
+// ========================================
+
+r3d_pool_t* r3d_pool_create(uint32_t objSize, uint32_t capacity)
+{
+    if (objSize == 0 || capacity == 0) {
+        return NULL;
+    }
+
+    uint8_t* mem = RL_MALLOC(pool_total_size(capacity, objSize));
+    if (!mem) return NULL;
+
+    r3d_pool_t* pool = (r3d_pool_t*)mem;
+    pool->objSize = objSize;
+    pool->count = 0;
+    pool->capacity = capacity;
+    pool->freeCount = 0;
+
+    pool_set_pointers(pool, capacity);
+
+    memset(pool->gens, 0, capacity * sizeof(uint16_t));
+    memset(pool->gensRef, 0, capacity * sizeof(uint16_t));
+
+    return pool;
+}
+
+void r3d_pool_destroy(r3d_pool_t* pool)
+{
+    RL_FREE(pool);
+}
+
+r3d_pool_t* r3d_pool_grow(r3d_pool_t* pool)
+{
+    uint32_t oldCap = pool->capacity;
+    uint32_t newCap = oldCap * 2;
+    if (newCap <= oldCap) return NULL; // Overflow or already at limit
+
+    uint8_t* newMem = RL_MALLOC(pool_total_size(newCap, pool->objSize));
+    if (!newMem) return NULL;
+
+    r3d_pool_t* newPool = (r3d_pool_t*)newMem;
+    *newPool = *pool;
+    newPool->capacity = newCap;
+
+    pool_set_pointers(newPool, newCap);
+
+    // Copy existing data
+    memcpy(newPool->gens, pool->gens, oldCap * sizeof(uint16_t));
+    memcpy(newPool->gensRef, pool->gensRef, oldCap * sizeof(uint16_t));
+    memcpy(newPool->freeStack, pool->freeStack, pool->freeCount * sizeof(uint16_t));
+    memcpy(newPool->objects, pool->objects, (size_t)pool->count * pool->objSize);
+
+    // Zero new slots
+    memset(newPool->gens + oldCap, 0, (newCap - oldCap) * sizeof(uint16_t));
+    memset(newPool->gensRef + oldCap, 0, (newCap - oldCap) * sizeof(uint16_t));
+
+    RL_FREE(pool);
+    return newPool;
+}
+
+bool r3d_pool_valid(const r3d_pool_t* pool, r3d_pool_id_t id)
+{
+    if (id == R3D_POOL_ID_NULL) return false;
+    uint32_t index = R3D_POOL_ID_INDEX(id);
+    if (index >= pool->capacity) return false;
+    // A slot is live if its current gen matches the gen recorded at insertion
+    return pool->gens[index] != 0
+        && pool->gens[index] == pool->gensRef[index];
+}
+
+void* r3d_pool_get(const r3d_pool_t* pool, r3d_pool_id_t id)
+{
+    if (!r3d_pool_valid(pool, id)) return NULL;
+    return (uint8_t*)pool->objects + R3D_POOL_ID_INDEX(id) * pool->objSize;
+}
+
+r3d_pool_id_t r3d_pool_insert(r3d_pool_t** poolPtr)
+{
+    r3d_pool_t* pool = *poolPtr;
+
+    // Grow if no free slot and dense array is full
+    if (pool->freeCount == 0 && pool->count >= pool->capacity) {
+        pool = r3d_pool_grow(pool);
+        if (!pool) return R3D_POOL_ID_NULL;
+        *poolPtr = pool;
+    }
+
+    // Pick a slot: recycle or append
+    uint32_t index = (pool->freeCount > 0)
+        ? pool->freeStack[--pool->freeCount]
+        : pool->count;
+
+    // Bump generation (wraps 65535 -> 1, never 0)
+    uint16_t gen = (uint16_t)((pool->gens[index] % POOL_MAX_GEN) + 1u);
+    pool->gens[index] = gen;
+    pool->gensRef[index] = gen; // Record gen for future validation
+    pool->count++;
+
+    return R3D_POOL_ID_MAKE(index);
+}
+
+void r3d_pool_remove(r3d_pool_t* pool, r3d_pool_id_t id)
+{
+    if (!r3d_pool_valid(pool, id)) return;
+
+    uint32_t index = R3D_POOL_ID_INDEX(id);
+
+    // Invalidate: bump gens but leave gensRef at the old value
+    pool->gens[index] = 0;
+    pool->freeStack[pool->freeCount++] = (uint16_t)index;
+    pool->count--;
+}

--- a/src/common/r3d_pool.h
+++ b/src/common/r3d_pool.h
@@ -1,0 +1,106 @@
+/* r3d_pool.h -- Generic contiguous object pool with versioned handles.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#ifndef R3D_POOL_H
+#define R3D_POOL_H
+
+#include <raylib.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+// ========================================
+// HANDLE TYPE & HELPERS
+// ========================================
+
+/* Public handle: simply index + 1. 0 is always null/invalid */
+typedef uint32_t r3d_pool_id_t;
+
+#define R3D_POOL_ID_NULL        0u
+#define R3D_POOL_ID_MAX_INDEX   0xFFFFFFFFu
+
+/* Extract the slot index from a handle (0-based) */
+#define R3D_POOL_ID_INDEX(id)   ((uint32_t)((id) - 1u))
+
+/* Build a handle from a 0-based slot index */
+#define R3D_POOL_ID_MAKE(index) ((r3d_pool_id_t)((index) + 1u))
+
+// ========================================
+// POOL STRUCT
+// ========================================
+
+/* Memory layout (single allocation):
+ *
+ *   [ r3d_pool_t | gens[capacity] | gensRef[capacity] | freeStack[capacity] | objects[capacity * objSize] ]
+ *
+ *   gens[]      : current generation per slot (0 = free)
+ *   gensRef[]   : generation at insertion time, used to validate handles
+ *   freeStack[] : LIFO stack of recycled slot indices
+ *   objects[]   : packed object bytes
+ */
+typedef struct {
+    uint32_t objSize;       // Size of one object in bytes
+    uint32_t count;         // Number of live objects
+    uint32_t capacity;      // Total allocated slots
+    uint32_t freeCount;     // Number of entries in freeStack
+    uint16_t* gens;         // Current generation per slot
+    uint16_t* gensRef;      // Generation at last insertion, per slot
+    uint16_t* freeStack;    // Recycled slot indices
+    void* objects;          // Packed object storage
+} r3d_pool_t;
+
+// ========================================
+// POOL ITERATION
+// ========================================
+
+/* Iterate over all live objects (skips free slots)
+ * 'pool'    : r3d_pool_t*
+ * 'Type'    : concrete object type (eg r3d_light_t)
+ * 'varname' : loop variable name, declared as Type*
+ * 'idx'     : uint32_t slot index, usable inside the loop body (eg to rebuild a handle) */
+#define R3D_POOL_FOR_EACH(pool, Type, varname, idx)         \
+    for (uint32_t idx = 0; idx < (pool)->capacity; idx++)   \
+        if ((pool)->gens[idx] != 0)                         \
+            for (Type* varname =                            \
+                     (Type*)((uint8_t*)(pool)->objects      \
+                             + idx * (pool)->objSize);      \
+                 varname;                                   \
+                 varname = NULL)
+
+// ========================================
+// POOL FUNCTIONS
+// ========================================
+
+/* Allocate a pool with the given object size and initial capacity
+ * Returns NULL on allocation failure */
+r3d_pool_t* r3d_pool_create(uint32_t objSize, uint32_t capacity);
+
+/* Free all memory used by the pool. */
+void r3d_pool_destroy(r3d_pool_t* pool);
+
+/* Grow the pool to at least double its current capacity
+ * Returns the new pool pointer (the old one is invalid after this call)
+ * Returns NULL on failure (old pool remains valid in that case) */
+r3d_pool_t* r3d_pool_grow(r3d_pool_t* pool);
+
+/* Return whether a handle is valid (O(1)) */
+bool r3d_pool_valid(const r3d_pool_t* pool, r3d_pool_id_t id);
+
+/* Return a pointer to the object for the given handle, or NULL if invalid */
+void* r3d_pool_get(const r3d_pool_t* pool, r3d_pool_id_t id);
+
+/* Allocate a new slot and return its handle
+ * *poolPtr may be updated if the pool had to grow
+ * Returns R3D_POOL_ID_NULL on failure */
+r3d_pool_id_t r3d_pool_insert(r3d_pool_t** poolPtr);
+
+/* Release the slot held by the given handle
+ * Does nothing if the handle is invalid */
+void r3d_pool_remove(r3d_pool_t* pool, r3d_pool_id_t id);
+
+#endif // R3D_POOL_H

--- a/src/common/r3d_pool.h
+++ b/src/common/r3d_pool.h
@@ -12,7 +12,6 @@
 #include <raylib.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdbool.h>
 
 // ========================================
 // HANDLE TYPE & HELPERS

--- a/src/modules/r3d_env.c
+++ b/src/modules/r3d_env.c
@@ -107,11 +107,11 @@ typedef struct {
     int layers;
     int mipLevels;
     GLenum target;
-} cubemap_spec_t;
+} cubemap_array_spec_t;
 
-static inline cubemap_spec_t cubemap_spec(int size, int layers, bool mipmapped)
+static inline cubemap_array_spec_t cubemap_array_spec(int size, int layers, bool mipmapped)
 {
-    return (cubemap_spec_t) {
+    return (cubemap_array_spec_t) {
         .size = size,
         .layers = layers,
         .mipLevels = mipmapped ? r3d_get_mip_levels_1d(size) : 1,
@@ -119,7 +119,7 @@ static inline cubemap_spec_t cubemap_spec(int size, int layers, bool mipmapped)
     };
 }
 
-static bool allocate_cubemap(GLuint texture, cubemap_spec_t spec)
+static bool cubemap_array_allocate(GLuint texture, cubemap_array_spec_t spec)
 {
     glBindTexture(spec.target, texture);
 
@@ -157,12 +157,12 @@ static bool allocate_cubemap(GLuint texture, cubemap_spec_t spec)
     return true;
 }
 
-static bool resize_cubemap_array(GLuint* texture, cubemap_spec_t oldSpec, cubemap_spec_t newSpec)
+static bool cubemap_array_resize(GLuint* texture, cubemap_array_spec_t oldSpec, cubemap_array_spec_t newSpec)
 {
     GLuint newTexture;
     glGenTextures(1, &newTexture);
 
-    if (!allocate_cubemap(newTexture, newSpec)) {
+    if (!cubemap_array_allocate(newTexture, newSpec)) {
         glDeleteTextures(1, &newTexture);
         return false;
     }
@@ -197,12 +197,12 @@ static bool resize_cubemap_array(GLuint* texture, cubemap_spec_t oldSpec, cubema
     return true;
 }
 
-static bool expand_cubemap_capacity(GLuint* texture, r3d_env_layer_pool_t* pool, int size, bool mipmapped)
+static bool cubemap_array_expand_capacity(GLuint* texture, r3d_env_layer_pool_t* pool, int size, bool mipmapped)
 {
-    cubemap_spec_t oldSpec = cubemap_spec(size, pool->totalLayers, mipmapped);
-    cubemap_spec_t newSpec = cubemap_spec(size, pool->totalLayers + LAYER_GROWTH, mipmapped);
+    cubemap_array_spec_t oldSpec = cubemap_array_spec(size, pool->totalLayers, mipmapped);
+    cubemap_array_spec_t newSpec = cubemap_array_spec(size, pool->totalLayers + LAYER_GROWTH, mipmapped);
 
-    if (!resize_cubemap_array(texture, oldSpec, newSpec)) {
+    if (!cubemap_array_resize(texture, oldSpec, newSpec)) {
         return false;
     }
 
@@ -213,7 +213,7 @@ static bool expand_cubemap_capacity(GLuint* texture, r3d_env_layer_pool_t* pool,
 // PROBE FUNCTIONS
 // ========================================
 
-static bool init_probe(r3d_env_probe_t* probe, R3D_ProbeFlags flags)
+static bool probe_init(r3d_env_probe_t* probe, R3D_ProbeFlags flags)
 {
     probe->flags = flags;
     probe->irradiance = -1;
@@ -250,7 +250,7 @@ static bool init_probe(r3d_env_probe_t* probe, R3D_ProbeFlags flags)
     return true;
 }
 
-static void deinit_probe(r3d_env_probe_t* probe)
+static void probe_deinit(r3d_env_probe_t* probe)
 {
     if (probe->irradiance >= 0) {
         r3d_env_irradiance_release_layer(probe->irradiance);
@@ -260,7 +260,7 @@ static void deinit_probe(r3d_env_probe_t* probe)
     }
 }
 
-static void update_probe_matrix_frustum(r3d_env_probe_t* probe)
+static void probe_update_matrix_frustum(r3d_env_probe_t* probe)
 {
     static const Vector3 dirs[6] = {
         { 1.0,  0.0,  0.0}, {-1.0,  0.0,  0.0},  // +X, -X
@@ -368,7 +368,7 @@ R3D_Probe r3d_env_probe_new(R3D_ProbeFlags flags)
     }
 
     r3d_env_probe_t* probe = r3d_pool_get(R3D_MOD_ENV.pool, id);
-    if (!init_probe(probe, flags)) {
+    if (!probe_init(probe, flags)) {
         r3d_pool_remove(R3D_MOD_ENV.pool, id);
         R3D_TRACELOG(LOG_ERROR, "Failed to initialize probe");
         return R3D_POOL_ID_NULL;
@@ -384,7 +384,7 @@ void r3d_env_probe_delete(R3D_Probe id)
     r3d_env_probe_t* probe = r3d_pool_get(R3D_MOD_ENV.pool, id);
     if (!probe) return;
 
-    deinit_probe(probe);
+    probe_deinit(probe);
     r3d_pool_remove(R3D_MOD_ENV.pool, id);
 
     R3D_TRACELOG(LOG_INFO, "[ID %d] Probe destroyed", id);
@@ -407,7 +407,7 @@ void r3d_env_probe_update_and_cull(const R3D_Frustum* viewFrustum, bool* hasVisi
     R3D_POOL_FOR_EACH(R3D_MOD_ENV.pool, r3d_env_probe_t, probe, idx) {
         if (probe->state.matrixShouldBeUpdated) {
             probe->state.matrixShouldBeUpdated = false;
-            update_probe_matrix_frustum(probe);
+            probe_update_matrix_frustum(probe);
         }
 
         if (!probe->enabled) continue;
@@ -458,7 +458,7 @@ int r3d_env_irradiance_reserve_layer(void)
     int layer = layer_pool_reserve(&R3D_MOD_ENV.irradiancePool);
 
     if (layer < 0) {
-        if (!expand_cubemap_capacity(&R3D_MOD_ENV.irradianceArray, &R3D_MOD_ENV.irradiancePool, R3D_CUBEMAP_IRRADIANCE_SIZE, false)) {
+        if (!cubemap_array_expand_capacity(&R3D_MOD_ENV.irradianceArray, &R3D_MOD_ENV.irradiancePool, R3D_CUBEMAP_IRRADIANCE_SIZE, false)) {
             return -1;
         }
         layer = layer_pool_reserve(&R3D_MOD_ENV.irradiancePool);
@@ -493,7 +493,7 @@ int r3d_env_prefilter_reserve_layer(void)
     int layer = layer_pool_reserve(&R3D_MOD_ENV.prefilterPool);
 
     if (layer < 0) {
-        if (!expand_cubemap_capacity(&R3D_MOD_ENV.prefilterArray, &R3D_MOD_ENV.prefilterPool, R3D_CUBEMAP_PREFILTER_SIZE, true)) {
+        if (!cubemap_array_expand_capacity(&R3D_MOD_ENV.prefilterArray, &R3D_MOD_ENV.prefilterPool, R3D_CUBEMAP_PREFILTER_SIZE, true)) {
             return -1;
         }
         layer = layer_pool_reserve(&R3D_MOD_ENV.prefilterPool);
@@ -534,8 +534,8 @@ void r3d_env_capture_bind_fbo(int face, int mipLevel)
 
     if (!R3D_MOD_ENV.captureCubeAllocated) {
         alloc_depth_stencil_renderbuffer(R3D_MOD_ENV.captureDepth, R3D_PROBE_CAPTURE_SIZE);
-        cubemap_spec_t spec = cubemap_spec(R3D_PROBE_CAPTURE_SIZE, 0, true);
-        allocate_cubemap(R3D_MOD_ENV.captureCube, spec);
+        cubemap_array_spec_t spec = cubemap_array_spec(R3D_PROBE_CAPTURE_SIZE, 0, true);
+        cubemap_array_allocate(R3D_MOD_ENV.captureCube, spec);
         R3D_MOD_ENV.captureCubeAllocated = true;
 
         glFramebufferRenderbuffer(

--- a/src/modules/r3d_env.c
+++ b/src/modules/r3d_env.c
@@ -405,12 +405,12 @@ void r3d_env_probe_update_and_cull(const R3D_Frustum* viewFrustum, bool* hasVisi
     R3D_MOD_ENV.visibleCount = 0;
 
     R3D_POOL_FOR_EACH(R3D_MOD_ENV.pool, r3d_env_probe_t, probe, idx) {
+        if (!probe->enabled) continue;
+
         if (probe->state.matrixShouldBeUpdated) {
             probe->state.matrixShouldBeUpdated = false;
             probe_update_matrix_frustum(probe);
         }
-
-        if (!probe->enabled) continue;
 
         BoundingBox aabb = {
             .min = {

--- a/src/modules/r3d_env.c
+++ b/src/modules/r3d_env.c
@@ -16,14 +16,12 @@
 #include <assert.h>
 
 #include "../common/r3d_helper.h"
-#include "../common/r3d_math.h"
 
 // ========================================
 // CONSTANTS
 // ========================================
 
-#define PROBE_INITIAL_CAPACITY  16
-#define LAYER_GROWTH            4
+#define LAYER_GROWTH    4
 
 // ========================================
 // MODULE STATE
@@ -215,25 +213,6 @@ static bool expand_cubemap_capacity(GLuint* texture, r3d_env_layer_pool_t* pool,
 // PROBE FUNCTIONS
 // ========================================
 
-static bool growth_probe_arrays(void)
-{
-    int newCapacity = 2 * R3D_MOD_ENV.capacityProbes;
-
-    r3d_env_probe_t* newProbes = RL_REALLOC(R3D_MOD_ENV.probes, newCapacity * sizeof(*R3D_MOD_ENV.probes));
-    if (!newProbes) return false;
-
-    R3D_MOD_ENV.capacityProbes = newCapacity;
-    R3D_MOD_ENV.probes = newProbes;
-
-    for (int i = 0; i < R3D_ENV_PROBE_ARRAY_COUNT; i++) {
-        R3D_Probe* newPtr = RL_REALLOC(R3D_MOD_ENV.arrays[i].probes, newCapacity * sizeof(R3D_Probe));
-        if (!newPtr) return false;
-        R3D_MOD_ENV.arrays[i].probes = newPtr;
-    }
-
-    return true;
-}
-
 static bool init_probe(r3d_env_probe_t* probe, R3D_ProbeFlags flags)
 {
     probe->flags = flags;
@@ -338,22 +317,20 @@ bool r3d_env_init(void)
     }
 
     // Allocate probe arrays
-    R3D_MOD_ENV.probes = RL_MALLOC(PROBE_INITIAL_CAPACITY * sizeof(*R3D_MOD_ENV.probes));
-    R3D_MOD_ENV.capacityProbes = PROBE_INITIAL_CAPACITY;
-
-    if (!R3D_MOD_ENV.probes) {
-        R3D_TRACELOG(LOG_FATAL, "Failed to allocate probe array");
+    R3D_MOD_ENV.pool = r3d_pool_create(sizeof(r3d_env_probe_t), 16);
+    if (!R3D_MOD_ENV.pool) {
+        R3D_TRACELOG(LOG_FATAL, "Failed to create probe pool");
         r3d_env_quit();
         return false;
     }
 
-    for (int i = 0; i < R3D_ENV_PROBE_ARRAY_COUNT; i++) {
-        R3D_MOD_ENV.arrays[i].probes = RL_MALLOC(PROBE_INITIAL_CAPACITY * sizeof(R3D_Probe));
-        if (!R3D_MOD_ENV.arrays[i].probes) {
-            R3D_TRACELOG(LOG_FATAL, "Failed to allocate probe list array %i", i);
-            r3d_env_quit();
-            return false;
-        }
+    R3D_MOD_ENV.visible = RL_MALLOC(16 * sizeof(R3D_Probe));
+    R3D_MOD_ENV.visibleCapacity = 16;
+    R3D_MOD_ENV.visibleCount = 0;
+    if (!R3D_MOD_ENV.visible) {
+        R3D_TRACELOG(LOG_FATAL, "Failed to allocate visible probe array");
+        r3d_env_quit();
+        return false;
     }
 
     return true;
@@ -373,112 +350,61 @@ void r3d_env_quit(void)
     layer_pool_quit(&R3D_MOD_ENV.irradiancePool);
     layer_pool_quit(&R3D_MOD_ENV.prefilterPool);
 
-    for (int i = 0; i < R3D_ENV_PROBE_ARRAY_COUNT; i++) {
-        RL_FREE(R3D_MOD_ENV.arrays[i].probes);
-    }
-
-    RL_FREE(R3D_MOD_ENV.probes);
+    r3d_pool_destroy(R3D_MOD_ENV.pool);
+    RL_FREE(R3D_MOD_ENV.visible);
 }
 
 R3D_Probe r3d_env_probe_new(R3D_ProbeFlags flags)
 {
     if (!BIT_TEST_ANY(flags, R3D_PROBE_ILLUMINATION | R3D_PROBE_REFLECTION)) {
         R3D_TRACELOG(LOG_FATAL, "Failed to create probe; Invalid flags");
-        return -1;
+        return R3D_POOL_ID_NULL;
     }
 
-    r3d_env_probe_array_t* validProbes = &R3D_MOD_ENV.arrays[R3D_ENV_PROBE_ARRAY_VALID];
-    r3d_env_probe_array_t* freeProbes = &R3D_MOD_ENV.arrays[R3D_ENV_PROBE_ARRAY_FREE];
-
-    R3D_Probe index;
-    if (freeProbes->count == 0) index = validProbes->count;
-    else index = freeProbes->probes[--freeProbes->count];
-
-    if (index >= R3D_MOD_ENV.capacityProbes) {
-        if (!growth_probe_arrays()) {
-            R3D_TRACELOG(LOG_FATAL, "Failed to grow probe arrays");
-            return -1;
-        }
+    R3D_Probe id = r3d_pool_insert(&R3D_MOD_ENV.pool);
+    if (id == R3D_POOL_ID_NULL) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to insert probe into pool");
+        return R3D_POOL_ID_NULL;
     }
 
-    if (!init_probe(&R3D_MOD_ENV.probes[index], flags)) {
-        R3D_TRACELOG(LOG_FATAL, "Failed to initialize probe");
-        return -1;
+    r3d_env_probe_t* probe = r3d_pool_get(R3D_MOD_ENV.pool, id);
+    if (!init_probe(probe, flags)) {
+        r3d_pool_remove(R3D_MOD_ENV.pool, id);
+        R3D_TRACELOG(LOG_ERROR, "Failed to initialize probe");
+        return R3D_POOL_ID_NULL;
     }
 
-    validProbes->probes[validProbes->count++] = index;
+    R3D_TRACELOG(LOG_INFO, "[ID %d] Probe created successfully", id);
 
-    return index;
+    return id;
 }
 
-void r3d_env_probe_delete(R3D_Probe index)
+void r3d_env_probe_delete(R3D_Probe id)
 {
-    if (index < 0) return;
+    r3d_env_probe_t* probe = r3d_pool_get(R3D_MOD_ENV.pool, id);
+    if (!probe) return;
 
-    r3d_env_probe_array_t* validProbes = &R3D_MOD_ENV.arrays[R3D_ENV_PROBE_ARRAY_VALID];
+    deinit_probe(probe);
+    r3d_pool_remove(R3D_MOD_ENV.pool, id);
 
-    // Find and remove from valid list
-    for (int i = 0; i < validProbes->count; i++) {
-        if (index == validProbes->probes[i]) {
-            int numToMove = validProbes->count - i - 1;
-            if (numToMove > 0) {
-                memmove(&validProbes->probes[i], &validProbes->probes[i + 1],
-                       numToMove * sizeof(validProbes->probes[0]));
-            }
-            validProbes->count--;
-
-            // Add to free list and cleanup
-            r3d_env_probe_array_t* freeProbes = &R3D_MOD_ENV.arrays[R3D_ENV_PROBE_ARRAY_FREE];
-            freeProbes->probes[freeProbes->count++] = index;
-            deinit_probe(&R3D_MOD_ENV.probes[index]);
-            return;
-        }
-    }
+    R3D_TRACELOG(LOG_INFO, "[ID %d] Probe destroyed", id);
 }
 
-bool r3d_env_probe_is_valid(R3D_Probe index)
+bool r3d_env_probe_is_valid(R3D_Probe id)
 {
-    if (index < 0) return false;
-
-    const r3d_env_probe_array_t* validProbes = &R3D_MOD_ENV.arrays[R3D_ENV_PROBE_ARRAY_VALID];
-    for (int i = 0; i < validProbes->count; i++) {
-        if (index == validProbes->probes[i]) return true;
-    }
-    return false;
+    return r3d_pool_valid(R3D_MOD_ENV.pool, id);
 }
 
-r3d_env_probe_t* r3d_env_probe_get(R3D_Probe index)
+r3d_env_probe_t* r3d_env_probe_get(R3D_Probe id)
 {
-    return r3d_env_probe_is_valid(index) ? &R3D_MOD_ENV.probes[index] : NULL;
-}
-
-bool r3d_env_probe_has(r3d_env_probe_array_enum_t array)
-{
-    return (R3D_MOD_ENV.arrays[array].count > 0);
-}
-
-bool r3d_env_probe_iter(r3d_env_probe_t** probe, r3d_env_probe_array_enum_t array)
-{
-    static int index = 0;
-    index = (*probe == NULL) ? 0 : index + 1;
-
-    if (index >= R3D_MOD_ENV.arrays[array].count) return false;
-
-    *probe = &R3D_MOD_ENV.probes[R3D_MOD_ENV.arrays[array].probes[index]];
-    return true;
+    return r3d_pool_get(R3D_MOD_ENV.pool, id);
 }
 
 void r3d_env_probe_update_and_cull(const R3D_Frustum* viewFrustum, bool* hasVisibleProbes)
 {
-    r3d_env_probe_array_t* visibleProbes = &R3D_MOD_ENV.arrays[R3D_ENV_PROBE_ARRAY_VISIBLE];
-    r3d_env_probe_array_t* validProbes = &R3D_MOD_ENV.arrays[R3D_ENV_PROBE_ARRAY_VALID];
+    R3D_MOD_ENV.visibleCount = 0;
 
-    visibleProbes->count = 0;
-
-    for (int i = 0; i < validProbes->count; i++) {
-        R3D_Probe index = validProbes->probes[i];
-        r3d_env_probe_t* probe = &R3D_MOD_ENV.probes[index];
-
+    R3D_POOL_FOR_EACH(R3D_MOD_ENV.pool, r3d_env_probe_t, probe, idx) {
         if (probe->state.matrixShouldBeUpdated) {
             probe->state.matrixShouldBeUpdated = false;
             update_probe_matrix_frustum(probe);
@@ -499,11 +425,21 @@ void r3d_env_probe_update_and_cull(const R3D_Frustum* viewFrustum, bool* hasVisi
             }
         };
 
-        if (R3D_FrustumIntersectsBoundingBox(viewFrustum, aabb)) {
-            visibleProbes->probes[visibleProbes->count++] = index;
-            if (hasVisibleProbes) *hasVisibleProbes = true;
+        if (!R3D_FrustumIntersectsBoundingBox(viewFrustum, aabb)) continue;
+
+        // Grow visible array if needed
+        if (R3D_MOD_ENV.visibleCount >= R3D_MOD_ENV.visibleCapacity) {
+            uint32_t newCap = R3D_MOD_ENV.visibleCapacity * 2;
+            R3D_Probe* newPtr = RL_REALLOC(R3D_MOD_ENV.visible, newCap * sizeof(R3D_Probe));
+            if (!newPtr) continue; // Skip rather than crash
+            R3D_MOD_ENV.visible = newPtr;
+            R3D_MOD_ENV.visibleCapacity = newCap;
         }
+
+        R3D_MOD_ENV.visible[R3D_MOD_ENV.visibleCount++] = R3D_POOL_ID_MAKE(idx);
     }
+
+    if (hasVisibleProbes) *hasVisibleProbes = (R3D_MOD_ENV.visibleCount > 0);
 }
 
 bool r3d_env_probe_should_be_updated(r3d_env_probe_t* probe, bool willBeUpdated)

--- a/src/modules/r3d_env.h
+++ b/src/modules/r3d_env.h
@@ -14,17 +14,21 @@
 #include <raylib.h>
 #include <glad.h>
 
+#include "../common/r3d_pool.h"
+
 // ========================================
 // HELPER MACROS
 // ========================================
 
-#define R3D_ENV_PROBE_FOR_EACH_VALID(probe) \
-    for (r3d_env_probe_t* probe = NULL; \
-         r3d_env_probe_iter(&probe, R3D_ENV_PROBE_ARRAY_VALID); )
+#define R3D_ENV_PROBE_FOR_EACH(varname) \
+    R3D_POOL_FOR_EACH(R3D_MOD_ENV.pool, r3d_env_probe_t, varname)
 
-#define R3D_ENV_PROBE_FOR_EACH_VISIBLE(probe) \
-    for (r3d_env_probe_t* probe = NULL; \
-         r3d_env_probe_iter(&probe, R3D_ENV_PROBE_ARRAY_VISIBLE); )
+#define R3D_ENV_PROBE_FOR_EACH_VISIBLE(varname)                 \
+    for (uint32_t _i = 0; _i < R3D_MOD_ENV.visibleCount; _i++)  \
+        for (r3d_env_probe_t* varname = r3d_pool_get(           \
+                 R3D_MOD_ENV.pool,                              \
+                 R3D_MOD_ENV.visible[_i]);                      \
+             varname; varname = NULL)
 
 // ========================================
 // TYPES
@@ -57,18 +61,6 @@ typedef struct {
     bool enabled;
 } r3d_env_probe_t;
 
-typedef enum {
-    R3D_ENV_PROBE_ARRAY_VISIBLE,
-    R3D_ENV_PROBE_ARRAY_VALID,
-    R3D_ENV_PROBE_ARRAY_FREE,
-    R3D_ENV_PROBE_ARRAY_COUNT
-} r3d_env_probe_array_enum_t;
-
-typedef struct {
-    R3D_Probe* probes;
-    int count;
-} r3d_env_probe_array_t;
-
 // Cubemap layer pool (manages reusable texture layers)
 typedef struct {
     int* freeLayers;        // Stack of available layer indices
@@ -95,9 +87,10 @@ extern struct r3d_env {
 
     bool captureCubeAllocated;
 
-    r3d_env_probe_array_t arrays[R3D_ENV_PROBE_ARRAY_COUNT];
-    r3d_env_probe_t* probes;
-    int capacityProbes;
+    r3d_pool_t* pool;           // Owns all r3d_env_probe_t objects
+    R3D_Probe* visible;         // Handles of probes visible this frame
+    uint32_t visibleCount;
+    uint32_t visibleCapacity;
 } R3D_MOD_ENV;
 
 // ========================================
@@ -121,12 +114,6 @@ bool r3d_env_probe_is_valid(R3D_Probe index);
 
 /* Get internal probe structure (returns NULL if invalid) */
 r3d_env_probe_t* r3d_env_probe_get(R3D_Probe index);
-
-/* Check if the specified probe array is not empty */
-bool r3d_env_probe_has(r3d_env_probe_array_enum_t array);
-
-/* Iterator for probes by category (stateful, not thread-safe) */
-bool r3d_env_probe_iter(r3d_env_probe_t** probe, r3d_env_probe_array_enum_t array);
 
 /* Update probe states and collect visible ones (can indicate if probes influcences are visible) */
 void r3d_env_probe_update_and_cull(const R3D_Frustum* viewFrustum, bool* hasVisibleProbes);
@@ -166,5 +153,19 @@ void r3d_env_capture_gen_mipmaps(void);
 
 /* Get capture cubemap texture ID */
 GLuint r3d_env_capture_get(void);
+
+// ========================================
+// INLINE QUERIES
+// ========================================
+
+static inline bool r3d_env_probe_has_visible(void)
+{
+    return R3D_MOD_ENV.visibleCount > 0;
+}
+
+static inline bool r3d_env_probe_has_any(void)
+{
+    return R3D_MOD_ENV.pool->count > 0;
+}
 
 #endif // R3D_MODULE_ENV_H

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -18,18 +18,9 @@
 // CONSTANTS
 // ========================================
 
-#define LIGHT_INITIAL_CAPACITY      32
 #define SHADOW_DIR_LAYER_GROWTH     2
 #define SHADOW_SPOT_LAYER_GROWTH    4
 #define SHADOW_OMNI_LAYER_GROWTH    4
-
-// ========================================
-// HELPER MACROS
-// ========================================
-
-#define LIGHT_TO_INDEX(id)  (id - 1)
-#define LIGHT_TO_ID(index)  (index + 1)
-#define LIGHT_NULL          0
 
 // ========================================
 // MODULE STATE
@@ -191,26 +182,7 @@ static bool expand_shadow_array_capacity(R3D_LightType type)
 // LIGHT FUNCTIONS
 // ========================================
 
-static bool growth_light_arrays(void)
-{
-    int newCapacity = 2 * R3D_MOD_LIGHT.capacityLights;
-
-    r3d_light_t* newLights = RL_REALLOC(R3D_MOD_LIGHT.lights, newCapacity * sizeof(*R3D_MOD_LIGHT.lights));
-    if (!newLights) return false;
-
-    R3D_MOD_LIGHT.capacityLights = newCapacity;
-    R3D_MOD_LIGHT.lights = newLights;
-
-    for (int i = 0; i < R3D_LIGHT_ARRAY_COUNT; i++) {
-        R3D_Light* newPtr = RL_REALLOC(R3D_MOD_LIGHT.arrays[i].lights, newCapacity * sizeof(R3D_Light));
-        if (!newPtr) return false;
-        R3D_MOD_LIGHT.arrays[i].lights = newPtr;
-    }
-
-    return true;
-}
-
-static bool init_light(r3d_light_t* light, R3D_LightType type)
+static bool light_init(r3d_light_t* light, R3D_LightType type)
 {
     if (type < 0 || type >= R3D_LIGHT_TYPE_COUNT) {
         return false;
@@ -269,7 +241,7 @@ static bool init_light(r3d_light_t* light, R3D_LightType type)
     return true;
 }
 
-static void update_light_shadow_state(r3d_light_t* light)
+static void light_update_shadow_state(r3d_light_t* light)
 {
     switch (light->state.shadowUpdate) {
     case R3D_SHADOW_UPDATE_MANUAL:
@@ -289,7 +261,7 @@ static void update_light_shadow_state(r3d_light_t* light)
     }
 }
 
-static void update_light_dir_matrix(r3d_light_t* light, R3D_Camera camera, double aspect)
+static void light_update_dir_matrix(r3d_light_t* light, R3D_Camera camera, double aspect)
 {
     assert(light->type == R3D_LIGHT_DIR);
 
@@ -333,7 +305,7 @@ static void update_light_dir_matrix(r3d_light_t* light, R3D_Camera camera, doubl
     light->viewProj[0] = MatrixMultiply(view, MatrixOrtho(-radius, radius, -radius, radius, light->near, light->far));
 }
 
-static void update_light_spot_matrix(r3d_light_t* light)
+static void light_update_spot_matrix(r3d_light_t* light)
 {
     assert(light->type == R3D_LIGHT_SPOT);
 
@@ -349,7 +321,7 @@ static void update_light_spot_matrix(r3d_light_t* light)
     light->viewProj[0] = MatrixMultiply(view, proj);
 }
 
-static void update_light_omni_matrix(r3d_light_t* light)
+static void light_update_omni_matrix(r3d_light_t* light)
 {
     assert(light->type == R3D_LIGHT_OMNI);
 
@@ -377,24 +349,24 @@ static void update_light_omni_matrix(r3d_light_t* light)
     }
 }
 
-static void update_light_matrix(r3d_light_t* light, R3D_Camera camera, double aspect)
+static void light_update_matrix(r3d_light_t* light, R3D_Camera camera, double aspect)
 {
     switch (light->type) {
     case R3D_LIGHT_DIR:
-        update_light_dir_matrix(light, camera, aspect);
+        light_update_dir_matrix(light, camera, aspect);
         break;
     case R3D_LIGHT_SPOT:
-        update_light_spot_matrix(light);
+        light_update_spot_matrix(light);
         break;
     case R3D_LIGHT_OMNI:
-        update_light_omni_matrix(light);
+        light_update_omni_matrix(light);
         break;
     default:
         break;
     }
 }
 
-static void update_light_frustum(r3d_light_t* light)
+static void light_update_frustum(r3d_light_t* light)
 {
     int faceCount = (light->type == R3D_LIGHT_OMNI) ? 6 : 1;
     for (int i = 0; i < faceCount; i++) {
@@ -402,7 +374,7 @@ static void update_light_frustum(r3d_light_t* light)
     }
 }
 
-static void update_light_bounding_box(r3d_light_t* light)
+static void light_update_bounding_box(r3d_light_t* light)
 {
     switch (light->type) {
     case R3D_LIGHT_OMNI:
@@ -419,6 +391,17 @@ static void update_light_bounding_box(r3d_light_t* light)
     default:
         break;
     }
+}
+
+static const char* light_get_type_name(R3D_LightType type)
+{
+    switch (type) {
+    case R3D_LIGHT_DIR:  return "Directional";
+    case R3D_LIGHT_SPOT: return "Spot";
+    case R3D_LIGHT_OMNI: return "Omni";
+    default: break;
+    }
+    return NULL;
 }
 
 // ========================================
@@ -448,23 +431,16 @@ bool r3d_light_init(void)
     }
 
     // Allocate light arrays
-    R3D_MOD_LIGHT.lights = RL_MALLOC(LIGHT_INITIAL_CAPACITY * sizeof(*R3D_MOD_LIGHT.lights));
-    R3D_MOD_LIGHT.capacityLights = LIGHT_INITIAL_CAPACITY;
-
-    if (!R3D_MOD_LIGHT.lights) {
+    R3D_MOD_LIGHT.pool = r3d_pool_create(sizeof(r3d_light_t), 32);
+    if (!R3D_MOD_LIGHT.pool) {
         R3D_TRACELOG(LOG_FATAL, "Failed to allocate light array");
         r3d_light_quit();
         return false;
     }
 
-    for (int i = 0; i < R3D_LIGHT_ARRAY_COUNT; i++) {
-        R3D_MOD_LIGHT.arrays[i].lights = RL_MALLOC(LIGHT_INITIAL_CAPACITY * sizeof(R3D_Light));
-        if (!R3D_MOD_LIGHT.arrays[i].lights) {
-            R3D_TRACELOG(LOG_FATAL, "Failed to allocate light list array %i", i);
-            r3d_light_quit();
-            return false;
-        }
-    }
+    R3D_MOD_LIGHT.visible = RL_MALLOC(32 * sizeof(R3D_Light));
+    R3D_MOD_LIGHT.visibleCapacity = 32;
+    R3D_MOD_LIGHT.visibleCount = 0;
 
     return true;
 }
@@ -482,95 +458,51 @@ void r3d_light_quit(void)
         shadow_pool_quit(&R3D_MOD_LIGHT.shadowPools[i]);
     }
 
-    for (int i = 0; i < R3D_LIGHT_ARRAY_COUNT; i++) {
-        RL_FREE(R3D_MOD_LIGHT.arrays[i].lights);
-    }
-
-    RL_FREE(R3D_MOD_LIGHT.lights);
+    r3d_pool_destroy(R3D_MOD_LIGHT.pool);
+    RL_FREE(R3D_MOD_LIGHT.visible);
 }
 
 R3D_Light r3d_light_new(R3D_LightType type)
 {
-    r3d_light_array_t* validLights = &R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_VALID];
-    r3d_light_array_t* freeLights = &R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_FREE];
-
-    // Get index (from free list or new)
-    bool tookFromFree = (freeLights->count > 0);
-    R3D_Light index = tookFromFree
-        ? freeLights->lights[--freeLights->count]
-        : validLights->count;
-
-    // Grow if needed
-    if (index >= R3D_MOD_LIGHT.capacityLights && !growth_light_arrays()) {
-        R3D_TRACELOG(LOG_ERROR, "Failed to grow light arrays");
-        goto error_restore_free;
+    R3D_Light id = r3d_pool_insert(&R3D_MOD_LIGHT.pool);
+    if (id == R3D_POOL_ID_NULL) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to insert light into pool");
+        return R3D_POOL_ID_NULL;
     }
 
-    // Initialize light
-    if (!init_light(&R3D_MOD_LIGHT.lights[index], type)) {
-        R3D_TRACELOG(LOG_ERROR, "Failed to initialize light (type: %d)", type);
-        goto error_restore_free;
+    r3d_light_t* light = r3d_pool_get(R3D_MOD_LIGHT.pool, id);
+    if (!light_init(light, type)) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to initialize light");
+        r3d_pool_remove(R3D_MOD_LIGHT.pool, id);
+        return R3D_POOL_ID_NULL;
     }
 
-    // Add to valid array
-    validLights->lights[validLights->count++] = index;
-    return LIGHT_TO_ID(index);
+    R3D_TRACELOG(LOG_INFO, "[ID %d] Light created successfully (type: %s)", id, light_get_type_name(type));
 
-error_restore_free:
-    // Restore free list if we took from it
-    if (tookFromFree) {
-        freeLights->lights[freeLights->count++] = index;
-    }
-    return LIGHT_NULL;
+    return id;
 }
 
 void r3d_light_delete(R3D_Light id)
 {
-    if (id == LIGHT_NULL) return;
+    r3d_light_t* light = r3d_pool_get(R3D_MOD_LIGHT.pool, id);
+    if (!light) return;
 
-    R3D_Light index = LIGHT_TO_INDEX(id);
-    r3d_light_array_t* validLights = &R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_VALID];
-
-    for (int i = 0; i < validLights->count; i++) {
-        if (index == validLights->lights[i]) {
-            int numToMove = validLights->count - i - 1;
-            if (numToMove > 0) {
-                memmove(
-                    &validLights->lights[i], &validLights->lights[i + 1],
-                    numToMove * sizeof(validLights->lights[0])
-                );
-            }
-            validLights->count--;
-
-            // Release shadow layer and add to free list
-            r3d_light_t* light = &R3D_MOD_LIGHT.lights[index];
-            if (light->shadowLayer >= 0) {
-                shadow_pool_release(&R3D_MOD_LIGHT.shadowPools[light->type], light->shadowLayer);
-                light->shadowLayer = -1;
-            }
-
-            r3d_light_array_t* freeLights = &R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_FREE];
-            freeLights->lights[freeLights->count++] = index;
-            return;
-        }
+    if (light->shadowLayer >= 0) {
+        shadow_pool_release(&R3D_MOD_LIGHT.shadowPools[light->type], light->shadowLayer);
     }
+    r3d_pool_remove(R3D_MOD_LIGHT.pool, id);
+
+    R3D_TRACELOG(LOG_INFO, "[ID %d] Light destroyed", id);
 }
 
 bool r3d_light_is_valid(R3D_Light id)
 {
-    if (id == LIGHT_NULL) return false;
-    R3D_Light index = LIGHT_TO_INDEX(id);
-    const r3d_light_array_t* validLights = &R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_VALID];
-    for (int i = 0; i < validLights->count; i++) {
-        if (index == validLights->lights[i]) return true;
-    }
-    return false;
+    return r3d_pool_valid(R3D_MOD_LIGHT.pool, id);
 }
 
 r3d_light_t* r3d_light_get(R3D_Light id)
 {
-    uint32_t index = LIGHT_TO_INDEX(id);
-    return r3d_light_is_valid(id) ? &R3D_MOD_LIGHT.lights[index] : NULL;
+    return r3d_pool_get(R3D_MOD_LIGHT.pool, id);
 }
 
 r3d_rect_t r3d_light_get_screen_rect(const r3d_light_t* light, const Matrix* viewProj, int w, int h)
@@ -616,17 +548,6 @@ r3d_rect_t r3d_light_get_screen_rect(const r3d_light_t* light, const Matrix* vie
     return (r3d_rect_t){x, y, rectW, rectH};
 }
 
-bool r3d_light_iter(r3d_light_t** light, r3d_light_array_enum_t array)
-{
-    static int index = 0;
-    index = (*light == NULL) ? 0 : index + 1;
-
-    if (index >= R3D_MOD_LIGHT.arrays[array].count) return false;
-
-    *light = &R3D_MOD_LIGHT.lights[R3D_MOD_LIGHT.arrays[array].lights[index]];
-    return true;
-}
-
 bool r3d_light_enable_shadows(r3d_light_t* light)
 {
     if (light->shadowLayer >= 0) return true;
@@ -653,21 +574,16 @@ void r3d_light_disable_shadows(r3d_light_t* light)
     }
 }
 
-void r3d_light_update_and_cull(const R3D_Frustum* viewFrustum, R3D_Camera camera, double aspect, bool* hasVisibleShadows)
+void r3d_light_update_and_cull(const R3D_Frustum* viewFrustum, R3D_Camera camera,
+                               double aspect, bool* hasVisibleShadows)
 {
-    r3d_light_array_t* visibleLights = &R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_VISIBLE];
-    r3d_light_array_t* validLights = &R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_VALID];
+    R3D_MOD_LIGHT.visibleCount = 0;
 
-    visibleLights->count = 0;
-
-    for (int i = 0; i < validLights->count; i++) {
-        R3D_Light index = validLights->lights[i];
-        r3d_light_t* light = &R3D_MOD_LIGHT.lights[index];
-
+    R3D_POOL_FOR_EACH(R3D_MOD_LIGHT.pool, r3d_light_t, light, idx) {
         if (!light->enabled) continue;
 
         if (light->shadowLayer >= 0) {
-            update_light_shadow_state(light);
+            light_update_shadow_state(light);
         }
 
         bool isDirectional = (light->type == R3D_LIGHT_DIR);
@@ -676,18 +592,25 @@ void r3d_light_update_and_cull(const R3D_Frustum* viewFrustum, R3D_Camera camera
             : light->state.matrixShouldBeUpdated;
 
         if (shouldUpdateMatrix) {
-            update_light_matrix(light, camera, aspect);
-            update_light_frustum(light);
-            if (!isDirectional) {
-                update_light_bounding_box(light);
-            }
+            light_update_matrix(light, camera, aspect);
+            light_update_frustum(light);
+            if (!isDirectional) light_update_bounding_box(light);
             light->state.matrixShouldBeUpdated = false;
         }
 
-        if (R3D_FrustumIntersectsBoundingBox(viewFrustum, light->aabb)) {
-            if (hasVisibleShadows) *hasVisibleShadows |= (light->shadowLayer >= 0);
-            visibleLights->lights[visibleLights->count++] = index;
+        if (!R3D_FrustumIntersectsBoundingBox(viewFrustum, light->aabb)) continue;
+        if (hasVisibleShadows) *hasVisibleShadows |= (light->shadowLayer >= 0);
+
+        // Grow visible array if needed
+        if (R3D_MOD_LIGHT.visibleCount >= R3D_MOD_LIGHT.visibleCapacity) {
+            uint32_t newCap = R3D_MOD_LIGHT.visibleCapacity * 2;
+            R3D_Light* newPtr = RL_REALLOC(R3D_MOD_LIGHT.visible, newCap * sizeof(R3D_Light));
+            if (!newPtr) continue; // Skip rather than crash
+            R3D_MOD_LIGHT.visible = newPtr;
+            R3D_MOD_LIGHT.visibleCapacity = newCap;
         }
+
+        R3D_MOD_LIGHT.visible[R3D_MOD_LIGHT.visibleCount++] = R3D_POOL_ID_MAKE(idx);
     }
 }
 

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -24,6 +24,14 @@
 #define SHADOW_OMNI_LAYER_GROWTH    4
 
 // ========================================
+// HELPER MACROS
+// ========================================
+
+#define LIGHT_TO_INDEX(id)  (id - 1)
+#define LIGHT_TO_ID(index)  (index + 1)
+#define LIGHT_NULL          0
+
+// ========================================
 // MODULE STATE
 // ========================================
 
@@ -487,7 +495,8 @@ R3D_Light r3d_light_new(R3D_LightType type)
     r3d_light_array_t* freeLights = &R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_FREE];
 
     // Get index (from free list or new)
-    R3D_Light index = (freeLights->count > 0) 
+    bool tookFromFree = (freeLights->count > 0);
+    R3D_Light index = tookFromFree
         ? freeLights->lights[--freeLights->count]
         : validLights->count;
 
@@ -505,20 +514,21 @@ R3D_Light r3d_light_new(R3D_LightType type)
 
     // Add to valid array
     validLights->lights[validLights->count++] = index;
-    return index;
+    return LIGHT_TO_ID(index);
 
 error_restore_free:
     // Restore free list if we took from it
-    if (index < validLights->count) {
+    if (tookFromFree) {
         freeLights->lights[freeLights->count++] = index;
     }
-    return -1;
+    return LIGHT_NULL;
 }
 
-void r3d_light_delete(R3D_Light index)
+void r3d_light_delete(R3D_Light id)
 {
-    if (index < 0) return;
+    if (id == LIGHT_NULL) return;
 
+    R3D_Light index = LIGHT_TO_INDEX(id);
     r3d_light_array_t* validLights = &R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_VALID];
 
     for (int i = 0; i < validLights->count; i++) {
@@ -546,10 +556,10 @@ void r3d_light_delete(R3D_Light index)
     }
 }
 
-bool r3d_light_is_valid(R3D_Light index)
+bool r3d_light_is_valid(R3D_Light id)
 {
-    if (index < 0) return false;
-
+    if (id == LIGHT_NULL) return false;
+    R3D_Light index = LIGHT_TO_INDEX(id);
     const r3d_light_array_t* validLights = &R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_VALID];
     for (int i = 0; i < validLights->count; i++) {
         if (index == validLights->lights[i]) return true;
@@ -557,9 +567,10 @@ bool r3d_light_is_valid(R3D_Light index)
     return false;
 }
 
-r3d_light_t* r3d_light_get(R3D_Light index)
+r3d_light_t* r3d_light_get(R3D_Light id)
 {
-    return r3d_light_is_valid(index) ? &R3D_MOD_LIGHT.lights[index] : NULL;
+    uint32_t index = LIGHT_TO_INDEX(id);
+    return r3d_light_is_valid(id) ? &R3D_MOD_LIGHT.lights[index] : NULL;
 }
 
 r3d_rect_t r3d_light_get_screen_rect(const r3d_light_t* light, const Matrix* viewProj, int w, int h)

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -107,7 +107,7 @@ static bool shadow_pool_expand(r3d_light_shadow_pool_t* pool, int addCount)
 // SHADOW MAP TEXTURE FUNCTIONS
 // ========================================
 
-static bool allocate_shadow_array(GLuint texture, GLenum target, int size, int layers)
+static bool shadow_array_allocate(GLuint texture, GLenum target, int size, int layers)
 {
     int actualLayers = (target == GL_TEXTURE_CUBE_MAP_ARRAY) ? layers * 6 : layers;
 
@@ -133,12 +133,12 @@ static bool allocate_shadow_array(GLuint texture, GLenum target, int size, int l
     return true;
 }
 
-static bool resize_shadow_array(GLuint* texture, GLenum target, int size, int oldLayers, int newLayers)
+static bool shadow_array_resize(GLuint* texture, GLenum target, int size, int oldLayers, int newLayers)
 {
     GLuint newTexture;
     glGenTextures(1, &newTexture);
 
-    if (!allocate_shadow_array(newTexture, target, size, newLayers)) {
+    if (!shadow_array_allocate(newTexture, target, size, newLayers)) {
         glDeleteTextures(1, &newTexture);
         return false;
     }
@@ -163,7 +163,7 @@ static bool resize_shadow_array(GLuint* texture, GLenum target, int size, int ol
     return true;
 }
 
-static bool expand_shadow_array_capacity(R3D_LightType type)
+static bool shadow_array_expand_capacity(R3D_LightType type)
 {
     r3d_light_shadow_pool_t* pool = &R3D_MOD_LIGHT.shadowPools[type];
     GLuint* shadowArray = &R3D_MOD_LIGHT.shadowArrays[type];
@@ -171,7 +171,7 @@ static bool expand_shadow_array_capacity(R3D_LightType type)
     int shadowSize = R3D_LIGHT_SHADOW_SIZE[type];
     int growth = SHADOW_LAYER_GROWTH[type];
 
-    if (!resize_shadow_array(shadowArray, shadowTarget, shadowSize, pool->totalLayers, pool->totalLayers + growth)) {
+    if (!shadow_array_resize(shadowArray, shadowTarget, shadowSize, pool->totalLayers, pool->totalLayers + growth)) {
         return false;
     }
 
@@ -554,7 +554,7 @@ bool r3d_light_enable_shadows(r3d_light_t* light)
 
     int layer = shadow_pool_reserve(&R3D_MOD_LIGHT.shadowPools[light->type]);
     if (layer < 0) {
-        if (!expand_shadow_array_capacity(light->type)) {
+        if (!shadow_array_expand_capacity(light->type)) {
             return false;
         }
         layer = shadow_pool_reserve(&R3D_MOD_LIGHT.shadowPools[light->type]);

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -215,16 +215,16 @@ static bool light_init(r3d_light_t* light, R3D_LightType type)
     light->outerCutOff = cosf(45.0f * DEG2RAD);
     light->fogEnergy = 1.0f;
 
-    light->shadowSoftness = 4.0f / R3D_LIGHT_SHADOW_SIZE[light->type];
+    light->shadowSoftness = 4.0f / R3D_LIGHT_SHADOW_SIZE[type];
     light->shadowOpacity = 1.0f;
     switch (type) {
     case R3D_LIGHT_DIR:
-        light->shadowDepthBias = 4.0f / R3D_LIGHT_SHADOW_SIZE[light->type];
-        light->shadowSlopeBias = 6.0f / R3D_LIGHT_SHADOW_SIZE[light->type];
+        light->shadowDepthBias = 4.0f / R3D_LIGHT_SHADOW_SIZE[type];
+        light->shadowSlopeBias = 6.0f / R3D_LIGHT_SHADOW_SIZE[type];
         break;
     case R3D_LIGHT_SPOT:
-        light->shadowDepthBias = 0.25f / R3D_LIGHT_SHADOW_SIZE[light->type];
-        light->shadowSlopeBias = 1.0f / R3D_LIGHT_SHADOW_SIZE[light->type];
+        light->shadowDepthBias = 0.25f / R3D_LIGHT_SHADOW_SIZE[type];
+        light->shadowSlopeBias = 1.0f / R3D_LIGHT_SHADOW_SIZE[type];
         break;
     case R3D_LIGHT_OMNI:
         light->shadowDepthBias = 0.025f;

--- a/src/modules/r3d_light.h
+++ b/src/modules/r3d_light.h
@@ -16,6 +16,7 @@
 #include <raylib.h>
 #include <glad.h>
 
+#include "../common/r3d_pool.h"
 #include "../common/r3d_math.h"
 
 // ========================================
@@ -32,9 +33,12 @@ static const int R3D_LIGHT_SHADOW_SIZE[] = {
 // HELPER MACROS
 // ========================================
 
-#define R3D_LIGHT_FOR_EACH_VISIBLE(light) \
-    for (r3d_light_t* light = NULL; \
-         r3d_light_iter(&light, R3D_LIGHT_ARRAY_VISIBLE); )
+#define R3D_LIGHT_FOR_EACH_VISIBLE(varname)                         \
+    for (uint32_t _i = 0; _i < R3D_MOD_LIGHT.visibleCount; _i++)    \
+        for (r3d_light_t* varname = r3d_pool_get(                   \
+                 R3D_MOD_LIGHT.pool,                                \
+                 R3D_MOD_LIGHT.visible[_i]);                        \
+             varname; varname = NULL)
 
 // ========================================
 // TYPES
@@ -81,18 +85,6 @@ typedef struct {
 
 } r3d_light_t;
 
-typedef enum {
-    R3D_LIGHT_ARRAY_VISIBLE,
-    R3D_LIGHT_ARRAY_VALID,
-    R3D_LIGHT_ARRAY_FREE,
-    R3D_LIGHT_ARRAY_COUNT
-} r3d_light_array_enum_t;
-
-typedef struct {
-    R3D_Light* lights;
-    int count;
-} r3d_light_array_t;
-
 // Shadow layer pool
 typedef struct {
     int* freeLayers;
@@ -115,9 +107,10 @@ extern struct r3d_light {
     r3d_light_shadow_pool_t shadowPools[R3D_LIGHT_TYPE_COUNT];
 
     // Light management
-    r3d_light_array_t arrays[R3D_LIGHT_ARRAY_COUNT];
-    r3d_light_t* lights;
-    int capacityLights;
+    r3d_pool_t* pool;           // Owns all r3d_light_t objects
+    R3D_Light* visible;         // Handles of lights visible this frame
+    uint32_t visibleCount;
+    uint32_t visibleCapacity;
 
 } R3D_MOD_LIGHT;
 
@@ -146,9 +139,6 @@ r3d_light_t* r3d_light_get(R3D_Light id);
 /* Returns the screen-space rectangle covered by the light's influence */
 r3d_rect_t r3d_light_get_screen_rect(const r3d_light_t* light, const Matrix* viewProj, int w, int h);
 
-/* Iterator for lights by category (stateful, not thread-safe) */
-bool r3d_light_iter(r3d_light_t** light, r3d_light_array_enum_t array);
-
 /* Enable shadows for a light */
 bool r3d_light_enable_shadows(r3d_light_t* light);
 
@@ -173,7 +163,12 @@ GLuint r3d_light_shadow_get(R3D_LightType type);
 
 static inline bool r3d_light_has_visible(void)
 {
-    return R3D_MOD_LIGHT.arrays[R3D_LIGHT_ARRAY_VISIBLE].count > 0;
+    return R3D_MOD_LIGHT.visibleCount > 0;
+}
+
+static inline bool r3d_light_has_any(void)
+{
+    return R3D_MOD_LIGHT.pool->count > 0;
 }
 
 #endif // R3D_MODULE_LIGHT_H

--- a/src/modules/r3d_light.h
+++ b/src/modules/r3d_light.h
@@ -135,13 +135,13 @@ void r3d_light_quit(void);
 R3D_Light r3d_light_new(R3D_LightType type);
 
 /* Delete a light and return it to the free list */
-void r3d_light_delete(R3D_Light index);
+void r3d_light_delete(R3D_Light id);
 
 /* Check whether a light handle is valid */
-bool r3d_light_is_valid(R3D_Light index);
+bool r3d_light_is_valid(R3D_Light id);
 
 /* Get internal light structure (returns NULL if invalid) */
-r3d_light_t* r3d_light_get(R3D_Light index);
+r3d_light_t* r3d_light_get(R3D_Light id);
 
 /* Returns the screen-space rectangle covered by the light's influence */
 r3d_rect_t r3d_light_get_screen_rect(const r3d_light_t* light, const Matrix* viewProj, int w, int h);


### PR DESCRIPTION
## Overview

Lights and probes are now managed through a generic versioned pool (`r3d_pool_t`). Each pool allocates a single contiguous block of memory containing the generation counters, the free-slot stack, and the object storage. Slot validity is checked in O(1) by comparing two generation arrays, replacing the previous O(n) linear scans. Free-slot recycling is handled internally, removing the hand-rolled index/free-list management that existed in both modules.

## Changes

`R3D_Light` and `R3D_Probe` are now aliases for `uint32_t` instead of `int32_t`.
Handle `0` is now the null/invalid sentinel.