### PR TITLE
Added a hint system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ set(R3D_CONFIG_DEFAULTS
     R3D_MAX_SHADER_SAMPLERS             4
     R3D_MAX_SHADER_UNIFORMS             16
     R3D_MAX_SCREEN_SHADERS              4       #< Max possible in each screen shader chain hook
-    R3D_SHADER_LIGHT_FORWARD_UBO_CAP    8
-    R3D_SHADER_PROBE_UBO_CAP            8
+    R3D_SHADER_LIGHT_FORWARD_UBO_CAP    32
+    R3D_SHADER_PROBE_UBO_CAP            16
     R3D_ENABLE_TRACELOG                 1       #< Log level can be set via raylib
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,19 +51,13 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${R3D_ARCHIVE_OUTPUT_DIRECTORY})
 # ========================================
 
 set(R3D_CONFIG_DEFAULTS
-    R3D_MAX_LIGHT_FORWARD_PER_MESH      8
-    R3D_MAX_PROBE_ON_SCREEN             8
-    R3D_PROBE_CAPTURE_SIZE              256
-    R3D_SHADOW_MAP_DIRECTIONAL_SIZE     4096
-    R3D_SHADOW_MAP_SPOT_SIZE            2048
-    R3D_SHADOW_MAP_OMNI_SIZE            2048
-    R3D_CUBEMAP_IRRADIANCE_SIZE         32
-    R3D_CUBEMAP_PREFILTER_SIZE          128
     R3D_MAX_SHADER_CODE_LENGTH          16384
     R3D_MAX_SHADER_SAMPLERS             4
     R3D_MAX_SHADER_UNIFORMS             16
-    R3D_MAX_SCREEN_SHADERS              4
-    R3D_ENABLE_TRACELOG                 1
+    R3D_MAX_SCREEN_SHADERS              4       #< Max possible in each screen shader chain hook
+    R3D_SHADER_LIGHT_FORWARD_UBO_CAP    8
+    R3D_SHADER_PROBE_UBO_CAP            8
+    R3D_ENABLE_TRACELOG                 1       #< Log level can be set via raylib
 )
 
 list(LENGTH R3D_CONFIG_DEFAULTS _len)

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -31,15 +31,15 @@
  * @note Some hints may be clamped internally.
  */
 typedef enum R3D_Hint {
-    R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH,    ///< Max lights per mesh in forward pass. Default: 16
-    R3D_HINT_MAX_PROBE_ON_SCREEN,           ///< Max probes rendered simultaneously. Default: 8
-    R3D_HINT_PROBE_CAPTURE_SIZE,            ///< Probe capture cubemap face size (px). Default: 256
-    R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE,   ///< Directional light shadow map size (px). Default: 4096
-    R3D_HINT_SHADOW_MAP_SPOT_SIZE,          ///< Spot light shadow map size (px). Default: 2048
-    R3D_HINT_SHADOW_MAP_OMNI_SIZE,          ///< Omni light shadow map size (px). Default: 2048
-    R3D_HINT_CUBEMAP_IRRADIANCE_SIZE,       ///< Irradiance cubemap face size (px). Default: 32
-    R3D_HINT_CUBEMAP_PREFILTER_SIZE,        ///< Prefiltered cubemap face size (px). Default: 128
-    R3D_HINT_COUNT,                         ///< Sentinel, not a valid hint
+    R3D_HINT_FORWARD_LIGHT_PER_MESH,    ///< Max lights per mesh in forward pass. Default: 16
+    R3D_HINT_PROBE_MAX_ACTIVE,          ///< Max probes rendered simultaneously. Default: 8
+    R3D_HINT_PROBE_CAPTURE_SIZE,        ///< Probe capture cubemap face size (px). Default: 256
+    R3D_HINT_SHADOW_DIR_SIZE,           ///< Directional light shadow map size (px). Default: 4096
+    R3D_HINT_SHADOW_SPOT_SIZE,          ///< Spot light shadow map size (px). Default: 2048
+    R3D_HINT_SHADOW_OMNI_SIZE,          ///< Omni light shadow map size (px). Default: 2048
+    R3D_HINT_IBL_IRRADIANCE_SIZE,       ///< Irradiance cubemap face size, shared by ambient IBL and probes (px). Default: 32
+    R3D_HINT_IBL_PREFILTER_SIZE,        ///< Prefiltered cubemap face size, shared by ambient IBL and probes (px). Default: 128
+    R3D_HINT_COUNT,                     ///< Sentinel, not a valid hint
 } R3D_Hint;
 
 /**

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -23,6 +23,26 @@
 // ========================================
 
 /**
+ * @brief Configuration hints used to customize R3D before initialization.
+ *
+ * Hints must be set via R3D_SetHint() before calling R3D_Init().
+ * Any hint not explicitly set falls back to its default value.
+ *
+ * @note Some hints may be clamped internally.
+ */
+typedef enum R3D_Hint {
+    R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH,    ///< Max lights per mesh in forward pass. Default: 8
+    R3D_HINT_MAX_PROBE_ON_SCREEN,           ///< Max probes rendered simultaneously. Default: 8
+    R3D_HINT_PROBE_CAPTURE_SIZE,            ///< Probe capture cubemap face size (px). Default: 256
+    R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE,   ///< Directional light shadow map size (px). Default: 4096
+    R3D_HINT_SHADOW_MAP_SPOT_SIZE,          ///< Spot light shadow map size (px). Default: 2048
+    R3D_HINT_SHADOW_MAP_OMNI_SIZE,          ///< Omni light shadow map size (px). Default: 2048
+    R3D_HINT_CUBEMAP_IRRADIANCE_SIZE,       ///< Irradiance cubemap face size (px). Default: 32
+    R3D_HINT_CUBEMAP_PREFILTER_SIZE,        ///< Prefiltered cubemap face size (px). Default: 128
+    R3D_HINT_COUNT,                         ///< Sentinel, not a valid hint
+} R3D_Hint;
+
+/**
  * @brief Anti-aliasing modes used during rendering.
  *
  * Anti-aliasing reduces visible jagged edges (aliasing artifacts)
@@ -124,6 +144,18 @@ typedef enum R3D_ColorSpace {
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief Sets a configuration hint.
+ * 
+ * Must be called before R3D_Init().
+ */
+R3DAPI void R3D_SetHint(R3D_Hint hint, int value);
+
+/**
+ * @brief Returns the effective value of a hint.
+ */
+R3DAPI int R3D_GetHint(R3D_Hint hint);
 
 /**
  * @brief Initializes the rendering engine.

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -28,7 +28,7 @@
  * Hints must be set via R3D_SetHint() before calling R3D_Init().
  * Any hint not explicitly set falls back to its default value.
  *
- * @note Some hints may be clamped internally.
+ * @note Some hints may be clamped internally, accordingly to hardware limits.
  */
 typedef enum R3D_Hint {
     R3D_HINT_MESH_VERTEX_BUFFER_CAPACITY,   ///< Initial vertex capacity of the global VBO. Default: 65'536

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -31,15 +31,19 @@
  * @note Some hints may be clamped internally.
  */
 typedef enum R3D_Hint {
-    R3D_HINT_FORWARD_LIGHT_PER_MESH,    ///< Max lights per mesh in forward pass. Default: 16
-    R3D_HINT_PROBE_MAX_ACTIVE,          ///< Max probes rendered simultaneously. Default: 8
-    R3D_HINT_PROBE_CAPTURE_SIZE,        ///< Probe capture cubemap face size (px). Default: 256
-    R3D_HINT_SHADOW_DIR_SIZE,           ///< Directional light shadow map size (px). Default: 4096
-    R3D_HINT_SHADOW_SPOT_SIZE,          ///< Spot light shadow map size (px). Default: 2048
-    R3D_HINT_SHADOW_OMNI_SIZE,          ///< Omni light shadow map size (px). Default: 2048
-    R3D_HINT_IBL_IRRADIANCE_SIZE,       ///< Irradiance cubemap face size, shared by ambient IBL and probes (px). Default: 32
-    R3D_HINT_IBL_PREFILTER_SIZE,        ///< Prefiltered cubemap face size, shared by ambient IBL and probes (px). Default: 128
-    R3D_HINT_COUNT,                     ///< Sentinel, not a valid hint
+    R3D_HINT_MESH_VERTEX_BUFFER_CAPACITY,   ///< Initial vertex capacity of the global VBO. Default: 65'536
+    R3D_HINT_MESH_INDEX_BUFFER_CAPACITY,    ///< Initial index capacity of the global EBO. Default: 131'072
+    R3D_HINT_MESH_STREAMING_CAPACITY,       ///< Initial capacity for tracking freed mesh slots, relevant only for meshes loaded/unloaded at runtime. Default: 128
+    R3D_HINT_DRAW_CALL_CAPACITY,            ///< Initial capacity of the CPU-side draw call list. Default: 1024
+    R3D_HINT_FORWARD_LIGHT_PER_MESH,        ///< Max lights per mesh in forward pass. Default: 16
+    R3D_HINT_PROBE_MAX_ACTIVE,              ///< Max probes rendered simultaneously. Default: 8
+    R3D_HINT_PROBE_CAPTURE_SIZE,            ///< Probe capture cubemap face size (px). Default: 256
+    R3D_HINT_SHADOW_DIR_SIZE,               ///< Directional light shadow map size (px). Default: 4096
+    R3D_HINT_SHADOW_SPOT_SIZE,              ///< Spot light shadow map size (px). Default: 2048
+    R3D_HINT_SHADOW_OMNI_SIZE,              ///< Omni light shadow map size (px). Default: 2048
+    R3D_HINT_IBL_IRRADIANCE_SIZE,           ///< Irradiance cubemap face size, shared by ambient IBL and probes (px). Default: 32
+    R3D_HINT_IBL_PREFILTER_SIZE,            ///< Prefiltered cubemap face size, shared by ambient IBL and probes (px). Default: 128
+    R3D_HINT_COUNT,                         ///< Sentinel, not a valid hint
 } R3D_Hint;
 
 /**

--- a/include/r3d/r3d_core.h
+++ b/include/r3d/r3d_core.h
@@ -31,7 +31,7 @@
  * @note Some hints may be clamped internally.
  */
 typedef enum R3D_Hint {
-    R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH,    ///< Max lights per mesh in forward pass. Default: 8
+    R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH,    ///< Max lights per mesh in forward pass. Default: 16
     R3D_HINT_MAX_PROBE_ON_SCREEN,           ///< Max probes rendered simultaneously. Default: 8
     R3D_HINT_PROBE_CAPTURE_SIZE,            ///< Probe capture cubemap face size (px). Default: 256
     R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE,   ///< Directional light shadow map size (px). Default: 4096

--- a/include/r3d/r3d_lighting.h
+++ b/include/r3d/r3d_lighting.h
@@ -601,8 +601,8 @@ R3DAPI float R3D_GetShadowDepthBias(R3D_Light id);
  * or floating away from objects.
  *
  * Default per light type:
- *   - Directional: 0.0009765625
- *   - Spot:        0.0001220703
+ *   - Directional: 0.001
+ *   - Spot:        0.0001
  *   - Omni:        0.025
  */
 R3DAPI void R3D_SetShadowDepthBias(R3D_Light id, float value);
@@ -620,8 +620,8 @@ R3DAPI float R3D_GetShadowSlopeBias(R3D_Light id);
  * incorrectly appearing or disappearing along object edges.
  *
  * Default per light type:
- *   - Directional: 0.0014648438
- *   - Spot:        0.0004882813
+ *   - Directional: 0.0015
+ *   - Spot:        0.0005
  *   - Omni:        0.1
  */
 R3DAPI void R3D_SetShadowSlopeBias(R3D_Light id, float value);

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -118,9 +118,9 @@ void main()
     if (uLight.shadowLayer >= 0 && uLight.shadowOpacity != 0.0 && shadow > 1e-4) {
         mat2 diskRot = L_ShadowDebandingMatrix(gl_FragCoord.xy);
         switch (uLight.type) {
-        case LIGHT_DIR:  shadow *= L_SampleShadowDir(P, depth, NdotL, diskRot); break;
-        case LIGHT_SPOT: shadow *= L_SampleShadowSpot(P, NdotL, diskRot); break;
-        case LIGHT_OMNI: shadow *= L_SampleShadowOmni(P, NdotL, diskRot); break;
+        case LIGHT_DIR:  shadow *= L_SampleShadowDir(uLight, P, depth, NdotL, diskRot); break;
+        case LIGHT_SPOT: shadow *= L_SampleShadowSpot(uLight, P, NdotL, diskRot); break;
+        case LIGHT_OMNI: shadow *= L_SampleShadowOmni(uLight, P, NdotL, diskRot); break;
         }
     }
 

--- a/shaders/include/ubo/env.glsl
+++ b/shaders/include/ubo/env.glsl
@@ -23,7 +23,7 @@ struct E_Probe {
 };
 
 layout(std140) uniform EnvBlock {
-    E_Probe uProbes[NUM_PROBES];
+    E_Probe uProbes[MAX_PROBES];
     E_Ambient uAmbient;
     int uNumPrefilterLevels;
     int uNumProbes;

--- a/shaders/include/ubo/light.glsl
+++ b/shaders/include/ubo/light.glsl
@@ -32,9 +32,9 @@ struct Light {
     int type;
 };
 
-#ifdef NUM_FORWARD_LIGHTS
+#ifdef MAX_LIGHTS_FORWARD
 layout(std140) uniform LightArrayBlock {
-    Light uLights[NUM_FORWARD_LIGHTS];
+    Light uLights[MAX_LIGHTS_FORWARD];
     int uNumLights;
 };
 #else

--- a/shaders/include/wrap/light.glsl
+++ b/shaders/include/wrap/light.glsl
@@ -50,7 +50,7 @@ const vec2 VOGEL_DISK[8] = vec2[8](
     vec2(-0.446271, -0.859268)
 );
 
-#if defined(NUM_FORWARD_LIGHTS)
+#if defined(MAX_LIGHTS_FORWARD)
 #   define DECL_SHADOW_DIR(name)  float name(int lightIndex, vec4 Pls, float Zvs, float NdotL, mat2 diskRot)
 #   define DECL_SHADOW_SPOT(name) float name(int lightIndex, vec4 Pls, float NdotL, mat2 diskRot)
 #   define DECL_SHADOW_OMNI(name) float name(int lightIndex, vec3 Pws, float NdotL, mat2 diskRot)
@@ -71,7 +71,7 @@ mat2 L_ShadowDebandingMatrix(vec2 fragCoord)
 
 DECL_SHADOW_DIR(L_SampleShadowDir)
 {
-#if !defined(NUM_FORWARD_LIGHTS)
+#if !defined(MAX_LIGHTS_FORWARD)
     vec4 Pls = LIGHT.viewProj * vec4(Pws, 1.0);
 #endif
 
@@ -95,7 +95,7 @@ DECL_SHADOW_DIR(L_SampleShadowDir)
 
 DECL_SHADOW_SPOT(L_SampleShadowSpot)
 {
-#if !defined(NUM_FORWARD_LIGHTS)
+#if !defined(MAX_LIGHTS_FORWARD)
     vec4 Pls = LIGHT.viewProj * vec4(Pws, 1.0);
 #endif
 

--- a/shaders/include/wrap/light.glsl
+++ b/shaders/include/wrap/light.glsl
@@ -22,7 +22,7 @@ vec3 L_Diffuse(float LdotH, float NdotV, float NdotL, float roughness)
 
 vec3 L_Specular(vec3 F0, float LdotH, float cNdotH, float NdotV, float NdotL, float roughness)
 {
-    roughness = max(roughness, 0.02); // >0.01 to avoid FP16 overflow after GGX distribution
+    roughness = max(roughness, 0.02); // 'roughness > 0.01' to avoid FP16 overflow after GGX distribution
 
     float alphaGGX = roughness * roughness;
     float D = PBR_DistributionGGX(cNdotH, alphaGGX);
@@ -50,18 +50,6 @@ const vec2 VOGEL_DISK[8] = vec2[8](
     vec2(-0.446271, -0.859268)
 );
 
-#if defined(MAX_LIGHTS_FORWARD)
-#   define DECL_SHADOW_DIR(name)  float name(int lightIndex, vec4 Pls, float Zvs, float NdotL, mat2 diskRot)
-#   define DECL_SHADOW_SPOT(name) float name(int lightIndex, vec4 Pls, float NdotL, mat2 diskRot)
-#   define DECL_SHADOW_OMNI(name) float name(int lightIndex, vec3 Pws, float NdotL, mat2 diskRot)
-#   define LIGHT uLights[lightIndex]
-#else
-#   define DECL_SHADOW_DIR(name)  float name(vec3 Pws, float Zvs, float NdotL, mat2 diskRot)
-#   define DECL_SHADOW_SPOT(name) float name(vec3 Pws, float NdotL, mat2 diskRot)
-#   define DECL_SHADOW_OMNI(name) float name(vec3 Pws, float NdotL, mat2 diskRot)
-#   define LIGHT uLight
-#endif
-
 mat2 L_ShadowDebandingMatrix(vec2 fragCoord)
 {
     float r = M_TAU * M_HashIGN(fragCoord);
@@ -69,70 +57,60 @@ mat2 L_ShadowDebandingMatrix(vec2 fragCoord)
     return mat2(vec2(cr, -sr), vec2(sr, cr));
 }
 
-DECL_SHADOW_DIR(L_SampleShadowDir)
+float L_SampleShadowDir(Light light, vec3 Pws, float Zvs, float NdotL, mat2 diskRot)
 {
-#if !defined(MAX_LIGHTS_FORWARD)
-    vec4 Pls = LIGHT.viewProj * vec4(Pws, 1.0);
-#endif
-
+    vec4 Pls = light.viewProj * vec4(Pws, 1.0);
     vec3 projCoords = Pls.xyz / Pls.w * 0.5 + 0.5;
-    float bias = LIGHT.shadowDepthBias + LIGHT.shadowSlopeBias * (1.0 - NdotL);
+    float bias = light.shadowDepthBias + light.shadowSlopeBias * (1.0 - NdotL);
     float compareDepth = projCoords.z - bias;
 
     float shadow = 0.0;
     for (int i = 0; i < SHADOW_SAMPLES; ++i) {
-        vec2 offset = diskRot * VOGEL_DISK[i] * LIGHT.shadowSoftness;
-        shadow += texture(uShadowDirTex, vec4(projCoords.xy + offset, LIGHT.shadowLayer, compareDepth));
+        vec2 offset = diskRot * VOGEL_DISK[i] * light.shadowSoftness;
+        shadow += texture(uShadowDirTex, vec4(projCoords.xy + offset, light.shadowLayer, compareDepth));
     }
     shadow /= float(SHADOW_SAMPLES);
 
     vec3 distToBorder = min(projCoords, 1.0 - projCoords);
     float edgeFade = smoothstep(0.0, 0.05, min(distToBorder.x, min(distToBorder.y, distToBorder.z)));
-    float distFade = smoothstep(LIGHT.range, LIGHT.range * 0.75, Zvs);
+    float distFade = smoothstep(light.range, light.range * 0.75, Zvs);
 
-    return mix(1.0, shadow, edgeFade * distFade * LIGHT.shadowOpacity);
+    return mix(1.0, shadow, edgeFade * distFade * light.shadowOpacity);
 }
 
-DECL_SHADOW_SPOT(L_SampleShadowSpot)
+float L_SampleShadowSpot(Light light, vec3 Pws, float NdotL, mat2 diskRot)
 {
-#if !defined(MAX_LIGHTS_FORWARD)
-    vec4 Pls = LIGHT.viewProj * vec4(Pws, 1.0);
-#endif
-
+    vec4 Pls = light.viewProj * vec4(Pws, 1.0);
     vec3 projCoords = Pls.xyz / Pls.w * 0.5 + 0.5;
-    float bias = LIGHT.shadowDepthBias + LIGHT.shadowSlopeBias * (1.0 - NdotL);
+    float bias = light.shadowDepthBias + light.shadowSlopeBias * (1.0 - NdotL);
     float compareDepth = projCoords.z - bias;
 
     float shadow = 0.0;
     for (int i = 0; i < SHADOW_SAMPLES; ++i) {
-        vec2 offset = diskRot * VOGEL_DISK[i] * LIGHT.shadowSoftness;
-        shadow += texture(uShadowSpotTex, vec4(projCoords.xy + offset, LIGHT.shadowLayer, compareDepth));
+        vec2 offset = diskRot * VOGEL_DISK[i] * light.shadowSoftness;
+        shadow += texture(uShadowSpotTex, vec4(projCoords.xy + offset, light.shadowLayer, compareDepth));
     }
     shadow /= float(SHADOW_SAMPLES);
 
-    return mix(1.0, shadow, LIGHT.shadowOpacity);
+    return mix(1.0, shadow, light.shadowOpacity);
 }
 
-DECL_SHADOW_OMNI(L_SampleShadowOmni)
+float L_SampleShadowOmni(Light light, vec3 Pws, float NdotL, mat2 diskRot)
 {
-    vec3 lightToFrag = Pws - LIGHT.position;
+    vec3 lightToFrag = Pws - light.position;
     float currentDepth = length(lightToFrag);
 
-    float bias = LIGHT.shadowDepthBias + LIGHT.shadowSlopeBias * (1.0 - NdotL);
-    float compareDepth = (currentDepth - bias) / LIGHT.far;
+    float bias = light.shadowDepthBias + light.shadowSlopeBias * (1.0 - NdotL);
+    float compareDepth = (currentDepth - bias) / light.far;
 
     mat3 OBN = M_OrthonormalBasis(lightToFrag / currentDepth);
 
     float shadow = 0.0;
     for (int i = 0; i < SHADOW_SAMPLES; ++i) {
-        vec2 diskOffset = diskRot * VOGEL_DISK[i] * LIGHT.shadowSoftness;
-        shadow += texture(uShadowOmniTex, vec4(OBN * vec3(diskOffset.xy, 1.0), LIGHT.shadowLayer), compareDepth);
+        vec2 diskOffset = diskRot * VOGEL_DISK[i] * light.shadowSoftness;
+        shadow += texture(uShadowOmniTex, vec4(OBN * vec3(diskOffset.xy, 1.0), light.shadowLayer), compareDepth);
     }
     shadow /= float(SHADOW_SAMPLES);
 
-    return mix(1.0, shadow, LIGHT.shadowOpacity);
+    return mix(1.0, shadow, light.shadowOpacity);
 }
-
-#undef SAMPLE_SHADOW_PROJ
-#undef SAMPLE_SHADOW_OMNI
-#undef LIGHT

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -26,7 +26,7 @@ smooth in vec4 vColor;
 smooth in mat3 vTBN;
 
 smooth in float vLinearDepth;
-smooth in vec4 vPosLightSpace[NUM_FORWARD_LIGHTS];
+smooth in vec4 vPosLightSpace[MAX_LIGHTS_FORWARD];
 
 /* === Uniforms === */
 

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -26,7 +26,6 @@ smooth in vec4 vColor;
 smooth in mat3 vTBN;
 
 smooth in float vLinearDepth;
-smooth in vec4 vPosLightSpace[MAX_LIGHTS_FORWARD];
 
 /* === Uniforms === */
 
@@ -156,9 +155,9 @@ void main()
 
         if (light.shadowLayer >= 0 && light.shadowOpacity != 0.0 && shadow > 1e-4) {
             switch (light.type) {
-            case LIGHT_DIR:  shadow *= L_SampleShadowDir(i, vPosLightSpace[i], vLinearDepth, NdotL, diskRot); break;
-            case LIGHT_SPOT: shadow *= L_SampleShadowSpot(i, vPosLightSpace[i], NdotL, diskRot); break;
-            case LIGHT_OMNI: shadow *= L_SampleShadowOmni(i, vPosition, NdotL, diskRot); break;
+            case LIGHT_DIR:  shadow *= L_SampleShadowDir(light, vPosition, vLinearDepth, NdotL, diskRot); break;
+            case LIGHT_SPOT: shadow *= L_SampleShadowSpot(light, vPosition, NdotL, diskRot); break;
+            case LIGHT_OMNI: shadow *= L_SampleShadowOmni(light, vPosition, NdotL, diskRot); break;
             }
         }
 

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -79,7 +79,7 @@ smooth out float vLinearDepth;
 #endif // GEOMETRY || FORWARD || UNLIT || PROBE
 
 #if defined(FORWARD) || defined(PROBE_FORWARD)
-smooth out vec4 vPosLightSpace[NUM_FORWARD_LIGHTS];
+smooth out vec4 vPosLightSpace[MAX_LIGHTS_FORWARD];
 #endif // FORWARD || PROBE_FORWARD
 
 #if defined(DECAL)

--- a/shaders/scene/scene.vert
+++ b/shaders/scene/scene.vert
@@ -17,7 +17,6 @@
 /* === Includes === */
 
 #include <ubo/frame.glsl>
-#include <ubo/light.glsl>
 #include <ubo/view.glsl>
 #include <lib/math.glsl>
 
@@ -77,10 +76,6 @@ smooth out mat3 vTBN;
 #if defined(GEOMETRY) || defined(FORWARD) || defined(UNLIT) || defined(PROBE)
 smooth out float vLinearDepth;
 #endif // GEOMETRY || FORWARD || UNLIT || PROBE
-
-#if defined(FORWARD) || defined(PROBE_FORWARD)
-smooth out vec4 vPosLightSpace[MAX_LIGHTS_FORWARD];
-#endif // FORWARD || PROBE_FORWARD
 
 #if defined(DECAL)
 smooth out mat4 vDecalProjection;
@@ -237,12 +232,6 @@ void main()
 #elif defined(PROBE)
     vLinearDepth = -(uMatView * vec4(vPosition, 1.0)).z;
 #endif // GEOMETRY || FORWARD || UNLIT || PROBE
-
-#if defined(FORWARD) || defined(PROBE_FORWARD)
-    for (int i = 0; i < uNumLights; i++) {
-        vPosLightSpace[i] = uLights[i].viewProj * vec4(vPosition, 1.0);
-    }
-#endif // FORWARD || PROBE_FORWARD
 
     gl_Position = MATRIX_VIEW_PROJECTION * vec4(vPosition, 1.0);
 

--- a/src/common/r3d_pass.c
+++ b/src/common/r3d_pass.c
@@ -60,7 +60,7 @@ void r3d_pass_prepare_prefilter(int layerMap, GLuint srcCubemap, int srcSize)
     R3D_SHADER_SET_FLOAT(prepare.cubemapPrefilter, uSourceFaceSize, (float)srcSize);
     R3D_SHADER_SET_MAT4(prepare.cubemapPrefilter, uMatProj, matProj);
 
-    int numLevels = r3d_get_mip_levels_1d(R3D_CUBEMAP_PREFILTER_SIZE);
+    int numLevels = r3d_get_mip_levels_1d(R3D_HINT(R3D_HINT_CUBEMAP_PREFILTER_SIZE));
 
     for (int mip = 0; mip < numLevels; mip++) {
         float roughness = (float)mip / (float)(numLevels - 1);

--- a/src/common/r3d_pass.c
+++ b/src/common/r3d_pass.c
@@ -60,7 +60,7 @@ void r3d_pass_prepare_prefilter(int layerMap, GLuint srcCubemap, int srcSize)
     R3D_SHADER_SET_FLOAT(prepare.cubemapPrefilter, uSourceFaceSize, (float)srcSize);
     R3D_SHADER_SET_MAT4(prepare.cubemapPrefilter, uMatProj, matProj);
 
-    int numLevels = r3d_get_mip_levels_1d(R3D_HINT(R3D_HINT_CUBEMAP_PREFILTER_SIZE));
+    int numLevels = r3d_get_mip_levels_1d(R3D_HINT(R3D_HINT_IBL_PREFILTER_SIZE));
 
     for (int mip = 0; mip < numLevels; mip++) {
         float roughness = (float)mip / (float)(numLevels - 1);

--- a/src/modules/r3d_env.c
+++ b/src/modules/r3d_env.c
@@ -459,7 +459,7 @@ int r3d_env_irradiance_reserve_layer(void)
     int layer = layer_pool_reserve(&R3D_MOD_ENV.irradiancePool);
 
     if (layer < 0) {
-        if (!cubemap_array_expand_capacity(&R3D_MOD_ENV.irradianceArray, &R3D_MOD_ENV.irradiancePool, R3D_HINT(R3D_HINT_CUBEMAP_IRRADIANCE_SIZE), false)) {
+        if (!cubemap_array_expand_capacity(&R3D_MOD_ENV.irradianceArray, &R3D_MOD_ENV.irradiancePool, R3D_HINT(R3D_HINT_IBL_IRRADIANCE_SIZE), false)) {
             return -1;
         }
         layer = layer_pool_reserve(&R3D_MOD_ENV.irradiancePool);
@@ -481,7 +481,7 @@ void r3d_env_irradiance_bind_fbo(int layer, int face)
         R3D_MOD_ENV.irradianceArray, 0, layer * 6 + face
     );
 
-    glViewport(0, 0, R3D_HINT(R3D_HINT_CUBEMAP_IRRADIANCE_SIZE), R3D_HINT(R3D_HINT_CUBEMAP_IRRADIANCE_SIZE));
+    glViewport(0, 0, R3D_HINT(R3D_HINT_IBL_IRRADIANCE_SIZE), R3D_HINT(R3D_HINT_IBL_IRRADIANCE_SIZE));
 }
 
 GLuint r3d_env_irradiance_get(void)
@@ -494,7 +494,7 @@ int r3d_env_prefilter_reserve_layer(void)
     int layer = layer_pool_reserve(&R3D_MOD_ENV.prefilterPool);
 
     if (layer < 0) {
-        if (!cubemap_array_expand_capacity(&R3D_MOD_ENV.prefilterArray, &R3D_MOD_ENV.prefilterPool, R3D_HINT(R3D_HINT_CUBEMAP_PREFILTER_SIZE), true)) {
+        if (!cubemap_array_expand_capacity(&R3D_MOD_ENV.prefilterArray, &R3D_MOD_ENV.prefilterPool, R3D_HINT(R3D_HINT_IBL_PREFILTER_SIZE), true)) {
             return -1;
         }
         layer = layer_pool_reserve(&R3D_MOD_ENV.prefilterPool);
@@ -510,7 +510,7 @@ void r3d_env_prefilter_release_layer(int layer)
 
 void r3d_env_prefilter_bind_fbo(int layer, int face, int mipLevel)
 {
-    assert(mipLevel < r3d_get_mip_levels_1d(R3D_HINT(R3D_HINT_CUBEMAP_PREFILTER_SIZE)));
+    assert(mipLevel < r3d_get_mip_levels_1d(R3D_HINT(R3D_HINT_IBL_PREFILTER_SIZE)));
 
     glBindFramebuffer(GL_FRAMEBUFFER, R3D_MOD_ENV.workFramebuffer);
     glFramebufferTextureLayer(
@@ -518,7 +518,7 @@ void r3d_env_prefilter_bind_fbo(int layer, int face, int mipLevel)
         R3D_MOD_ENV.prefilterArray, mipLevel, layer * 6 + face
     );
 
-    int mipSize = R3D_HINT(R3D_HINT_CUBEMAP_PREFILTER_SIZE) >> mipLevel;
+    int mipSize = R3D_HINT(R3D_HINT_IBL_PREFILTER_SIZE) >> mipLevel;
     glViewport(0, 0, mipSize, mipSize);
 }
 

--- a/src/modules/r3d_env.c
+++ b/src/modules/r3d_env.c
@@ -16,6 +16,7 @@
 #include <assert.h>
 
 #include "../common/r3d_helper.h"
+#include "../r3d_core_state.h"
 
 // ========================================
 // CONSTANTS
@@ -458,7 +459,7 @@ int r3d_env_irradiance_reserve_layer(void)
     int layer = layer_pool_reserve(&R3D_MOD_ENV.irradiancePool);
 
     if (layer < 0) {
-        if (!cubemap_array_expand_capacity(&R3D_MOD_ENV.irradianceArray, &R3D_MOD_ENV.irradiancePool, R3D_CUBEMAP_IRRADIANCE_SIZE, false)) {
+        if (!cubemap_array_expand_capacity(&R3D_MOD_ENV.irradianceArray, &R3D_MOD_ENV.irradiancePool, R3D_HINT(R3D_HINT_CUBEMAP_IRRADIANCE_SIZE), false)) {
             return -1;
         }
         layer = layer_pool_reserve(&R3D_MOD_ENV.irradiancePool);
@@ -480,7 +481,7 @@ void r3d_env_irradiance_bind_fbo(int layer, int face)
         R3D_MOD_ENV.irradianceArray, 0, layer * 6 + face
     );
 
-    glViewport(0, 0, R3D_CUBEMAP_IRRADIANCE_SIZE, R3D_CUBEMAP_IRRADIANCE_SIZE);
+    glViewport(0, 0, R3D_HINT(R3D_HINT_CUBEMAP_IRRADIANCE_SIZE), R3D_HINT(R3D_HINT_CUBEMAP_IRRADIANCE_SIZE));
 }
 
 GLuint r3d_env_irradiance_get(void)
@@ -493,7 +494,7 @@ int r3d_env_prefilter_reserve_layer(void)
     int layer = layer_pool_reserve(&R3D_MOD_ENV.prefilterPool);
 
     if (layer < 0) {
-        if (!cubemap_array_expand_capacity(&R3D_MOD_ENV.prefilterArray, &R3D_MOD_ENV.prefilterPool, R3D_CUBEMAP_PREFILTER_SIZE, true)) {
+        if (!cubemap_array_expand_capacity(&R3D_MOD_ENV.prefilterArray, &R3D_MOD_ENV.prefilterPool, R3D_HINT(R3D_HINT_CUBEMAP_PREFILTER_SIZE), true)) {
             return -1;
         }
         layer = layer_pool_reserve(&R3D_MOD_ENV.prefilterPool);
@@ -509,7 +510,7 @@ void r3d_env_prefilter_release_layer(int layer)
 
 void r3d_env_prefilter_bind_fbo(int layer, int face, int mipLevel)
 {
-    assert(mipLevel < r3d_get_mip_levels_1d(R3D_CUBEMAP_PREFILTER_SIZE));
+    assert(mipLevel < r3d_get_mip_levels_1d(R3D_HINT(R3D_HINT_CUBEMAP_PREFILTER_SIZE)));
 
     glBindFramebuffer(GL_FRAMEBUFFER, R3D_MOD_ENV.workFramebuffer);
     glFramebufferTextureLayer(
@@ -517,7 +518,7 @@ void r3d_env_prefilter_bind_fbo(int layer, int face, int mipLevel)
         R3D_MOD_ENV.prefilterArray, mipLevel, layer * 6 + face
     );
 
-    int mipSize = R3D_CUBEMAP_PREFILTER_SIZE >> mipLevel;
+    int mipSize = R3D_HINT(R3D_HINT_CUBEMAP_PREFILTER_SIZE) >> mipLevel;
     glViewport(0, 0, mipSize, mipSize);
 }
 
@@ -528,13 +529,13 @@ GLuint r3d_env_prefilter_get(void)
 
 void r3d_env_capture_bind_fbo(int face, int mipLevel)
 {
-    assert(mipLevel < r3d_get_mip_levels_1d(R3D_PROBE_CAPTURE_SIZE));
+    assert(mipLevel < r3d_get_mip_levels_1d(R3D_HINT(R3D_HINT_PROBE_CAPTURE_SIZE)));
 
     glBindFramebuffer(GL_FRAMEBUFFER, R3D_MOD_ENV.captureFramebuffer);
 
     if (!R3D_MOD_ENV.captureCubeAllocated) {
-        alloc_depth_stencil_renderbuffer(R3D_MOD_ENV.captureDepth, R3D_PROBE_CAPTURE_SIZE);
-        cubemap_array_spec_t spec = cubemap_array_spec(R3D_PROBE_CAPTURE_SIZE, 0, true);
+        alloc_depth_stencil_renderbuffer(R3D_MOD_ENV.captureDepth, R3D_HINT(R3D_HINT_PROBE_CAPTURE_SIZE));
+        cubemap_array_spec_t spec = cubemap_array_spec(R3D_HINT(R3D_HINT_PROBE_CAPTURE_SIZE), 0, true);
         cubemap_array_allocate(R3D_MOD_ENV.captureCube, spec);
         R3D_MOD_ENV.captureCubeAllocated = true;
 
@@ -550,7 +551,7 @@ void r3d_env_capture_bind_fbo(int face, int mipLevel)
         R3D_MOD_ENV.captureCube, mipLevel
     );
 
-    int mipSize = R3D_PROBE_CAPTURE_SIZE >> mipLevel;
+    int mipSize = R3D_HINT(R3D_HINT_PROBE_CAPTURE_SIZE) >> mipLevel;
     glViewport(0, 0, mipSize, mipSize);
 }
 

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -7,13 +7,15 @@
  */
 
 #include "./r3d_light.h"
-#include "raylib.h"
+
 #include <r3d_config.h>
 #include <raymath.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 #include <float.h>
+
+#include "../r3d_core_state.h"
 
 // ========================================
 // CONSTANTS
@@ -169,7 +171,7 @@ static bool shadow_array_expand_capacity(R3D_LightType type)
     r3d_light_shadow_pool_t* pool = &R3D_MOD_LIGHT.shadowPools[type];
     GLuint* shadowArray = &R3D_MOD_LIGHT.shadowArrays[type];
     GLenum shadowTarget = SHADOW_TEXTURE_TARGET[type];
-    int shadowSize = R3D_LIGHT_SHADOW_SIZE[type];
+    int shadowSize = r3d_light_shadow_get_size(type);
     int growth = SHADOW_LAYER_GROWTH[type];
 
     if (!shadow_array_resize(shadowArray, shadowTarget, shadowSize, pool->totalLayers, pool->totalLayers + growth)) {
@@ -216,16 +218,18 @@ static bool light_init(r3d_light_t* light, R3D_LightType type)
     light->outerCutOff = cosf(45.0f * DEG2RAD);
     light->fogEnergy = 1.0f;
 
-    light->shadowSoftness = 4.0f / R3D_LIGHT_SHADOW_SIZE[type];
+    int shadowMapSize = r3d_light_shadow_get_size(type);
+
+    light->shadowSoftness = 4.0f / shadowMapSize;
     light->shadowOpacity = 1.0f;
     switch (type) {
     case R3D_LIGHT_DIR:
-        light->shadowDepthBias = 4.0f / R3D_LIGHT_SHADOW_SIZE[type];
-        light->shadowSlopeBias = 6.0f / R3D_LIGHT_SHADOW_SIZE[type];
+        light->shadowDepthBias = 4.0f / shadowMapSize;
+        light->shadowSlopeBias = 6.0f / shadowMapSize;
         break;
     case R3D_LIGHT_SPOT:
-        light->shadowDepthBias = 0.25f / R3D_LIGHT_SHADOW_SIZE[type];
-        light->shadowSlopeBias = 1.0f / R3D_LIGHT_SHADOW_SIZE[type];
+        light->shadowDepthBias = 0.25f / shadowMapSize;
+        light->shadowSlopeBias = 1.0f / shadowMapSize;
         break;
     case R3D_LIGHT_OMNI:
         light->shadowDepthBias = 0.025f;
@@ -284,7 +288,7 @@ static void light_update_dir_matrix(r3d_light_t* light, R3D_Camera camera, doubl
     Vector3 lightRight = Vector3Normalize(Vector3CrossProduct(up, lightDir));
     Vector3 lightUp = Vector3CrossProduct(lightDir, lightRight);
 
-    float texelSize = (radius * 2.0f) / R3D_SHADOW_MAP_DIRECTIONAL_SIZE;
+    float texelSize = (radius * 2.0f) / (float)R3D_HINT(R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE);
     float cx = floorf(Vector3DotProduct(frustumCenter, lightRight) / texelSize) * texelSize;
     float cy = floorf(Vector3DotProduct(frustumCenter, lightUp) / texelSize) * texelSize;
     float cz = Vector3DotProduct(frustumCenter, lightDir);
@@ -653,12 +657,31 @@ void r3d_light_shadow_bind_fbo(R3D_LightType type, int layer, int face)
     assert((type == R3D_LIGHT_OMNI && face >= 0 && face < 6) || (type != R3D_LIGHT_OMNI && face == 0));
 
     GLuint shadowArray = R3D_MOD_LIGHT.shadowArrays[type];
-    int shadowSize = R3D_LIGHT_SHADOW_SIZE[type];
+    int shadowSize = r3d_light_shadow_get_size(type);
     int stride = (type == R3D_LIGHT_OMNI) ? 6 : 1;
 
     glBindFramebuffer(GL_FRAMEBUFFER, R3D_MOD_LIGHT.workFramebuffer);
     glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, shadowArray, 0, layer * stride + face);
     glViewport(0, 0, shadowSize, shadowSize);
+}
+
+int r3d_light_shadow_get_size(R3D_LightType type)
+{
+    int size = 0;
+    switch (type) {
+    case R3D_LIGHT_DIR:
+        size = R3D_HINT(R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE);
+        break;
+    case R3D_LIGHT_SPOT:
+        size = R3D_HINT(R3D_HINT_SHADOW_MAP_SPOT_SIZE);
+        break;
+    case R3D_LIGHT_OMNI:
+        size = R3D_HINT(R3D_HINT_SHADOW_MAP_OMNI_SIZE);
+        break;
+    case R3D_LIGHT_TYPE_COUNT:
+        break;
+    }
+    return size;
 }
 
 GLuint r3d_light_shadow_get(R3D_LightType type)

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -288,7 +288,7 @@ static void light_update_dir_matrix(r3d_light_t* light, R3D_Camera camera, doubl
     Vector3 lightRight = Vector3Normalize(Vector3CrossProduct(up, lightDir));
     Vector3 lightUp = Vector3CrossProduct(lightDir, lightRight);
 
-    float texelSize = (radius * 2.0f) / (float)R3D_HINT(R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE);
+    float texelSize = (radius * 2.0f) / (float)R3D_HINT(R3D_HINT_SHADOW_DIR_SIZE);
     float cx = floorf(Vector3DotProduct(frustumCenter, lightRight) / texelSize) * texelSize;
     float cy = floorf(Vector3DotProduct(frustumCenter, lightUp) / texelSize) * texelSize;
     float cz = Vector3DotProduct(frustumCenter, lightDir);
@@ -670,13 +670,13 @@ int r3d_light_shadow_get_size(R3D_LightType type)
     int size = 0;
     switch (type) {
     case R3D_LIGHT_DIR:
-        size = R3D_HINT(R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE);
+        size = R3D_HINT(R3D_HINT_SHADOW_DIR_SIZE);
         break;
     case R3D_LIGHT_SPOT:
-        size = R3D_HINT(R3D_HINT_SHADOW_MAP_SPOT_SIZE);
+        size = R3D_HINT(R3D_HINT_SHADOW_SPOT_SIZE);
         break;
     case R3D_LIGHT_OMNI:
-        size = R3D_HINT(R3D_HINT_SHADOW_MAP_OMNI_SIZE);
+        size = R3D_HINT(R3D_HINT_SHADOW_OMNI_SIZE);
         break;
     case R3D_LIGHT_TYPE_COUNT:
         break;

--- a/src/modules/r3d_light.c
+++ b/src/modules/r3d_light.c
@@ -224,12 +224,12 @@ static bool light_init(r3d_light_t* light, R3D_LightType type)
     light->shadowOpacity = 1.0f;
     switch (type) {
     case R3D_LIGHT_DIR:
-        light->shadowDepthBias = 4.0f / shadowMapSize;
-        light->shadowSlopeBias = 6.0f / shadowMapSize;
+        light->shadowDepthBias = 0.001f;
+        light->shadowSlopeBias = 0.0015f;
         break;
     case R3D_LIGHT_SPOT:
-        light->shadowDepthBias = 0.25f / shadowMapSize;
-        light->shadowSlopeBias = 1.0f / shadowMapSize;
+        light->shadowDepthBias = 0.0001f;
+        light->shadowSlopeBias = 0.0005f;
         break;
     case R3D_LIGHT_OMNI:
         light->shadowDepthBias = 0.025f;

--- a/src/modules/r3d_light.h
+++ b/src/modules/r3d_light.h
@@ -20,16 +20,6 @@
 #include "../common/r3d_math.h"
 
 // ========================================
-// MODULE CONSTANTS
-// ========================================
-
-static const int R3D_LIGHT_SHADOW_SIZE[] = {
-    [R3D_LIGHT_DIR]  = R3D_SHADOW_MAP_DIRECTIONAL_SIZE,
-    [R3D_LIGHT_SPOT] = R3D_SHADOW_MAP_SPOT_SIZE,
-    [R3D_LIGHT_OMNI] = R3D_SHADOW_MAP_OMNI_SIZE,
-};
-
-// ========================================
 // HELPER MACROS
 // ========================================
 
@@ -153,6 +143,9 @@ bool r3d_light_shadow_should_be_updated(r3d_light_t* light, bool willBeUpdated);
 
 /* Bind shadow framebuffer for a light type */
 void r3d_light_shadow_bind_fbo(R3D_LightType type, int layer, int face);
+
+/* Get a shadow map layer dimensions */
+int r3d_light_shadow_get_size(R3D_LightType type);
 
 /* Get a shadow map array texture ID */
 GLuint r3d_light_shadow_get(R3D_LightType type);

--- a/src/modules/r3d_light.h
+++ b/src/modules/r3d_light.h
@@ -144,7 +144,7 @@ bool r3d_light_shadow_should_be_updated(r3d_light_t* light, bool willBeUpdated);
 /* Bind shadow framebuffer for a light type */
 void r3d_light_shadow_bind_fbo(R3D_LightType type, int layer, int face);
 
-/* Get a shadow map layer dimensions */
+/* Get the shadow map dimensions */
 int r3d_light_shadow_get_size(R3D_LightType type);
 
 /* Get a shadow map array texture ID */

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -19,6 +19,7 @@
 
 #include "../common/r3d_math.h"
 #include "../common/r3d_hash.h"
+#include "../r3d_core_state.h"
 
 // ========================================
 // MODULE CONSTANTS
@@ -880,7 +881,7 @@ bool r3d_render_init(void)
     /* --- CPU array allocation (draw calls, groups, etc) --- */
 
     #define ALLOC_AND_ASSIGN(field, logfmt, ...) do { \
-        void* _p = RL_CALLOC(R3D_RENDER_INITIAL_DRAW_CALL_RESERVE, sizeof(*R3D_MOD_RENDER.field)); \
+        void* _p = RL_CALLOC(R3D_HINT(R3D_HINT_DRAW_CALL_CAPACITY), sizeof(*R3D_MOD_RENDER.field)); \
         if (_p == NULL) { \
             R3D_TRACELOG(LOG_FATAL, "Failed to init render module; " logfmt, ##__VA_ARGS__); \
             goto fail; \
@@ -903,18 +904,18 @@ bool r3d_render_init(void)
 
     #undef ALLOC_AND_ASSIGN
 
-    R3D_MOD_RENDER.capacity = R3D_RENDER_INITIAL_DRAW_CALL_RESERVE;
+    R3D_MOD_RENDER.capacity = R3D_HINT(R3D_HINT_DRAW_CALL_CAPACITY);
     R3D_MOD_RENDER.activeCluster = -1;
 
     /* --- CPU free list allocation --- */
 
     #define ALLOC_FREELIST(field, cap_field, logmsg) do { \
-        R3D_MOD_RENDER.field = RL_MALLOC(R3D_RENDER_INITIAL_FREE_LIST_RESERVE * sizeof(*R3D_MOD_RENDER.field)); \
+        R3D_MOD_RENDER.field = RL_MALLOC(R3D_HINT(R3D_HINT_MESH_STREAMING_CAPACITY) * sizeof(*R3D_MOD_RENDER.field)); \
         if (!R3D_MOD_RENDER.field) { \
             R3D_TRACELOG(LOG_FATAL, "Failed to init render module; " logmsg); \
             goto fail; \
         } \
-        R3D_MOD_RENDER.cap_field = R3D_RENDER_INITIAL_FREE_LIST_RESERVE; \
+        R3D_MOD_RENDER.cap_field = R3D_HINT(R3D_HINT_MESH_STREAMING_CAPACITY); \
     } while (0)
 
     ALLOC_FREELIST(freeVertices, freeVertexCapacity, "Free vertex list allocation failed");
@@ -930,17 +931,17 @@ bool r3d_render_init(void)
     glGenBuffers(1, &R3D_MOD_RENDER.globalVbo);
     glBindBuffer(GL_ARRAY_BUFFER, R3D_MOD_RENDER.globalVbo);
     glBufferData(GL_ARRAY_BUFFER,
-        R3D_RENDER_INITIAL_VERTICES_RESERVE * sizeof(R3D_Vertex),
+        R3D_HINT(R3D_HINT_MESH_VERTEX_BUFFER_CAPACITY) * sizeof(R3D_Vertex),
         NULL, GL_DYNAMIC_DRAW);
 
     glGenBuffers(1, &R3D_MOD_RENDER.globalEbo);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, R3D_MOD_RENDER.globalEbo);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-        R3D_RENDER_INITIAL_ELEMENTS_RESERVE * sizeof(GLuint),
+        R3D_HINT(R3D_HINT_MESH_INDEX_BUFFER_CAPACITY) * sizeof(GLuint),
         NULL, GL_DYNAMIC_DRAW);
 
-    R3D_MOD_RENDER.globalVertexCapacity  = R3D_RENDER_INITIAL_VERTICES_RESERVE;
-    R3D_MOD_RENDER.globalElementCapacity = R3D_RENDER_INITIAL_ELEMENTS_RESERVE;
+    R3D_MOD_RENDER.globalVertexCapacity  = R3D_HINT(R3D_HINT_MESH_VERTEX_BUFFER_CAPACITY);
+    R3D_MOD_RENDER.globalElementCapacity = R3D_HINT(R3D_HINT_MESH_INDEX_BUFFER_CAPACITY);
 
     /* --- Configuring vertex attributes --- */
 

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -806,14 +806,14 @@ bool r3d_shader_load_scene_forward(r3d_shader_custom_t* custom)
 {
     DECL_SHADER_SELECT(r3d_shader_scene_forward_t, scene, forward, custom);
 
-    char defNumForwardLights[32] = {0};
+    char defNumLightsForward[32] = {0};
     char defNumProbes[32] = {0};
 
-    r3d_string_format(defNumForwardLights, sizeof(defNumForwardLights), "NUM_FORWARD_LIGHTS %i", R3D_MAX_LIGHT_FORWARD_PER_MESH);
-    r3d_string_format(defNumProbes, sizeof(defNumProbes), "NUM_PROBES %i", R3D_MAX_PROBE_ON_SCREEN);
+    r3d_string_format(defNumLightsForward, sizeof(defNumLightsForward), "MAX_LIGHTS_FORWARD %i", R3D_SHADER_LIGHT_FORWARD_UBO_CAP);
+    r3d_string_format(defNumProbes, sizeof(defNumProbes), "MAX_PROBES %i", R3D_SHADER_PROBE_UBO_CAP);
 
-    const char* VS_DEFINES[] = {"STAGE_VERT", "FORWARD", defNumForwardLights};
-    const char* FS_DEFINES[] = {"STAGE_FRAG", "FORWARD", defNumForwardLights, defNumProbes};
+    const char* VS_DEFINES[] = {"STAGE_VERT", "FORWARD", defNumLightsForward};
+    const char* FS_DEFINES[] = {"STAGE_FRAG", "FORWARD", defNumLightsForward, defNumProbes};
 
     char* vsCode = inject_defines(SCENE_VERT,   VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
     char* fsCode = inject_defines(FORWARD_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
@@ -1061,14 +1061,14 @@ bool r3d_shader_load_scene_probe_forward(r3d_shader_custom_t* custom)
 {
     DECL_SHADER_SELECT(r3d_shader_scene_probe_forward_t, scene, probeForward, custom);
 
-    char defNumForwardLights[32] = {0};
+    char defNumLightsForward[32] = {0};
     char defNumProbes[32] = {0};
 
-    r3d_string_format(defNumForwardLights, sizeof(defNumForwardLights), "NUM_FORWARD_LIGHTS %i", R3D_MAX_LIGHT_FORWARD_PER_MESH);
-    r3d_string_format(defNumProbes, sizeof(defNumProbes), "NUM_PROBES %i", R3D_MAX_PROBE_ON_SCREEN);
+    r3d_string_format(defNumLightsForward, sizeof(defNumLightsForward), "MAX_LIGHTS_FORWARD %i", R3D_SHADER_LIGHT_FORWARD_UBO_CAP);
+    r3d_string_format(defNumProbes, sizeof(defNumProbes), "MAX_PROBES %i", R3D_SHADER_PROBE_UBO_CAP);
 
-    const char* VS_DEFINES[] = {"STAGE_VERT", "PROBE", "PROBE_FORWARD", defNumForwardLights};
-    const char* FS_DEFINES[] = {"STAGE_FRAG", "PROBE", "PROBE_FORWARD", defNumForwardLights, defNumProbes};
+    const char* VS_DEFINES[] = {"STAGE_VERT", "PROBE", "PROBE_FORWARD", defNumLightsForward};
+    const char* FS_DEFINES[] = {"STAGE_FRAG", "PROBE", "PROBE_FORWARD", defNumLightsForward, defNumProbes};
 
     char* vsCode = inject_defines(SCENE_VERT,   VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
     char* fsCode = inject_defines(FORWARD_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
@@ -1256,7 +1256,7 @@ bool r3d_shader_load_deferred_ambient(r3d_shader_custom_t* custom)
     DECL_SHADER(r3d_shader_deferred_ambient_t, deferred, ambient);
 
     char defNumProbes[32] = {0};
-    r3d_string_format(defNumProbes, sizeof(defNumProbes), "NUM_PROBES %i", R3D_MAX_PROBE_ON_SCREEN);
+    r3d_string_format(defNumProbes, sizeof(defNumProbes), "MAX_PROBES %i", R3D_SHADER_PROBE_UBO_CAP);
 
     const char* FS_DEFINES[] = {defNumProbes};
     char* fsCode = inject_defines(AMBIENT_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -507,7 +507,7 @@ typedef struct {
         alignas(4) int32_t irradiance;
         alignas(4) int32_t prefilter;
     }
-    uProbes[R3D_MAX_PROBE_ON_SCREEN];
+    uProbes[R3D_SHADER_PROBE_UBO_CAP];
 
     struct r3d_shader_block_env_ambient
     {
@@ -646,7 +646,7 @@ typedef struct {
 } r3d_shader_block_light_t;
 
 typedef struct {
-    alignas(16) r3d_shader_block_light_t uLights[R3D_MAX_LIGHT_FORWARD_PER_MESH];
+    alignas(16) r3d_shader_block_light_t uLights[R3D_SHADER_LIGHT_FORWARD_UBO_CAP];
     alignas(4) int32_t uNumLights;
 } r3d_shader_block_light_array_t;
 

--- a/src/r3d_config.h.in
+++ b/src/r3d_config.h.in
@@ -53,13 +53,13 @@
 
 /*
  * Defines the maximum number of lights stored in the forward rendering UBO.
- * Matches the maximum value allowed for `R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH`.
+ * Matches the maximum value allowed for `R3D_HINT_FORWARD_LIGHT_PER_MESH`.
  */
 #define R3D_SHADER_LIGHT_FORWARD_UBO_CAP @R3D_SHADER_LIGHT_FORWARD_UBO_CAP@
 
 /*
  * Defines the maximum number of probes stored in the UBO.
- * Matches the maximum value allowed for `R3D_HINT_MAX_PROBE_ON_SCREEN`.
+ * Matches the maximum value allowed for `R3D_HINT_PROBE_MAX_ACTIVE`.
  */
 #define R3D_SHADER_PROBE_UBO_CAP @R3D_SHADER_PROBE_UBO_CAP@
 

--- a/src/r3d_config.h.in
+++ b/src/r3d_config.h.in
@@ -18,66 +18,6 @@
 #cmakedefine R3D_SUPPORT_ASSIMP
 
 // ========================================
-// Forward rendering limits
-// ========================================
-
-/**
- * Maximum number of lights affecting a single mesh in the forward rendering path.
- * This applies to transparent objects and/or non-mixed blending modes,
- * and any rendering performed during probe capture.
- */
-#define R3D_MAX_LIGHT_FORWARD_PER_MESH @R3D_MAX_LIGHT_FORWARD_PER_MESH@
-
-// ========================================
-// Probe system
-// ========================================
-
-/**
- * Maximum number of probes whose maps can be rendered simultaneously on screen.
- */
-#define R3D_MAX_PROBE_ON_SCREEN @R3D_MAX_PROBE_ON_SCREEN@
-
-/**
- * Resolution of each face of the probe capture cubemap.
- */
-#define R3D_PROBE_CAPTURE_SIZE @R3D_PROBE_CAPTURE_SIZE@
-
-// ========================================
-// Shadow mapping
-// ========================================
-
-/**
- * Resolution of directional light shadow maps.
- */
-#define R3D_SHADOW_MAP_DIRECTIONAL_SIZE @R3D_SHADOW_MAP_DIRECTIONAL_SIZE@
-
-/**
- * Resolution of spot light shadow maps.
- */
-#define R3D_SHADOW_MAP_SPOT_SIZE @R3D_SHADOW_MAP_SPOT_SIZE@
-
-/**
- * Resolution of omni (point) light shadow maps.
- */
-#define R3D_SHADOW_MAP_OMNI_SIZE @R3D_SHADOW_MAP_OMNI_SIZE@
-
-// ========================================
-// IBL / Probes
-// ========================================
-
-/**
- * Resolution of each face of irradiance cubemaps
- * used for ambient lighting and probes.
- */
-#define R3D_CUBEMAP_IRRADIANCE_SIZE @R3D_CUBEMAP_IRRADIANCE_SIZE@
-
-/**
- * Resolution of each face of prefiltered cubemaps
- * used for ambient lighting and probes.
- */
-#define R3D_CUBEMAP_PREFILTER_SIZE @R3D_CUBEMAP_PREFILTER_SIZE@
-
-// ========================================
 // Material Shaders
 // ========================================
 
@@ -106,6 +46,22 @@
  * Defines the maximum possible number in the screen shader chain.
  */
 #define R3D_MAX_SCREEN_SHADERS @R3D_MAX_SCREEN_SHADERS@
+
+// ========================================
+// Shader Module
+// ========================================
+
+/*
+ * Defines the maximum number of lights stored in the forward rendering UBO.
+ * Matches the maximum value allowed for `R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH`.
+ */
+#define R3D_SHADER_LIGHT_FORWARD_UBO_CAP @R3D_SHADER_LIGHT_FORWARD_UBO_CAP@
+
+/*
+ * Defines the maximum number of probes stored in the UBO.
+ * Matches the maximum value allowed for `R3D_HINT_MAX_PROBE_ON_SCREEN`.
+ */
+#define R3D_SHADER_PROBE_UBO_CAP @R3D_SHADER_PROBE_UBO_CAP@
 
 // ========================================
 // Render Module

--- a/src/r3d_config.h.in
+++ b/src/r3d_config.h.in
@@ -64,30 +64,6 @@
 #define R3D_SHADER_PROBE_UBO_CAP @R3D_SHADER_PROBE_UBO_CAP@
 
 // ========================================
-// Render Module
-// ========================================
-
-/*
- * Initial number of vertex slots pre-allocated in the global VBO at startup.
- */
-#define R3D_RENDER_INITIAL_VERTICES_RESERVE (1 << 16)   // 65 536 vertices (~2.3 MB)
-
-/*
- * Initial number of index slots pre-allocated in the global EBO at startup.
- */
-#define R3D_RENDER_INITIAL_ELEMENTS_RESERVE (1 << 17)   // 131 072 indices (~0.5 MB)
-
-/*
- * Initial capacity of the CPU-side draw call, group, and cluster arrays.
- */
-#define R3D_RENDER_INITIAL_DRAW_CALL_RESERVE 1024
-
-/*
- * Initial capacity of the vertex and element free list arrays.
- */
-#define R3D_RENDER_INITIAL_FREE_LIST_RESERVE 128
-
-// ========================================
 // Debug
 // ========================================
 

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -25,14 +25,14 @@
 // ========================================
 
 static const int R3D_HINT_DEFAULTS[R3D_HINT_COUNT] = {
-    [R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH]  = 16,
-    [R3D_HINT_MAX_PROBE_ON_SCREEN]         = 8,
+    [R3D_HINT_FORWARD_LIGHT_PER_MESH]  = 16,
+    [R3D_HINT_PROBE_MAX_ACTIVE]         = 8,
     [R3D_HINT_PROBE_CAPTURE_SIZE]          = 256,
-    [R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE] = 4096,
-    [R3D_HINT_SHADOW_MAP_SPOT_SIZE]        = 2048,
-    [R3D_HINT_SHADOW_MAP_OMNI_SIZE]        = 2048,
-    [R3D_HINT_CUBEMAP_IRRADIANCE_SIZE]     = 32,
-    [R3D_HINT_CUBEMAP_PREFILTER_SIZE]      = 128,
+    [R3D_HINT_SHADOW_DIR_SIZE] = 4096,
+    [R3D_HINT_SHADOW_SPOT_SIZE]        = 2048,
+    [R3D_HINT_SHADOW_OMNI_SIZE]        = 2048,
+    [R3D_HINT_IBL_IRRADIANCE_SIZE]     = 32,
+    [R3D_HINT_IBL_PREFILTER_SIZE]      = 128,
 };
 
 // ========================================
@@ -53,28 +53,28 @@ void R3D_SetHint(R3D_Hint hint, int value)
     const int MAX_TEXMAP_SIZE = 4096;
 
     switch (hint) {
-    case R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH:
+    case R3D_HINT_FORWARD_LIGHT_PER_MESH:
         value = CLAMP(value, 1, R3D_SHADER_LIGHT_FORWARD_UBO_CAP);
         break;
-    case R3D_HINT_MAX_PROBE_ON_SCREEN:
+    case R3D_HINT_PROBE_MAX_ACTIVE:
         value = CLAMP(value, 1, R3D_SHADER_PROBE_UBO_CAP);
         break;
     case R3D_HINT_PROBE_CAPTURE_SIZE:
         value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
         break;
-    case R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE:
+    case R3D_HINT_SHADOW_DIR_SIZE:
         value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
         break;
-    case R3D_HINT_SHADOW_MAP_SPOT_SIZE:
+    case R3D_HINT_SHADOW_SPOT_SIZE:
         value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
         break;
-    case R3D_HINT_SHADOW_MAP_OMNI_SIZE:
+    case R3D_HINT_SHADOW_OMNI_SIZE:
         value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
         break;
-    case R3D_HINT_CUBEMAP_IRRADIANCE_SIZE:
+    case R3D_HINT_IBL_IRRADIANCE_SIZE:
         value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
         break;
-    case R3D_HINT_CUBEMAP_PREFILTER_SIZE:
+    case R3D_HINT_IBL_PREFILTER_SIZE:
         value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
         break;
     case R3D_HINT_COUNT:

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -53,10 +53,32 @@ void R3D_SetHint(R3D_Hint hint, int value)
 {
     if (R3D.initialized || hint < 0 || hint > R3D_HINT_COUNT) return;
 
-    const int MIN_TEXMAP_SIZE = 16;
-    const int MAX_TEXMAP_SIZE = 4096;
+    const int MIN_BUFFER_SZ   = 8;
+    const int MIN_DRAW_CALLS  = 1;
+    const int MIN_FREE_SLOTS  = 1;
+    const int MIN_TEXMAP_SIZE = 2;
+
+    static bool maxTexSizeFetched = false;
+    static GLint maxTexSize = 1024;
+
+    if (!maxTexSizeFetched) {
+        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTexSize);
+        maxTexSizeFetched = true;
+    }
 
     switch (hint) {
+    case R3D_HINT_MESH_VERTEX_BUFFER_CAPACITY:
+        value = MAX(value, MIN_BUFFER_SZ);
+        break;
+    case R3D_HINT_MESH_INDEX_BUFFER_CAPACITY:
+        value = MAX(value, MIN_BUFFER_SZ);
+        break;
+    case R3D_HINT_MESH_STREAMING_CAPACITY:
+        value = MAX(value, MIN_FREE_SLOTS);
+        break;
+    case R3D_HINT_DRAW_CALL_CAPACITY:
+        value = MAX(value, MIN_DRAW_CALLS);
+        break;
     case R3D_HINT_FORWARD_LIGHT_PER_MESH:
         value = CLAMP(value, 1, R3D_SHADER_LIGHT_FORWARD_UBO_CAP);
         break;
@@ -64,22 +86,22 @@ void R3D_SetHint(R3D_Hint hint, int value)
         value = CLAMP(value, 1, R3D_SHADER_PROBE_UBO_CAP);
         break;
     case R3D_HINT_PROBE_CAPTURE_SIZE:
-        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        value = CLAMP(value, MIN_TEXMAP_SIZE, maxTexSize);
         break;
     case R3D_HINT_SHADOW_DIR_SIZE:
-        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        value = CLAMP(value, MIN_TEXMAP_SIZE, maxTexSize);
         break;
     case R3D_HINT_SHADOW_SPOT_SIZE:
-        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        value = CLAMP(value, MIN_TEXMAP_SIZE, maxTexSize);
         break;
     case R3D_HINT_SHADOW_OMNI_SIZE:
-        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        value = CLAMP(value, MIN_TEXMAP_SIZE, maxTexSize);
         break;
     case R3D_HINT_IBL_IRRADIANCE_SIZE:
-        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        value = CLAMP(value, MIN_TEXMAP_SIZE, maxTexSize);
         break;
     case R3D_HINT_IBL_PREFILTER_SIZE:
-        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        value = CLAMP(value, MIN_TEXMAP_SIZE, maxTexSize);
         break;
     case R3D_HINT_COUNT:
         break;

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -24,8 +24,8 @@
 // CONSTANTS
 // ========================================
 
-static int R3D_HINT_DEFAULTS[R3D_HINT_COUNT] = {
-    [R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH]  = 8,
+static const int R3D_HINT_DEFAULTS[R3D_HINT_COUNT] = {
+    [R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH]  = 16,
     [R3D_HINT_MAX_PROBE_ON_SCREEN]         = 8,
     [R3D_HINT_PROBE_CAPTURE_SIZE]          = 256,
     [R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE] = 4096,

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -25,14 +25,18 @@
 // ========================================
 
 static const int R3D_HINT_DEFAULTS[R3D_HINT_COUNT] = {
-    [R3D_HINT_FORWARD_LIGHT_PER_MESH]  = 16,
-    [R3D_HINT_PROBE_MAX_ACTIVE]         = 8,
+    [R3D_HINT_MESH_VERTEX_BUFFER_CAPACITY] = 65536,
+    [R3D_HINT_MESH_INDEX_BUFFER_CAPACITY]  = 131072,
+    [R3D_HINT_MESH_STREAMING_CAPACITY]     = 128,
+    [R3D_HINT_DRAW_CALL_CAPACITY]          = 1024,
+    [R3D_HINT_FORWARD_LIGHT_PER_MESH]      = 16,
+    [R3D_HINT_PROBE_MAX_ACTIVE]            = 8,
     [R3D_HINT_PROBE_CAPTURE_SIZE]          = 256,
-    [R3D_HINT_SHADOW_DIR_SIZE] = 4096,
-    [R3D_HINT_SHADOW_SPOT_SIZE]        = 2048,
-    [R3D_HINT_SHADOW_OMNI_SIZE]        = 2048,
-    [R3D_HINT_IBL_IRRADIANCE_SIZE]     = 32,
-    [R3D_HINT_IBL_PREFILTER_SIZE]      = 128,
+    [R3D_HINT_SHADOW_DIR_SIZE]             = 4096,
+    [R3D_HINT_SHADOW_SPOT_SIZE]            = 2048,
+    [R3D_HINT_SHADOW_OMNI_SIZE]            = 2048,
+    [R3D_HINT_IBL_IRRADIANCE_SIZE]         = 32,
+    [R3D_HINT_IBL_PREFILTER_SIZE]          = 128,
 };
 
 // ========================================

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -21,19 +21,84 @@
 #include "./r3d_core_state.h"
 
 // ========================================
+// CONSTANTS
+// ========================================
+
+static int R3D_HINT_DEFAULTS[R3D_HINT_COUNT] = {
+    [R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH]  = 8,
+    [R3D_HINT_MAX_PROBE_ON_SCREEN]         = 8,
+    [R3D_HINT_PROBE_CAPTURE_SIZE]          = 256,
+    [R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE] = 4096,
+    [R3D_HINT_SHADOW_MAP_SPOT_SIZE]        = 2048,
+    [R3D_HINT_SHADOW_MAP_OMNI_SIZE]        = 2048,
+    [R3D_HINT_CUBEMAP_IRRADIANCE_SIZE]     = 32,
+    [R3D_HINT_CUBEMAP_PREFILTER_SIZE]      = 128,
+};
+
+// ========================================
 // SHARED CORE STATE
 // ========================================
 
-struct r3d_core_state R3D;
+struct r3d_core_state R3D = {0};
 
 // ========================================
 // PUBLIC API
 // ========================================
 
+void R3D_SetHint(R3D_Hint hint, int value)
+{
+    if (R3D.initialized || hint < 0 || hint > R3D_HINT_COUNT) return;
+
+    const int MIN_TEXMAP_SIZE = 16;
+    const int MAX_TEXMAP_SIZE = 4096;
+
+    switch (hint) {
+    case R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH:
+        value = CLAMP(value, 1, R3D_SHADER_LIGHT_FORWARD_UBO_CAP);
+        break;
+    case R3D_HINT_MAX_PROBE_ON_SCREEN:
+        value = CLAMP(value, 1, R3D_SHADER_PROBE_UBO_CAP);
+        break;
+    case R3D_HINT_PROBE_CAPTURE_SIZE:
+        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        break;
+    case R3D_HINT_SHADOW_MAP_DIRECTIONAL_SIZE:
+        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        break;
+    case R3D_HINT_SHADOW_MAP_SPOT_SIZE:
+        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        break;
+    case R3D_HINT_SHADOW_MAP_OMNI_SIZE:
+        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        break;
+    case R3D_HINT_CUBEMAP_IRRADIANCE_SIZE:
+        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        break;
+    case R3D_HINT_CUBEMAP_PREFILTER_SIZE:
+        value = CLAMP(value, MIN_TEXMAP_SIZE, MAX_TEXMAP_SIZE);
+        break;
+    case R3D_HINT_COUNT:
+        break;
+    }
+
+    R3D.hints[hint] = (r3d_hint_t) {
+        .value = value, .override = true,
+    };
+}
+
+int R3D_GetHint(R3D_Hint hint)
+{
+    if (hint < 0 || hint > R3D_HINT_COUNT) return 0;
+    r3d_hint_t h = R3D.hints[hint];
+
+    if (!R3D.initialized && !h.override) {
+        return R3D_HINT_DEFAULTS[hint];
+    }
+    return h.value;
+}
+
 bool R3D_Init(int resWidth, int resHeight)
 {
-    memset(&R3D, 0, sizeof(R3D));
-
     R3D.matCubeViews[0] = MatrixLookAt((Vector3) {0}, (Vector3) { 1.0f,  0.0f,  0.0f}, (Vector3) {0.0f, -1.0f,  0.0f});
     R3D.matCubeViews[1] = MatrixLookAt((Vector3) {0}, (Vector3) {-1.0f,  0.0f,  0.0f}, (Vector3) {0.0f, -1.0f,  0.0f});
     R3D.matCubeViews[2] = MatrixLookAt((Vector3) {0}, (Vector3) { 0.0f,  1.0f,  0.0f}, (Vector3) {0.0f,  0.0f,  1.0f});
@@ -63,6 +128,12 @@ bool R3D_Init(int resWidth, int resHeight)
     R3D.textureWrap = TEXTURE_WRAP_CLAMP;
     R3D.colorSpace = R3D_COLORSPACE_SRGB;
 
+    for (int i = 0; i < R3D_HINT_COUNT; i++) {
+        if (!R3D.hints[i].override) {
+            R3D.hints[i].value = R3D_HINT_DEFAULTS[i];
+        }
+    }
+
     if (!r3d_texture_init()) { R3D_TRACELOG(LOG_ERROR, "Failed to init texture module"); return false; }
     if (!r3d_target_init(resWidth, resHeight)) { R3D_TRACELOG(LOG_ERROR, "Failed to init target module"); return false; }
     if (!r3d_shader_init()) { R3D_TRACELOG(LOG_ERROR, "Failed to init shader module"); return false; }
@@ -70,6 +141,8 @@ bool R3D_Init(int resWidth, int resHeight)
     if (!r3d_render_init()) { R3D_TRACELOG(LOG_ERROR, "Failed to init render module"); return false; }
     if (!r3d_light_init()) { R3D_TRACELOG(LOG_ERROR, "Failed to init light module"); return false; }
     if (!r3d_env_init()) { R3D_TRACELOG(LOG_ERROR, "Failed to init env module"); return false; }
+
+    R3D.initialized = true;
 
     R3D_TRACELOG(LOG_INFO, "Initialized successfully (%dx%d)", resWidth, resHeight);
 
@@ -85,6 +158,8 @@ void R3D_Close(void)
     r3d_render_quit();
     r3d_light_quit();
     r3d_env_quit();
+
+    memset(&R3D, 0, sizeof(R3D));
 }
 
 void R3D_GetResolution(int* width, int* height)

--- a/src/r3d_core_state.h
+++ b/src/r3d_core_state.h
@@ -19,8 +19,22 @@
 #include <raylib.h>
 
 // ========================================
+// HELPER MACROS
+// ========================================
+
+#define R3D_HINT(hint) (R3D.hints[hint].value)
+
+// ========================================
 // CORE STATE
 // ========================================
+
+/*
+ * Storage for a single hint value.
+ */
+typedef struct {
+    int value;      //< Effective value (user-provided if overridden, default otherwise)
+    bool override;  //< True if explicitly set by the user via R3D_SetHint()
+} r3d_hint_t;
 
 /*
  * Current view state including view frustum and transforms.
@@ -56,6 +70,8 @@ extern struct r3d_core_state {
     TextureWrap textureWrap;            //< Default texture wrap for material map loading
     R3D_ColorSpace colorSpace;          //< Color space that must be considered for supplied colors or surface colors
     Matrix matCubeViews[6];             //< Pre-computed view matrices for cubemap faces
+    r3d_hint_t hints[R3D_HINT_COUNT];   //< User-configurable hints, resolved at R3D_Init()
+    bool initialized;                   //< Indicates if R3D has been initialized successfully
 } R3D;
 
 #endif // R3D_CORE_STATE_H

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -743,7 +743,7 @@ void upload_light_array_block_for_mesh(const r3d_render_call_t* call, bool shado
         data->shadowLayer = shadow ? light->shadowLayer : -1;
         data->type = light->type;
 
-        if (++lights.uNumLights == R3D_HINT(R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH)) {
+        if (++lights.uNumLights == R3D_HINT(R3D_HINT_FORWARD_LIGHT_PER_MESH)) {
             break;
         }
     }
@@ -799,7 +799,7 @@ void upload_env_block(void)
             .irradiance = probe->irradiance,
             .prefilter = probe->prefilter
         };
-        if (++iProbe >= R3D_HINT(R3D_HINT_MAX_PROBE_ON_SCREEN)) {
+        if (++iProbe >= R3D_HINT(R3D_HINT_PROBE_MAX_ACTIVE)) {
             break;
         }
     }
@@ -810,7 +810,7 @@ void upload_env_block(void)
     env.uAmbient.irradiance = (int)ambient->map.irradiance - 1;
     env.uAmbient.prefilter = (int)ambient->map.prefilter - 1;
 
-    env.uNumPrefilterLevels = r3d_get_mip_levels_1d(R3D_HINT(R3D_HINT_CUBEMAP_PREFILTER_SIZE));
+    env.uNumPrefilterLevels = r3d_get_mip_levels_1d(R3D_HINT(R3D_HINT_IBL_PREFILTER_SIZE));
     env.uNumProbes = iProbe;
 
     r3d_shader_set_uniform_block(R3D_SHADER_BLOCK_ENV, &env, false);

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -743,7 +743,7 @@ void upload_light_array_block_for_mesh(const r3d_render_call_t* call, bool shado
         data->shadowLayer = shadow ? light->shadowLayer : -1;
         data->type = light->type;
 
-        if (++lights.uNumLights == R3D_MAX_LIGHT_FORWARD_PER_MESH) {
+        if (++lights.uNumLights == R3D_HINT(R3D_HINT_MAX_LIGHT_FORWARD_PER_MESH)) {
             break;
         }
     }
@@ -799,7 +799,7 @@ void upload_env_block(void)
             .irradiance = probe->irradiance,
             .prefilter = probe->prefilter
         };
-        if (++iProbe >= R3D_MAX_PROBE_ON_SCREEN) {
+        if (++iProbe >= R3D_HINT(R3D_HINT_MAX_PROBE_ON_SCREEN)) {
             break;
         }
     }
@@ -810,7 +810,7 @@ void upload_env_block(void)
     env.uAmbient.irradiance = (int)ambient->map.irradiance - 1;
     env.uAmbient.prefilter = (int)ambient->map.prefilter - 1;
 
-    env.uNumPrefilterLevels = r3d_get_mip_levels_1d(R3D_CUBEMAP_PREFILTER_SIZE);
+    env.uNumPrefilterLevels = r3d_get_mip_levels_1d(R3D_HINT(R3D_HINT_CUBEMAP_PREFILTER_SIZE));
     env.uNumProbes = iProbe;
 
     r3d_shader_set_uniform_block(R3D_SHADER_BLOCK_ENV, &env, false);
@@ -1680,11 +1680,11 @@ void pass_scene_probes(void)
         r3d_env_capture_gen_mipmaps();
 
         if (probe->irradiance >= 0) {
-            r3d_pass_prepare_irradiance(probe->irradiance, r3d_env_capture_get(), R3D_PROBE_CAPTURE_SIZE);
+            r3d_pass_prepare_irradiance(probe->irradiance, r3d_env_capture_get(), R3D_HINT(R3D_HINT_PROBE_CAPTURE_SIZE));
         }
 
         if (probe->prefilter >= 0) {
-            r3d_pass_prepare_prefilter(probe->prefilter, r3d_env_capture_get(), R3D_PROBE_CAPTURE_SIZE);
+            r3d_pass_prepare_prefilter(probe->prefilter, r3d_env_capture_get(), R3D_HINT(R3D_HINT_PROBE_CAPTURE_SIZE));
         }
 
         r3d_target_invalidate_cache(); //< The IBL gen functions bind framebuffers; resetting them prevents any problems

--- a/src/r3d_lighting.c
+++ b/src/r3d_lighting.c
@@ -340,13 +340,13 @@ void R3D_UpdateShadowMap(R3D_Light id)
 float R3D_GetShadowSoftness(R3D_Light id)
 {
     GET_LIGHT_OR_RETURN(light, id, 0);
-    return light->shadowSoftness * R3D_LIGHT_SHADOW_SIZE[light->type];
+    return light->shadowSoftness * r3d_light_shadow_get_size(light->type);
 }
 
 void R3D_SetShadowSoftness(R3D_Light id, float softness)
 {
     GET_LIGHT_OR_RETURN(light, id);
-    light->shadowSoftness = softness / R3D_LIGHT_SHADOW_SIZE[light->type];
+    light->shadowSoftness = softness / r3d_light_shadow_get_size(light->type);
 }
 
 float R3D_GetShadowOpacity(R3D_Light id)


### PR DESCRIPTION
## Overview

Added a runtime-configurable hint system via `R3D_SetHint()`/`R3D_GetHint()`, to be set before `R3D_Init()`.

## Changes

- New API: `R3D_SetHint(R3D_Hint hint, int value)` / `R3D_GetHint(R3D_Hint hint)`
- New `R3D_Hint` enum:

```c
/**
 * @brief Configuration hints used to customize R3D before initialization.
 *
 * Hints must be set via R3D_SetHint() before calling R3D_Init().
 * Any hint not explicitly set falls back to its default value.
 *
 * @note Some hints may be clamped internally.
 */
typedef enum R3D_Hint {
    R3D_HINT_MESH_VERTEX_BUFFER_CAPACITY,   ///< Initial vertex capacity of the global VBO. Default: 65'536
    R3D_HINT_MESH_INDEX_BUFFER_CAPACITY,    ///< Initial index capacity of the global EBO. Default: 131'072
    R3D_HINT_MESH_STREAMING_CAPACITY,       ///< Initial capacity for tracking freed mesh slots, relevant only for meshes loaded/unloaded at runtime. Default: 128
    R3D_HINT_DRAW_CALL_CAPACITY,            ///< Initial capacity of the CPU-side draw call list. Default: 1024
    R3D_HINT_FORWARD_LIGHT_PER_MESH,        ///< Max lights per mesh in forward pass. Default: 16
    R3D_HINT_PROBE_MAX_ACTIVE,              ///< Max probes rendered simultaneously. Default: 8
    R3D_HINT_PROBE_CAPTURE_SIZE,            ///< Probe capture cubemap face size (px). Default: 256
    R3D_HINT_SHADOW_DIR_SIZE,               ///< Directional light shadow map size (px). Default: 4096
    R3D_HINT_SHADOW_SPOT_SIZE,              ///< Spot light shadow map size (px). Default: 2048
    R3D_HINT_SHADOW_OMNI_SIZE,              ///< Omni light shadow map size (px). Default: 2048
    R3D_HINT_IBL_IRRADIANCE_SIZE,           ///< Irradiance cubemap face size, shared by ambient IBL and probes (px). Default: 32
    R3D_HINT_IBL_PREFILTER_SIZE,            ///< Prefiltered cubemap face size, shared by ambient IBL and probes (px). Default: 128
    R3D_HINT_COUNT,                         ///< Sentinel, not a valid hint
} R3D_Hint;
```