### PR TITLE
Replace framebuffer blits with shader-based copies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,9 @@ embed_shaders(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/shaders/post/smaa.frag"
     "${R3D_ROOT_PATH}/shaders/post/visualizer.frag"
     # Blit
+    "${R3D_ROOT_PATH}/shaders/blit/common_copy.frag"
+    "${R3D_ROOT_PATH}/shaders/blit/common_nearest.frag"
+    "${R3D_ROOT_PATH}/shaders/blit/common_linear.frag"
     "${R3D_ROOT_PATH}/shaders/blit/up_bicubic.frag"
     "${R3D_ROOT_PATH}/shaders/blit/up_lanczos.frag"
     "${R3D_ROOT_PATH}/shaders/blit/down_rgss.frag"

--- a/shaders/blit/common_copy.frag
+++ b/shaders/blit/common_copy.frag
@@ -1,0 +1,25 @@
+/* common_copy.frag -- Fast blit copy
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+// NOTE: Must only be used between two targets of the same dimensions
+
+#version 330 core
+
+noperspective in vec2 vTexCoord;
+
+uniform sampler2D uSourceTex;
+uniform sampler2D uDepthTex;
+
+out vec4 FragColor;
+
+void main()
+{
+    ivec2 pixCoord = ivec2(gl_FragCoord.xy);
+    FragColor = texelFetch(uSourceTex, pixCoord, 0);
+    gl_FragDepth = texelFetch(uDepthTex, pixCoord, 0).r;
+}

--- a/shaders/blit/common_linear.frag
+++ b/shaders/blit/common_linear.frag
@@ -1,0 +1,22 @@
+/* common_linear.frag -- Blit with linear scaling
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+noperspective in vec2 vTexCoord;
+
+uniform sampler2D uSourceTex;
+uniform sampler2D uDepthTex;
+
+out vec4 FragColor;
+
+void main()
+{
+    FragColor = texture(uSourceTex, vTexCoord);
+    gl_FragDepth = texture(uDepthTex, vTexCoord).r;
+}

--- a/shaders/blit/common_nearest.frag
+++ b/shaders/blit/common_nearest.frag
@@ -1,0 +1,26 @@
+/* common_nearest.frag -- Blit with nearest scaling
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#version 330 core
+
+noperspective in vec2 vTexCoord;
+
+uniform sampler2D uSourceTex;
+uniform sampler2D uDepthTex;
+
+out vec4 FragColor;
+
+void main()
+{
+    ivec2 sourceSize = textureSize(uSourceTex, 0);
+    ivec2 pixCoord = ivec2(vTexCoord * vec2(sourceSize));
+    pixCoord = clamp(pixCoord, ivec2(0), sourceSize - 1);
+
+    FragColor = texelFetch(uSourceTex, pixCoord, 0);
+    gl_FragDepth = texelFetch(uDepthTex, pixCoord, 0).r;
+}

--- a/shaders/blit/down_pdss.frag
+++ b/shaders/blit/down_pdss.frag
@@ -8,22 +8,15 @@
 
 #version 330 core
 
-/* === Varyings === */
-
 noperspective in vec2 vTexCoord;
 
-/* === Uniforms === */
-
 uniform sampler2D uSourceTex;
+uniform sampler2D uDepthTex;
 uniform vec2 uDestTexel;
-
-/* === Fragments === */
 
 out vec4 FragColor;
 
-/* === Main program === */
-
-void main()
+vec4 SampleColor(sampler2D tex, vec2 texCoord, vec2 dstTexel)
 {
     const vec2 o00 = vec2( 0.176777,  0.000000) * 0.5;
     const vec2 o01 = vec2(-0.225772,  0.206826) * 0.5;
@@ -42,22 +35,28 @@ void main()
     const vec2 o14 = vec2(-0.547507,  0.778772) * 0.5;
     const vec2 o15 = vec2(-0.126487, -0.976090) * 0.5;
 
-    vec4 c  = texture(uSourceTex, vTexCoord + o00 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o01 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o02 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o03 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o04 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o05 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o06 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o07 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o08 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o09 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o10 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o11 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o12 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o13 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o14 * uDestTexel);
-         c += texture(uSourceTex, vTexCoord + o15 * uDestTexel);
+    vec4 c  = texture(tex, texCoord + o00 * dstTexel);
+         c += texture(tex, texCoord + o01 * dstTexel);
+         c += texture(tex, texCoord + o02 * dstTexel);
+         c += texture(tex, texCoord + o03 * dstTexel);
+         c += texture(tex, texCoord + o04 * dstTexel);
+         c += texture(tex, texCoord + o05 * dstTexel);
+         c += texture(tex, texCoord + o06 * dstTexel);
+         c += texture(tex, texCoord + o07 * dstTexel);
+         c += texture(tex, texCoord + o08 * dstTexel);
+         c += texture(tex, texCoord + o09 * dstTexel);
+         c += texture(tex, texCoord + o10 * dstTexel);
+         c += texture(tex, texCoord + o11 * dstTexel);
+         c += texture(tex, texCoord + o12 * dstTexel);
+         c += texture(tex, texCoord + o13 * dstTexel);
+         c += texture(tex, texCoord + o14 * dstTexel);
+         c += texture(tex, texCoord + o15 * dstTexel);
 
-    FragColor = c * (1.0 / 16.0);
+    return c * (1.0 / 16.0);
+}
+
+void main()
+{
+    FragColor = SampleColor(uSourceTex, vTexCoord, uDestTexel);
+    gl_FragDepth = texture(uDepthTex, vTexCoord).r;
 }

--- a/shaders/blit/down_rgss.frag
+++ b/shaders/blit/down_rgss.frag
@@ -8,22 +8,15 @@
 
 #version 330 core
 
-/* === Varyings === */
-
 noperspective in vec2 vTexCoord;
 
-/* === Uniforms === */
-
 uniform sampler2D uSourceTex;
+uniform sampler2D uDepthTex;
 uniform vec2 uDestTexel;
-
-/* === Fragments === */
 
 out vec4 FragColor;
 
-/* === Main program === */
-
-void main()
+vec4 SampleColor(sampler2D tex, vec2 texCoord, vec2 dstTexel)
 {
     // Rotated grid at ~26.6°, rhombus covering [-3/8, 3/8] on X and Y
 
@@ -32,10 +25,16 @@ void main()
     const vec2 o2 = vec2( 3.0, -1.0) / 8.0;
     const vec2 o3 = vec2(-1.0, -3.0) / 8.0;
 
-    vec4 c0 = texture(uSourceTex, vTexCoord + o0 * uDestTexel);
-    vec4 c1 = texture(uSourceTex, vTexCoord + o1 * uDestTexel);
-    vec4 c2 = texture(uSourceTex, vTexCoord + o2 * uDestTexel);
-    vec4 c3 = texture(uSourceTex, vTexCoord + o3 * uDestTexel);
+    vec4 c0 = texture(tex, texCoord + o0 * dstTexel);
+    vec4 c1 = texture(tex, texCoord + o1 * dstTexel);
+    vec4 c2 = texture(tex, texCoord + o2 * dstTexel);
+    vec4 c3 = texture(tex, texCoord + o3 * dstTexel);
 
-    FragColor = (c0 + c1 + c2 + c3) * 0.25;
+    return (c0 + c1 + c2 + c3) * 0.25;
+}
+
+void main()
+{
+    FragColor = SampleColor(uSourceTex, vTexCoord, uDestTexel);
+    gl_FragDepth = texture(uDepthTex, vTexCoord).r;
 }

--- a/shaders/blit/up_bicubic.frag
+++ b/shaders/blit/up_bicubic.frag
@@ -6,75 +6,57 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-// Based on MJP's implementation: https://gist.github.com/TheRealMJP/c83b8c0f46b63f3a88a5986f4fa982b1
-// Uses bilinear hardware filtering to reduce texture fetches from 16 to 9
+// Catmull-Rom bicubic filtering (B=0, C=0.5) using 9 bilinear taps.
+// Based on: https://gist.github.com/TheRealMJP/c83b8c0f46b63f3a88a5986f4fa982b1
 
 #version 330 core
 
-/* === Varyings === */
-
 noperspective in vec2 vTexCoord;
 
-/* === Uniforms === */
-
 uniform sampler2D uSourceTex;
-uniform vec2 uSourceTexel;
-
-/* === Fragments === */
+uniform sampler2D uDepthTex;
 
 out vec4 FragColor;
 
-/* === Main program === */
+vec4 SampleBicubic(sampler2D tex, vec2 uv)
+{
+    vec2 texSize = vec2(textureSize(tex, 0));
+    vec2 texel = 1.0 / texSize;
+
+    vec2 pos = uv * texSize;
+    vec2 tc = floor(pos - 0.5) + 0.5;
+    vec2 f = pos - tc;
+    vec2 f2 = f * f;
+    vec2 f3 = f2 * f;
+
+    vec2 w0 = f2 - 0.5 * (f3 + f);
+    vec2 w1 = 1.5 * f3 - 2.5 * f2 + 1.0;
+    vec2 w3 = 0.5 * (f3 - f2);
+    vec2 w2 = 1.0 - w0 - w1 - w3;
+
+    vec2 w12 = w1 + w2;
+    vec2 tc0  = (tc - 1.0) * texel;
+    vec2 tc3  = (tc + 2.0) * texel;
+    vec2 tc12 = (tc + w2 / w12) * texel;
+
+    vec4 c = vec4(0.0);
+    c += textureLod(tex, vec2(tc0.x,  tc0.y),  0.0) * w0.x  * w0.y;
+    c += textureLod(tex, vec2(tc12.x, tc0.y),  0.0) * w12.x * w0.y;
+    c += textureLod(tex, vec2(tc3.x,  tc0.y),  0.0) * w3.x  * w0.y;
+
+    c += textureLod(tex, vec2(tc0.x,  tc12.y), 0.0) * w0.x  * w12.y;
+    c += textureLod(tex, vec2(tc12.x, tc12.y), 0.0) * w12.x * w12.y;
+    c += textureLod(tex, vec2(tc3.x,  tc12.y), 0.0) * w3.x  * w12.y;
+
+    c += textureLod(tex, vec2(tc0.x,  tc3.y),  0.0) * w0.x  * w3.y;
+    c += textureLod(tex, vec2(tc12.x, tc3.y),  0.0) * w12.x * w3.y;
+    c += textureLod(tex, vec2(tc3.x,  tc3.y),  0.0) * w3.x  * w3.y;
+
+    return c;
+}
 
 void main()
 {
-    // We're going to sample a a 4x4 grid of texels surrounding the target UV coordinate. We'll do this by rounding
-    // down the sample location to get the exact center of our "starting" texel. The starting texel will be at
-    // location [1, 1] in the grid, where [0, 0] is the top left corner.
-    vec2 samplePos = vTexCoord * vec2(textureSize(uSourceTex, 0));
-    vec2 texPos1 = floor(samplePos - 0.5) + 0.5;
-
-    // Compute the fractional offset from our starting texel to our original sample location, which we'll
-    // feed into the Catmull-Rom spline function to get our filter weights.
-    vec2 f = samplePos - texPos1;
-
-    // Compute the Catmull-Rom weights (optimized Horner form) using the fractional offset that we calculated earlier.
-    // These equations are pre-expanded based on our knowledge of where the texels will be located,
-    // which lets us avoid having to evaluate a piece-wise function.
-    vec2 w0 = f * (-0.5 + f * (1.0 - 0.5 * f));
-    vec2 w1 = 1.0 + f * f * (-2.5 + 1.5 * f);
-    vec2 w2 = f * (0.5 + f * (2.0 - 1.5 * f));
-    vec2 w3 = f * f * (-0.5 + 0.5 * f);
-
-    // Work out weighting factors and sampling offsets that will let us use bilinear filtering to
-    // simultaneously evaluate the middle 2 samples from the 4x4 grid.
-    vec2 w12 = w1 + w2;
-    vec2 offset12 = w2 / (w1 + w2);
-
-    // Compute the final UV coordinates we'll use for sampling the texture
-    vec2 texPos0 = texPos1 - 1.0;
-    vec2 texPos3 = texPos1 + 2.0;
-    vec2 texPos12 = texPos1 + offset12;
-
-    // Convert back to UV space
-    texPos0 *= uSourceTexel;
-    texPos3 *= uSourceTexel;
-    texPos12 *= uSourceTexel;
-
-    // Sample texture at 9 positions using bilinear filtering
-    vec4 result = vec4(0.0);
-
-    result += texture(uSourceTex, vec2(texPos0.x, texPos0.y)) * w0.x * w0.y;
-    result += texture(uSourceTex, vec2(texPos12.x, texPos0.y)) * w12.x * w0.y;
-    result += texture(uSourceTex, vec2(texPos3.x, texPos0.y)) * w3.x * w0.y;
-
-    result += texture(uSourceTex, vec2(texPos0.x, texPos12.y)) * w0.x * w12.y;
-    result += texture(uSourceTex, vec2(texPos12.x, texPos12.y)) * w12.x * w12.y;
-    result += texture(uSourceTex, vec2(texPos3.x, texPos12.y)) * w3.x * w12.y;
-
-    result += texture(uSourceTex, vec2(texPos0.x, texPos3.y)) * w0.x * w3.y;
-    result += texture(uSourceTex, vec2(texPos12.x, texPos3.y)) * w12.x * w3.y;
-    result += texture(uSourceTex, vec2(texPos3.x, texPos3.y)) * w3.x * w3.y;
-
-    FragColor = result;
+    FragColor = SampleBicubic(uSourceTex, vTexCoord);
+    gl_FragDepth = texture(uDepthTex, vTexCoord).r;
 }

--- a/shaders/blit/up_lanczos.frag
+++ b/shaders/blit/up_lanczos.frag
@@ -6,82 +6,77 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
+// 12-tap Lanczos-2 approximation (4x4 grid minus its 4 outer corners).
+// Corner taps are nulled via Lanczos(1.0) == 0.0, avoiding 4 extra fetches.
+
 #version 330 core
 
-/* === Includes === */
-
-#include <lib/math.glsl>
-
-/* === Varyings === */
+#define M_PI  3.1415926535897931
+#define M_HPI 1.5707963267948966
 
 noperspective in vec2 vTexCoord;
 
-/* === Uniforms === */
-
 uniform sampler2D uSourceTex;
-uniform vec2 uSourceTexel;
-
-/* === Fragments === */
+uniform sampler2D uDepthTex;
 
 out vec4 FragColor;
 
-/* === Lanczos-2 filter === */
-
 vec4 Lanczos(vec4 x)
 {
-    // Lanczos windowed sinc function
-    // sinc(x) * sinc(x/2) where sinc(x) = sin(M_PI*x)/(M_PI*x)
-    return (x == vec4(0.0)) ? vec4(M_PI * M_HPI) : sin(x * M_HPI) * sin(x * M_PI) / (x * x);
+    x += 1e-5; // avoids 0/0 when a sample lands exactly on a texel center
+    return sin(x * M_PI) * sin(x * M_HPI) / (x * x);
 }
 
-/* === Main program === */
-
-void main()
+vec4 SampleLanczos(sampler2D tex, vec2 texCoord)
 {
-    vec3 color;
-    mat4 weights;
+    vec2 texSize = vec2(textureSize(tex, 0));
+    vec2 texel = 1.0 / texSize;
 
     vec2 dx = vec2(1.0, 0.0);
     vec2 dy = vec2(0.0, 1.0);
 
-    vec2 pc = vTexCoord * vec2(textureSize(uSourceTex, 0));
-    vec2 tc = floor(pc - vec2(0.5, 0.5)) + vec2(0.5, 0.5);
+    vec2 pc = texCoord * texSize;
+    vec2 tc = floor(pc - 0.5) + 0.5;
 
-    weights[0] = Lanczos(vec4(1.0, distance(pc, tc - dy), distance(pc, tc + dx - dy), 1.0));
-    weights[1] = Lanczos(vec4(distance(pc, tc - dx), distance(pc, tc), distance(pc, tc + dx), distance(pc, tc + 2.0 * dx)));
-    weights[2] = Lanczos(vec4(distance(pc, tc - dx + dy), distance(pc, tc + dy), distance(pc, tc + dx + dy), distance(pc, tc + 2.0 * dx + dy)));
-    weights[3] = Lanczos(vec4(1.0, distance(pc, tc + 2.0 * dy), distance(pc, tc + dx + 2.0 * dy), 1.0));
+    mat4 w;
+    w[0] = Lanczos(vec4(1.0, distance(pc, tc - dy), distance(pc, tc + dx - dy), 1.0));
+    w[1] = Lanczos(vec4(distance(pc, tc - dx), distance(pc, tc), distance(pc, tc + dx), distance(pc, tc + 2.0 * dx)));
+    w[2] = Lanczos(vec4(distance(pc, tc - dx + dy), distance(pc, tc + dy), distance(pc, tc + dx + dy), distance(pc, tc + 2.0 * dx + dy)));
+    w[3] = Lanczos(vec4(1.0, distance(pc, tc + 2.0 * dy), distance(pc, tc + dx + 2.0 * dy), 1.0));
 
-    dx = dx * uSourceTexel;
-    dy = dy * uSourceTexel;
-    tc = tc * uSourceTexel;
+    dx *= texel;
+    dy *= texel;
+    tc *= texel;
 
-    vec3 c10 = texture(uSourceTex, tc - dy).rgb;
-    vec3 c20 = texture(uSourceTex, tc + dx - dy).rgb;
-    vec3 c01 = texture(uSourceTex, tc - dx).rgb;
-    vec3 c11 = texture(uSourceTex, tc).rgb;
-    vec3 c21 = texture(uSourceTex, tc + dx).rgb;
-    vec3 c31 = texture(uSourceTex, tc + 2.0 * dx).rgb;
-    vec3 c02 = texture(uSourceTex, tc - dx + dy).rgb;
-    vec3 c12 = texture(uSourceTex, tc + dy).rgb;
-    vec3 c22 = texture(uSourceTex, tc + dx + dy).rgb;
-    vec3 c32 = texture(uSourceTex, tc + 2.0 * dx + dy).rgb;
-    vec3 c13 = texture(uSourceTex, tc + 2.0 * dy).rgb;
-    vec3 c23 = texture(uSourceTex, tc + dx + 2.0 * dy).rgb;
+    vec3 c10 = textureLod(tex, tc - dy, 0.0).rgb;
+    vec3 c20 = textureLod(tex, tc + dx - dy, 0.0).rgb;
+    vec3 c01 = textureLod(tex, tc - dx, 0.0).rgb;
+    vec3 c11 = textureLod(tex, tc, 0.0).rgb;
+    vec3 c21 = textureLod(tex, tc + dx, 0.0).rgb;
+    vec3 c31 = textureLod(tex, tc + 2.0 * dx, 0.0).rgb;
+    vec3 c02 = textureLod(tex, tc - dx + dy, 0.0).rgb;
+    vec3 c12 = textureLod(tex, tc + dy, 0.0).rgb;
+    vec3 c22 = textureLod(tex, tc + dx + dy, 0.0).rgb;
+    vec3 c32 = textureLod(tex, tc + 2.0 * dx + dy, 0.0).rgb;
+    vec3 c13 = textureLod(tex, tc + 2.0 * dy, 0.0).rgb;
+    vec3 c23 = textureLod(tex, tc + dx + 2.0 * dy, 0.0).rgb;
 
-    vec3 o = vec3(0.0);
-
-    color  = weights[0][0] * o   + weights[0][1] * c10 + weights[0][2] * c20 + weights[0][3] * o;
-    color += weights[1][0] * c01 + weights[1][1] * c11 + weights[1][2] * c21 + weights[1][3] * c31;
-    color += weights[2][0] * c02 + weights[2][1] * c12 + weights[2][2] * c22 + weights[2][3] * c32;
-    color += weights[3][0] * o   + weights[3][1] * c13 + weights[3][2] * c23 + weights[3][3] * o;
+    vec3 color =
+        w[0][1] * c10 + w[0][2] * c20 +
+        w[1][0] * c01 + w[1][1] * c11 + w[1][2] * c21 + w[1][3] * c31 +
+        w[2][0] * c02 + w[2][1] * c12 + w[2][2] * c22 + w[2][3] * c32 +
+        w[3][1] * c13 + w[3][2] * c23;
 
     float weightSum = 0.0;
-    for (int i = 0; i < 4; i++) {
-        for (int j = 0; j < 4; j++) {
-            weightSum += weights[i][j];
-        }
-    }
+    for (int i = 0; i < 4; ++i)
+        for (int j = 0; j < 4; ++j)
+            weightSum += w[i][j];
 
-    FragColor = vec4(color / weightSum, 1.0);
+    return vec4(color / weightSum, 1.0);
+}
+
+void main()
+{
+    FragColor = SampleLanczos(uSourceTex, vTexCoord);
+    gl_FragDepth = texture(uDepthTex, vTexCoord).r;
 }

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -77,6 +77,9 @@
 #include <shaders/smaa.vert.h>
 #include <shaders/smaa.frag.h>
 #include <shaders/visualizer.frag.h>
+#include <shaders/common_copy.frag.h>
+#include <shaders/common_nearest.frag.h>
+#include <shaders/common_linear.frag.h>
 #include <shaders/up_bicubic.frag.h>
 #include <shaders/up_lanczos.frag.h>
 #include <shaders/down_rgss.frag.h>
@@ -1557,15 +1560,50 @@ bool r3d_shader_load_post_visualizer(r3d_shader_custom_t* custom)
     return true;
 }
 
+bool r3d_shader_load_blit_common_copy(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_blit_common_copy_t, blit, commonCopy);
+    LOAD_SHADER(commonCopy, SCREEN_VERT, COMMON_COPY_FRAG);
+
+    USE_SHADER(commonCopy);
+    SET_SAMPLER(commonCopy, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+    SET_SAMPLER(commonCopy, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+
+    return true;
+}
+
+bool r3d_shader_load_blit_common_nearest(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_blit_common_nearest_t, blit, commonNearest);
+    LOAD_SHADER(commonNearest, SCREEN_VERT, COMMON_NEAREST_FRAG);
+
+    USE_SHADER(commonNearest);
+    SET_SAMPLER(commonNearest, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+    SET_SAMPLER(commonNearest, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+
+    return true;
+}
+
+bool r3d_shader_load_blit_common_linear(r3d_shader_custom_t* custom)
+{
+    DECL_SHADER(r3d_shader_blit_common_linear_t, blit, commonLinear);
+    LOAD_SHADER(commonLinear, SCREEN_VERT, COMMON_LINEAR_FRAG);
+
+    USE_SHADER(commonLinear);
+    SET_SAMPLER(commonLinear, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+    SET_SAMPLER(commonLinear, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
+
+    return true;
+}
+
 bool r3d_shader_load_blit_up_bicubic(r3d_shader_custom_t* custom)
 {
     DECL_SHADER(r3d_shader_blit_up_bicubic_t, blit, upBicubic);
     LOAD_SHADER(upBicubic, SCREEN_VERT, UP_BICUBIC_FRAG);
 
-    GET_LOCATION(upBicubic, uSourceTexel);
-
     USE_SHADER(upBicubic);
     SET_SAMPLER(upBicubic, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+    SET_SAMPLER(upBicubic, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 
     return true;
 }
@@ -1575,10 +1613,9 @@ bool r3d_shader_load_blit_up_lanczos(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_blit_up_lanczos_t, blit, upLanczos);
     LOAD_SHADER(upLanczos, SCREEN_VERT, UP_LANCZOS_FRAG);
 
-    GET_LOCATION(upLanczos, uSourceTexel);
-
     USE_SHADER(upLanczos);
     SET_SAMPLER(upLanczos, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+    SET_SAMPLER(upLanczos, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 
     return true;
 }
@@ -1592,6 +1629,7 @@ bool r3d_shader_load_blit_down_rgss(r3d_shader_custom_t* custom)
 
     USE_SHADER(downRgss);
     SET_SAMPLER(downRgss, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+    SET_SAMPLER(downRgss, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 
     return true;
 }
@@ -1605,6 +1643,7 @@ bool r3d_shader_load_blit_down_pdss(r3d_shader_custom_t* custom)
 
     USE_SHADER(downPdss);
     SET_SAMPLER(downPdss, uSourceTex, R3D_SHADER_SAMPLER_SOURCE_2D_0);
+    SET_SAMPLER(downPdss, uDepthTex, R3D_SHADER_SAMPLER_BUFFER_DEPTH);
 
     return true;
 }
@@ -1690,6 +1729,9 @@ void r3d_shader_quit()
     UNLOAD_SHADERS(post.smaa);
     UNLOAD_SHADER(post.visualizer);
 
+    UNLOAD_SHADER(blit.commonCopy);
+    UNLOAD_SHADER(blit.commonNearest);
+    UNLOAD_SHADER(blit.commonLinear);
     UNLOAD_SHADER(blit.upBicubic);
     UNLOAD_SHADER(blit.upLanczos);
     UNLOAD_SHADER(blit.downRgss);

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -1189,24 +1189,44 @@ typedef struct {
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSourceTex;
-    r3d_shader_uniform_vec2_t uSourceTexel;
+    r3d_shader_uniform_sampler_t uDepthTex;
+} r3d_shader_blit_common_copy_t;
+
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uSourceTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
+} r3d_shader_blit_common_nearest_t;
+
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uSourceTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
+} r3d_shader_blit_common_linear_t;
+
+typedef struct {
+    GLuint id;
+    r3d_shader_uniform_sampler_t uSourceTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
 } r3d_shader_blit_up_bicubic_t;
 
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSourceTex;
-    r3d_shader_uniform_vec2_t uSourceTexel;
+    r3d_shader_uniform_sampler_t uDepthTex;
 } r3d_shader_blit_up_lanczos_t;
 
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSourceTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_vec2_t uDestTexel;
 } r3d_shader_blit_down_rgss_t;
 
 typedef struct {
     GLuint id;
     r3d_shader_uniform_sampler_t uSourceTex;
+    r3d_shader_uniform_sampler_t uDepthTex;
     r3d_shader_uniform_vec2_t uDestTexel;
 } r3d_shader_blit_down_pdss_t;
 
@@ -1335,6 +1355,9 @@ extern struct r3d_mod_shader {
 
     // Blit shaders
     struct {
+        r3d_shader_blit_common_copy_t commonCopy;
+        r3d_shader_blit_common_nearest_t commonNearest;
+        r3d_shader_blit_common_linear_t commonLinear;
         r3d_shader_blit_up_bicubic_t upBicubic;
         r3d_shader_blit_up_lanczos_t upLanczos;
         r3d_shader_blit_down_rgss_t downRgss;
@@ -1413,6 +1436,9 @@ bool r3d_shader_load_post_smaa_medium(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_smaa_high(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_smaa_ultra(r3d_shader_custom_t* custom);
 bool r3d_shader_load_post_visualizer(r3d_shader_custom_t* custom);
+bool r3d_shader_load_blit_common_copy(r3d_shader_custom_t* custom);
+bool r3d_shader_load_blit_common_nearest(r3d_shader_custom_t* custom);
+bool r3d_shader_load_blit_common_linear(r3d_shader_custom_t* custom);
 bool r3d_shader_load_blit_up_bicubic(r3d_shader_custom_t* custom);
 bool r3d_shader_load_blit_up_lanczos(r3d_shader_custom_t* custom);
 bool r3d_shader_load_blit_down_rgss(r3d_shader_custom_t* custom);
@@ -1491,6 +1517,9 @@ static const struct r3d_shader_loader {
 
     // Blit shaders
     struct {
+        r3d_shader_loader_func commonCopy;
+        r3d_shader_loader_func commonNearest;
+        r3d_shader_loader_func commonLinear;
         r3d_shader_loader_func upBicubic;
         r3d_shader_loader_func upLanczos;
         r3d_shader_loader_func downRgss;
@@ -1576,6 +1605,9 @@ static const struct r3d_shader_loader {
     },
 
     .blit = {
+        .commonCopy = r3d_shader_load_blit_common_copy,
+        .commonNearest = r3d_shader_load_blit_common_nearest,
+        .commonLinear = r3d_shader_load_blit_common_linear,
         .upBicubic = r3d_shader_load_blit_up_bicubic,
         .upLanczos = r3d_shader_load_blit_up_lanczos,
         .downRgss = r3d_shader_load_blit_down_rgss,

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -500,6 +500,11 @@ GLuint r3d_target_get_all_levels(r3d_target_t target)
     return R3D_MOD_TARGET.targetTextures[target];
 }
 
+GLuint r3d_target_get_depth_buffer(void)
+{
+    return R3D_MOD_TARGET.depthTexture;
+}
+
 void r3d_target_blit(r3d_target_t target, bool depth, GLuint dstFbo, int dstX, int dstY, int dstW, int dstH, bool linear)
 {
     assert(target > R3D_TARGET_INVALID || depth);

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -135,11 +135,17 @@ static void alloc_target_texture(r3d_target_t target)
     R3D_MOD_TARGET.targetLoaded[target] = true;
 }
 
-static void alloc_depth_stencil_renderbuffer(int resW, int resH)
+static void alloc_depth_stencil_texture(int resW, int resH)
 {
-    glBindRenderbuffer(GL_RENDERBUFFER, R3D_MOD_TARGET.depthRenderbuffer);
-    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, resW, resH);
-    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, R3D_MOD_TARGET.depthTexture);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, resW, resH, 0,
+                 GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 /*
@@ -191,9 +197,10 @@ static int get_or_create_fbo(const r3d_target_t* targets, int count, bool depth)
     }
 
     if (depth) {
-        glFramebufferRenderbuffer(
+        glFramebufferTexture2D(
             GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
-            GL_RENDERBUFFER, R3D_MOD_TARGET.depthRenderbuffer
+            GL_TEXTURE_2D, R3D_MOD_TARGET.depthTexture,
+            0
         );
     }
 
@@ -225,8 +232,8 @@ bool r3d_target_init(int resW, int resH)
     memset(&R3D_MOD_TARGET, 0, sizeof(R3D_MOD_TARGET));
 
     glGenTextures(R3D_TARGET_COUNT, R3D_MOD_TARGET.targetTextures);
-    glGenRenderbuffers(1, &R3D_MOD_TARGET.depthRenderbuffer);
-    alloc_depth_stencil_renderbuffer(resW, resH);
+    glGenTextures(1, &R3D_MOD_TARGET.depthTexture);
+    alloc_depth_stencil_texture(resW, resH);
 
     R3D_MOD_TARGET.currentFbo = -1;
 
@@ -241,7 +248,7 @@ bool r3d_target_init(int resW, int resH)
 void r3d_target_quit(void)
 {
     glDeleteTextures(R3D_TARGET_COUNT, R3D_MOD_TARGET.targetTextures);
-    glDeleteRenderbuffers(1, &R3D_MOD_TARGET.depthRenderbuffer);
+    glDeleteTextures(1, &R3D_MOD_TARGET.depthTexture);
 
     for (int i = 0; i < R3D_MOD_TARGET.fboCount; i++) {
         if (R3D_MOD_TARGET.fbo[i].id != 0) {
@@ -263,7 +270,7 @@ void r3d_target_resize(int resW, int resH)
     R3D_MOD_TARGET.txlW = 1.0f / resW;
     R3D_MOD_TARGET.txlH = 1.0f / resH;
 
-    alloc_depth_stencil_renderbuffer(resW, resH);
+    alloc_depth_stencil_texture(resW, resH);
 
     for (int i = 0; i < R3D_TARGET_COUNT; i++) {
         if (R3D_MOD_TARGET.targetLoaded[i]) {

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -182,7 +182,7 @@ extern struct r3d_mod_target {
     GLuint targetTextures[R3D_TARGET_COUNT];            //< Array of target IDs (textures)
     bool targetLoaded[R3D_TARGET_COUNT];                //< Indicates whether the targets have been allocated
 
-    GLuint depthRenderbuffer;   //< Internal depth buffer
+    GLuint depthTexture;        //< Internal HW depth buffer
     uint32_t resW, resH;        //< Full internal resolution
     float txlW, txlH;           //< Size of a texel for full resolution
 

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -340,6 +340,12 @@ GLuint r3d_target_get_levels(r3d_target_t target, int baseLevel, int maxLevel);
 GLuint r3d_target_get_all_levels(r3d_target_t target);
 
 /*
+ * Returns the ID of the internal HW depth texture,
+ * not the linear depth texture accessible via `r3d_target_get`.
+ */
+GLuint r3d_target_get_depth_buffer(void);
+
+/*
  * Blits the provided targets to the specified FBO.
  * Supports blitting with only a depth target.
  */

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -2714,73 +2714,82 @@ void blit_to_screen(r3d_target_t source)
         return;
     }
 
-    bool sameDim = (dstW == srcW) && (dstH == srcH);
-    bool upscale = (dstW >= srcW) && (dstH >= srcH) && !sameDim;
-    bool downscale = (dstW <= srcW) && (dstH <= srcH) && !sameDim;
-    bool mixedScale = !sameDim && !upscale && !downscale;
+    int dstSq = dstW * dstH;
+    int srcSq = srcW * srcH;
+    int sign = (dstSq > srcSq) - (dstSq < srcSq);
 
-    if (sameDim || (upscale && R3D.upscaleMode == R3D_UPSCALE_NEAREST) || (downscale && R3D.downscaleMode == R3D_DOWNSCALE_NEAREST)) {
-        r3d_target_blit(source, true, dstId, dstX, glDstY, dstW, dstH, false);
-        return;
-    }
+    glBindFramebuffer(GL_FRAMEBUFFER, dstId);
+    glViewport(dstX, glDstY, dstW, dstH);
 
-    if (mixedScale || (upscale && R3D.upscaleMode == R3D_UPSCALE_LINEAR) || (downscale && R3D.downscaleMode == R3D_DOWNSCALE_LINEAR)) {
-        r3d_target_blit(source, true, dstId, dstX, glDstY, dstW, dstH, true);
-        return;
-    }
+    r3d_driver_enable(GL_DEPTH_TEST);
+    r3d_driver_set_depth_mask(GL_TRUE);
+    r3d_driver_set_depth_func(GL_ALWAYS);
 
-    if (upscale) {
-        glBindFramebuffer(GL_FRAMEBUFFER, dstId);
-        glViewport(dstX, glDstY, dstW, dstH);
-
+    if (sign > 0) {
         switch (R3D.upscaleMode) {
+        case R3D_UPSCALE_NEAREST:
+            R3D_SHADER_USE(blit.commonNearest);
+            R3D_SHADER_BIND_SAMPLER(blit.commonNearest, uSourceTex, r3d_target_get(source));
+            R3D_SHADER_BIND_SAMPLER(blit.commonNearest, uDepthTex, r3d_target_get_depth_buffer());
+            R3D_RENDER_SCREEN();
+            break;
+        case R3D_UPSCALE_LINEAR:
+            R3D_SHADER_USE(blit.commonLinear);
+            R3D_SHADER_BIND_SAMPLER(blit.commonLinear, uSourceTex, r3d_target_get(source));
+            R3D_SHADER_BIND_SAMPLER(blit.commonLinear, uDepthTex, r3d_target_get_depth_buffer());
+            R3D_RENDER_SCREEN();
+            break;
         case R3D_UPSCALE_BICUBIC:
             R3D_SHADER_USE(blit.upBicubic);
-            R3D_SHADER_SET_VEC2(blit.upBicubic, uSourceTexel, (Vector2) {R3D_TARGET_TEXEL_W, R3D_TARGET_TEXEL_H});
             R3D_SHADER_BIND_SAMPLER(blit.upBicubic, uSourceTex, r3d_target_get(source));
+            R3D_SHADER_BIND_SAMPLER(blit.upBicubic, uDepthTex, r3d_target_get_depth_buffer());
+            R3D_RENDER_SCREEN();
             break;
-
         case R3D_UPSCALE_LANCZOS:
             R3D_SHADER_USE(blit.upLanczos);
-            R3D_SHADER_SET_VEC2(blit.upLanczos, uSourceTexel, (Vector2) {R3D_TARGET_TEXEL_W, R3D_TARGET_TEXEL_H});
             R3D_SHADER_BIND_SAMPLER(blit.upLanczos, uSourceTex, r3d_target_get(source));
+            R3D_SHADER_BIND_SAMPLER(blit.upLanczos, uDepthTex, r3d_target_get_depth_buffer());
+            R3D_RENDER_SCREEN();
             break;
-
         default:
-            r3d_target_blit(source, true, dstId, dstX, glDstY, dstW, dstH, true);
-            return;
+            break;
         }
-
-        R3D_RENDER_SCREEN();
-        r3d_target_blit(-1, true, dstId, dstX, glDstY, dstW, dstH, false);
-        return;
     }
-
-    if (downscale) {
-        glBindFramebuffer(GL_FRAMEBUFFER, dstId);
-        glViewport(dstX, glDstY, dstW, dstH);
-
+    else if (sign < 0) {
         switch (R3D.downscaleMode) {
+        case R3D_DOWNSCALE_NEAREST:
+            R3D_SHADER_USE(blit.commonNearest);
+            R3D_SHADER_BIND_SAMPLER(blit.commonNearest, uSourceTex, r3d_target_get(source));
+            R3D_SHADER_BIND_SAMPLER(blit.commonNearest, uDepthTex, r3d_target_get_depth_buffer());
+            R3D_RENDER_SCREEN();
+            break;
+        case R3D_DOWNSCALE_LINEAR:
+            R3D_SHADER_USE(blit.commonLinear);
+            R3D_SHADER_BIND_SAMPLER(blit.commonLinear, uSourceTex, r3d_target_get(source));
+            R3D_SHADER_BIND_SAMPLER(blit.commonLinear, uDepthTex, r3d_target_get_depth_buffer());
+            R3D_RENDER_SCREEN();
+            break;
         case R3D_DOWNSCALE_RGSS:
             R3D_SHADER_USE(blit.downRgss);
             R3D_SHADER_SET_VEC2(blit.downRgss, uDestTexel, (Vector2) {1.0f / dstW, 1.0f / dstH});
             R3D_SHADER_BIND_SAMPLER(blit.downRgss, uSourceTex, r3d_target_get(source));
+            R3D_RENDER_SCREEN();
             break;
-
         case R3D_DOWNSCALE_PDSS:
             R3D_SHADER_USE(blit.downPdss);
             R3D_SHADER_SET_VEC2(blit.downPdss, uDestTexel, (Vector2) {1.0f / dstW, 1.0f / dstH});
             R3D_SHADER_BIND_SAMPLER(blit.downPdss, uSourceTex, r3d_target_get(source));
+            R3D_RENDER_SCREEN();
             break;
-
         default:
-            r3d_target_blit(source, true, dstId, dstX, glDstY, dstW, dstH, true);
-            return;
+            break;
         }
-
+    }
+    else {
+        R3D_SHADER_USE(blit.commonCopy);
+        R3D_SHADER_BIND_SAMPLER(blit.commonCopy, uSourceTex, r3d_target_get(source));
+        R3D_SHADER_BIND_SAMPLER(blit.commonCopy, uDepthTex, r3d_target_get_depth_buffer());
         R3D_RENDER_SCREEN();
-        r3d_target_blit(-1, true, dstId, dstX, glDstY, dstW, dstH, false);
-        return;
     }
 }
 


### PR DESCRIPTION
Replace all `glBlitFramebuffer` copies with shader passes, including nearest and linear copies.

This avoids relying on drivers accepting depth blits between a `GL_DEPTH24_STENCIL8` source and a `GL_DEPTH_COMPONENT24` destination, which is not allowed by the OpenGL specification.

While NVIDIA and AMD drivers seems to have accepted this up to now, Apple's driver correctly rejects it (see #311).

Depth is now copied through `gl_FragDepth` using `GL_ALWAYS` to preserve the previous overwrite behavior.
The internal depth attachment is now a texture instead of a renderbuffer.
