### PR TITLE
[internal] Add internal temporary allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,7 @@ add_library(${PROJECT_NAME}
     "${R3D_ROOT_PATH}/src/common/r3d_anim.c"
     "${R3D_ROOT_PATH}/src/common/r3d_helper.c"
     "${R3D_ROOT_PATH}/src/common/r3d_image.c"
+    "${R3D_ROOT_PATH}/src/common/r3d_stack.c"
     "${R3D_ROOT_PATH}/src/common/r3d_pool.c"
     "${R3D_ROOT_PATH}/src/common/r3d_pass.c"
     # Modules

--- a/include/r3d/r3d_mesh_data.h
+++ b/include/r3d/r3d_mesh_data.h
@@ -443,6 +443,7 @@ R3DAPI void R3D_GenMeshDataUVsCylindrical(R3D_MeshData* meshData);
  * @param meshData Mesh data to modify.
  * @param type Primitive type of the mesh. Points and line primitives are not
  *             supported and will default to a front-facing normal (0, 0, 1).
+ * @warning Not thread-safe: uses the shared global scratch stack
  */
 R3DAPI void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType type);
 
@@ -451,6 +452,7 @@ R3DAPI void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType typ
  * @param meshData Mesh data to modify.
  * @param type Primitive type of the mesh. Points and line primitives are not
  *             supported and will default to a front-facing tangent (1, 0, 0, 1).
+ * @warning Not thread-safe: uses the shared global scratch stack
  */
 R3DAPI void R3D_GenMeshDataTangents(R3D_MeshData* meshData, R3D_PrimitiveType type);
 

--- a/src/common/r3d_helper.h
+++ b/src/common/r3d_helper.h
@@ -86,6 +86,9 @@
     )
 #endif
 
+#define R3D_CONCAT_(a, b) a##b
+#define R3D_CONCAT(a, b)  R3D_CONCAT_(a, b)
+
 // ========================================
 // HELPER FUNCTIONS
 // ========================================

--- a/src/common/r3d_stack.c
+++ b/src/common/r3d_stack.c
@@ -1,0 +1,153 @@
+/* r3d_stack.c -- Temporary bump/stack allocator with push/pop scopes.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#include "./r3d_stack.h"
+#include <raylib.h>
+#include <string.h>
+#include <assert.h>
+
+// ========================================
+// INTERNAL HELPERS
+// ========================================
+
+static inline size_t stack_total_size(size_t capacity)
+{
+    return sizeof(r3d_stack_t) + capacity;
+}
+
+static inline void stack_set_pointer(r3d_stack_t* stack)
+{
+    stack->memory = (uint8_t*)stack + sizeof(r3d_stack_t);
+}
+
+/* Reallocate to at least 'minCapacity' bytes (geometric x2 growth).
+ * Only bytes below 'cursor' are copied; the rest is unused scratch. */
+static r3d_stack_t* stack_grow(r3d_stack_t* stack, size_t minCapacity)
+{
+    size_t newCap = (stack->capacity > 0) ? stack->capacity : 64;
+
+    while (newCap < minCapacity) {
+        size_t doubled = newCap * 2;
+        if (doubled <= newCap) { // Overflow
+            newCap = minCapacity;
+            break;
+        }
+        newCap = doubled;
+    }
+
+    uint8_t* newMem = MemAlloc(stack_total_size(newCap));
+    if (!newMem) return NULL;
+
+    r3d_stack_t* newStack = (r3d_stack_t*)newMem;
+    *newStack = *stack;
+    newStack->capacity = newCap;
+
+    stack_set_pointer(newStack);
+
+    if (stack->cursor > 0) {
+        memcpy(newStack->memory, stack->memory, stack->cursor);
+    }
+
+    MemFree(stack);
+    return newStack;
+}
+
+// ========================================
+// STACK FUNCTIONS
+// ========================================
+
+r3d_stack_t* r3d_stack_create(size_t capacity)
+{
+    if (capacity == 0) {
+        return NULL;
+    }
+
+    uint8_t* mem = MemAlloc(stack_total_size(capacity));
+    if (!mem) return NULL;
+
+    r3d_stack_t* stack = (r3d_stack_t*)mem;
+    stack->capacity = capacity;
+    stack->cursor = 0;
+    stack->depth = 0;
+
+    stack_set_pointer(stack);
+
+    return stack;
+}
+
+void r3d_stack_destroy(r3d_stack_t* stack)
+{
+    MemFree(stack);
+}
+
+bool r3d_stack_push(r3d_stack_t** stackPtr, size_t reserve)
+{
+    r3d_stack_t* stack = *stackPtr;
+
+    assert(stack->depth < R3D_STACK_MAX_DEPTH && "r3d_stack: max push() depth exceeded");
+    if (stack->depth >= R3D_STACK_MAX_DEPTH) {
+        return false;
+    }
+
+    if (reserve > 0 && stack->cursor + reserve > stack->capacity) {
+        stack = stack_grow(stack, stack->cursor + reserve);
+        if (!stack) return false;
+        *stackPtr = stack;
+    }
+
+    stack->marks[stack->depth++] = stack->cursor;
+
+    return true;
+}
+
+void r3d_stack_pop(r3d_stack_t* stack)
+{
+    assert(stack->depth > 0 && "r3d_stack: pop() without matching push()");
+    if (stack->depth == 0) return;
+
+    stack->cursor = stack->marks[--stack->depth];
+}
+
+void* r3d_stack_alloc(r3d_stack_t** stackPtr, size_t size)
+{
+    return r3d_stack_alloc_aligned(stackPtr, size, R3D_STACK_DEFAULT_ALIGN);
+}
+
+void* r3d_stack_alloc_aligned(r3d_stack_t** stackPtr, size_t size, size_t align)
+{
+    if (size == 0) return NULL;
+    if (align == 0) align = 1;
+
+    assert((align & (align - 1)) == 0 && "r3d_stack: align must be a power of two");
+
+    r3d_stack_t* stack = *stackPtr;
+
+    // Worst-case space needed to satisfy alignment before knowing
+    // the final base address (it may change if we have to grow)
+    size_t worst = size + (align - 1);
+
+    if (stack->cursor + worst > stack->capacity) {
+        stack = stack_grow(stack, stack->cursor + worst);
+        if (!stack) return NULL;
+        *stackPtr = stack;
+    }
+
+    uintptr_t base = (uintptr_t)stack->memory + stack->cursor;
+    uintptr_t aligned = (base + (align - 1)) & ~(uintptr_t)(align - 1);
+    size_t padding = (size_t)(aligned - base);
+
+    stack->cursor += padding + size;
+
+    return (void*)aligned;
+}
+
+void r3d_stack_reset(r3d_stack_t* stack)
+{
+    stack->cursor = 0;
+    stack->depth = 0;
+}

--- a/src/common/r3d_stack.h
+++ b/src/common/r3d_stack.h
@@ -32,21 +32,26 @@
 // ========================================
 
 /* Push/alloc/pop in one block; pop() runs automatically on block exit.
- * Skips the body entirely if push() fails (max depth or OOM).
+ * 'okVar' (no need to initialize) ends up true only if the body ran
+ * to completion; false if push() failed (max depth or OOM, body
+ * skipped entirely) or if the body exited early.
  *
- *   R3D_STACK_SCOPE(&stack, 1024) {
+ *   bool ok;
+ *   R3D_STACK_SCOPE(&stack, 1024, ok) {
  *       void* tmp = r3d_stack_alloc(&stack, 64);
  *       ...
- *   } // pop() happens here
+ *   } // pop() happens here, ok is now set
+ *   if (!ok) { / * handle failure * / }
  *
  * A plain `break` inside the body exits early without popping.
  * Use R3D_STACK_SCOPE_EXIT for an early safe exit
  */
-#define R3D_STACK_SCOPE(stackPtr, reserve)                      \
-    for (bool R3D_CONCAT(r3d_stack_scope_ok_, __LINE__) =       \
-             r3d_stack_push((stackPtr), (reserve));             \
-         R3D_CONCAT(r3d_stack_scope_ok_, __LINE__);             \
-         r3d_stack_pop(*(stackPtr)),                            \
+#define R3D_STACK_SCOPE(stackPtr, reserve, okVar)                       \
+    for (bool R3D_CONCAT(r3d_stack_scope_ok_, __LINE__) =               \
+             ((okVar) = false, r3d_stack_push((stackPtr), (reserve)));  \
+         R3D_CONCAT(r3d_stack_scope_ok_, __LINE__);                     \
+         r3d_stack_pop(*(stackPtr)),                                    \
+         (okVar) = true,                                                \
          R3D_CONCAT(r3d_stack_scope_ok_, __LINE__) = false)
 
 /* Early, safe exit from a R3D_STACK_SCOPE: pops then breaks out.

--- a/src/common/r3d_stack.h
+++ b/src/common/r3d_stack.h
@@ -1,0 +1,120 @@
+/* r3d_stack.h -- Temporary stack allocator with push/pop scopes.
+ *
+ * Copyright (c) 2025-2026 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+#ifndef R3D_STACK_H
+#define R3D_STACK_H
+
+#include <raylib.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "./r3d_helper.h"
+
+// ========================================
+// CONFIG
+// ========================================
+
+/* Max nested push()/pop() depth (size of the internal marks[] array) */
+#ifndef R3D_STACK_MAX_DEPTH
+#   define R3D_STACK_MAX_DEPTH 16
+#endif
+
+/* Default alignment for r3d_stack_alloc() */
+#define R3D_STACK_DEFAULT_ALIGN (sizeof(void*))
+
+// ========================================
+// HELPER MACROS
+// ========================================
+
+/* Push/alloc/pop in one block; pop() runs automatically on block exit.
+ * Skips the body entirely if push() fails (max depth or OOM).
+ *
+ *   R3D_STACK_SCOPE(&stack, 1024) {
+ *       void* tmp = r3d_stack_alloc(&stack, 64);
+ *       ...
+ *   } // pop() happens here
+ *
+ * A plain `break` inside the body exits early without popping.
+ * Use R3D_STACK_SCOPE_EXIT for an early safe exit
+ */
+#define R3D_STACK_SCOPE(stackPtr, reserve)                      \
+    for (bool R3D_CONCAT(r3d_stack_scope_ok_, __LINE__) =       \
+             r3d_stack_push((stackPtr), (reserve));             \
+         R3D_CONCAT(r3d_stack_scope_ok_, __LINE__);             \
+         r3d_stack_pop(*(stackPtr)),                            \
+         R3D_CONCAT(r3d_stack_scope_ok_, __LINE__) = false)
+
+/* Early, safe exit from a R3D_STACK_SCOPE: pops then breaks out.
+ *
+ * CAUTION: this is a raw `break`, so it only exits the innermost
+ * enclosing loop/switch. Only call it directly inside the
+ * R3D_STACK_SCOPE body.
+ */
+#define R3D_STACK_SCOPE_EXIT(stack) do {    \
+    r3d_stack_pop(stack);                   \
+    break;                                  \
+} while (0)
+
+// ========================================
+// STACK STRUCT
+// ========================================
+
+/* Single allocation: [ r3d_stack_t | memory[capacity] ].
+ * push() saves the cursor, alloc() bumps it forward, pop() restores
+ * it; a pure LIFO scratch allocator, nothing is freed individually.
+ */
+typedef struct {
+    size_t capacity;                    // Buffer size in bytes
+    size_t cursor;                      // Current bump position
+    size_t marks[R3D_STACK_MAX_DEPTH];  // Saved cursor per push() level
+    uint32_t depth;                     // Current nesting depth
+    uint8_t* memory;                    // Buffer (right after the header)
+} r3d_stack_t;
+
+// ========================================
+// STACK FUNCTIONS
+// ========================================
+
+/* Create a stack with the given initial capacity. NULL on failure or capacity == 0 */
+r3d_stack_t* r3d_stack_create(size_t capacity);
+
+/* Free the stack and all its memory */
+void r3d_stack_destroy(r3d_stack_t* stack);
+
+/* Open a scope, saving the current cursor. 'reserve' (may be 0) pre-grows
+ * the buffer so at least that many bytes are available without further
+ * reallocation during the scope. *stackPtr is updated if it grows.
+ * Returns false on failure (max depth reached or OOM) */
+bool r3d_stack_push(r3d_stack_t** stackPtr, size_t reserve);
+
+/* Close the current scope: rewinds the cursor to the matching push() */
+void r3d_stack_pop(r3d_stack_t* stack);
+
+/* Bump-allocate 'size' bytes, aligned to R3D_STACK_DEFAULT_ALIGN.
+ * *stackPtr is updated if it grows. NULL on failure */
+void* r3d_stack_alloc(r3d_stack_t** stackPtr, size_t size);
+
+/* Same as r3d_stack_alloc(), with an explicit power-of-two alignment */
+void* r3d_stack_alloc_aligned(r3d_stack_t** stackPtr, size_t size, size_t align);
+
+/* Rewind everything at once: cursor to 0, all scopes closed (O(1)) */
+void r3d_stack_reset(r3d_stack_t* stack);
+
+/* Bytes currently in use */
+static inline size_t r3d_stack_used(const r3d_stack_t* stack)
+{
+    return stack->cursor;
+}
+
+/* Bytes free before the next reallocation */
+static inline size_t r3d_stack_remaining(const r3d_stack_t* stack)
+{
+    return stack->capacity - stack->cursor;
+}
+
+#endif // R3D_STACK_H

--- a/src/importer/r3d_importer_texture.c
+++ b/src/importer/r3d_importer_texture.c
@@ -37,7 +37,9 @@
 
 #include "../common/r3d_helper.h"
 #include "../common/r3d_image.h"
+#include "../common/r3d_stack.h"
 #include "../common/r3d_hash.h"
+#include "../r3d_core_state.h"
 
 // ========================================
 // CONSTANTS
@@ -92,30 +94,6 @@ typedef struct {
     atomic_int writePos;
     atomic_int readPos;
 } loader_context_t;
-
-// ========================================
-// MEMORY ARENA ALLOCATOR
-// ========================================
-
-typedef struct {
-    void* base;
-    size_t used;
-    size_t capacity;
-} memory_arena_t;
-
-static inline void* arena_alloc(memory_arena_t* arena, size_t size, size_t align)
-{
-    size_t padding = (align - (arena->used % align)) % align;
-    size_t required = arena->used + padding + size;
-    if (required > arena->capacity) return NULL;
-
-    void* ptr = (char*)arena->base + arena->used + padding;
-    arena->used = required;
-    return ptr;
-}
-
-#define ARENA_ALLOC(arena, type, count) \
-    arena_alloc(arena, sizeof(type) * (count), _Alignof(type))
 
 // ========================================
 // HELPER FUNCTIONS
@@ -398,10 +376,8 @@ r3d_importer_texture_cache_t* r3d_importer_load_texture_cache(
         return NULL;
     }
 
-    /* --- Early exit: check if any material has textures before allocating --- */
-
+    // Skip allocating anything if no material has textures
     int materialCount = r3d_importer_get_material_count(importer);
-
     bool hasAnyTexture = false;
     for (int matIdx = 0; matIdx < materialCount && !hasAnyTexture; matIdx++) {
         const struct aiMaterial* mat = r3d_importer_get_material(importer, matIdx);
@@ -414,148 +390,161 @@ r3d_importer_texture_cache_t* r3d_importer_load_texture_cache(
     }
     if (!hasAnyTexture) return NULL;
 
-    /* --- Phase 0: Allocate a large block of memory for work --- */
-
+    // Persistent output buffer (outlives the scratch scope below)
     int maxSlots = materialCount * R3D_MAP_COUNT;
+    Texture2D* finalTextures = MemAlloc(maxSlots * sizeof(Texture2D));
+    if (!finalTextures) {
+        R3D_TRACELOG(LOG_WARNING, "Failed to allocate texture cache: out of memory");
+        return NULL;
+    }
 
-    size_t arenaSize = 
-        sizeof(texture_job_t) * maxSlots +      // Jobs
-        sizeof(texture_slot_t) * maxSlots +     // Slots
-        sizeof(texture_entry_t) * maxSlots +    // Entries
-        sizeof(int) * maxSlots +                // Material mapping
-        sizeof(thrd_t) * r3d_get_cpu_count() +  // Thread handles
-        sizeof(atomic_int) * maxSlots +         // Ready slots queue
-        1024;                                   // Padding for alignment
+    int uniqueCount = 0, uploadedCount = 0, processedCount = 0;
+    bool oom = false;
 
-    void* arenaMemory = MemAlloc(arenaSize);
-    memory_arena_t arena = {.base = arenaMemory, .used = 0, .capacity = arenaSize};
-
-    /* --- Phase 1: Collect unique textures --- */
-
-    texture_job_t* jobs = ARENA_ALLOC(&arena, texture_job_t, maxSlots);
-    texture_slot_t* slots = ARENA_ALLOC(&arena, texture_slot_t, maxSlots);
-    texture_entry_t* entries = ARENA_ALLOC(&arena, texture_entry_t, maxSlots);
-
-    int* materialToSlot = ARENA_ALLOC(&arena, int, maxSlots);
-    for (int i = 0; i < maxSlots; i++) materialToSlot[i] = -1;
-
-    texture_entry_t* hashTable = NULL;
-    int entryPoolUsed = 0;
-    int uniqueCount = 0;
-
-    for (int matIdx = 0; matIdx < materialCount; matIdx++)
+    // Collect, load, upload, build
+    R3D_STACK_SCOPE(&R3D.stack, 0)
     {
-        const struct aiMaterial* material = r3d_importer_get_material(importer, matIdx);
+        // Pre-alloacte temp memory
+        texture_job_t* jobs = r3d_stack_alloc(&R3D.stack, maxSlots * sizeof(texture_job_t));
+        texture_slot_t* slots = r3d_stack_alloc(&R3D.stack, maxSlots * sizeof(texture_slot_t));
+        texture_entry_t* entries = r3d_stack_alloc(&R3D.stack, maxSlots * sizeof(texture_entry_t));
+        int* materialToSlot = r3d_stack_alloc(&R3D.stack, maxSlots * sizeof(int));
+        if (!jobs || !slots || !entries || !materialToSlot) {
+            oom = true;
+            R3D_STACK_SCOPE_EXIT(R3D.stack);
+        }
+        for (int i = 0; i < maxSlots; i++) materialToSlot[i] = -1;
 
-        for (int mapIdx = 0; mapIdx < R3D_MAP_COUNT; mapIdx++)
+        // Collect all unique textures
+        texture_entry_t* hashTable = NULL;
+        int entryPoolUsed = 0;
+
+        for (int matIdx = 0; matIdx < materialCount; matIdx++)
         {
-            texture_job_t job = {0};
-            if (!texture_job_init(&job, material, mapIdx)) continue;
+            const struct aiMaterial* material = r3d_importer_get_material(importer, matIdx);
 
-            texture_entry_t* entry = NULL;
-            texture_key_t key = make_key_texture_job(&job);
-            HASH_FIND(hh, hashTable, &key, sizeof(key), entry);
+            for (int mapIdx = 0; mapIdx < R3D_MAP_COUNT; mapIdx++)
+            {
+                texture_job_t job = {0};
+                if (!texture_job_init(&job, material, mapIdx)) continue;
 
-            if (entry) {
-                // Reuse existing slot
-                materialToSlot[matIdx * R3D_MAP_COUNT + mapIdx] = entry->slotIndex;
+                texture_entry_t* entry = NULL;
+                texture_key_t key = make_key_texture_job(&job);
+                HASH_FIND(hh, hashTable, &key, sizeof(key), entry);
+
+                if (entry) {
+                    // Reuse existing slot
+                    materialToSlot[matIdx * R3D_MAP_COUNT + mapIdx] = entry->slotIndex;
+                    continue;
+                }
+
+                // New unique texture
+                entry = &entries[entryPoolUsed++];
+                entry->key = key;
+                entry->slotIndex = uniqueCount;
+                HASH_ADD(hh, hashTable, key, sizeof(key), entry);
+
+                jobs[uniqueCount] = job;
+                slots[uniqueCount].map = mapIdx;
+
+                materialToSlot[matIdx * R3D_MAP_COUNT + mapIdx] = uniqueCount;
+                uniqueCount++;
+            }
+        }
+
+        // Parallel texture loading to RAM
+        loader_context_t ctx = {
+            .importer = importer,
+            .jobs = jobs,
+            .slots = slots,
+            .slotCount = uniqueCount,
+            .readySlots = r3d_stack_alloc(&R3D.stack, uniqueCount * sizeof(atomic_int))
+        };
+
+        int numThreads = r3d_get_cpu_count();
+        if (numThreads > uniqueCount) numThreads = uniqueCount;
+
+        thrd_t* threads = r3d_stack_alloc(&R3D.stack, numThreads * sizeof(thrd_t));
+
+        if (!ctx.readySlots || !threads) {
+            oom = true;
+            R3D_STACK_SCOPE_EXIT(R3D.stack);
+        }
+
+        atomic_init(&ctx.nextJob, 0);
+        atomic_init(&ctx.writePos, 0);
+        atomic_init(&ctx.readPos, 0);
+
+        for (int i = 0; i < numThreads; i++) {
+            thrd_create(&threads[i], worker_thread, &ctx);
+        }
+
+        // In the meantime, progressive upload to VRAM
+        while (processedCount < uniqueCount)
+        {
+            int readPos = atomic_load_explicit(&ctx.readPos, memory_order_acquire);
+            int writePos = atomic_load_explicit(&ctx.writePos, memory_order_acquire);
+
+            if (writePos == readPos) {
+                struct timespec ts = {.tv_sec = 0, .tv_nsec = 1000000}; // 1ms
+                thrd_sleep(&ts, NULL);
                 continue;
             }
 
-            // New unique texture
-            entry = &entries[entryPoolUsed++];
-            entry->key = key;
-            entry->slotIndex = uniqueCount;
-            HASH_ADD(hh, hashTable, key, sizeof(key), entry);
+            atomic_thread_fence(memory_order_acquire);
 
-            jobs[uniqueCount] = job;
-            slots[uniqueCount].map = mapIdx;
-
-            materialToSlot[matIdx * R3D_MAP_COUNT + mapIdx] = uniqueCount;
-            uniqueCount++;
-        }
-    }
-
-    /* --- Phase 2: Parallel loading to RAM --- */
-
-    loader_context_t ctx = {
-        .importer = importer,
-        .jobs = jobs,
-        .slots = slots,
-        .slotCount = uniqueCount,
-        .readySlots = ARENA_ALLOC(&arena, atomic_int, uniqueCount)
-    };
-
-    atomic_init(&ctx.nextJob, 0);
-    atomic_init(&ctx.writePos, 0);
-    atomic_init(&ctx.readPos, 0);
-
-    int numThreads = r3d_get_cpu_count();
-    if (numThreads > uniqueCount) numThreads = uniqueCount;
-
-    thrd_t* threads = ARENA_ALLOC(&arena, thrd_t, numThreads);
-    for (int i = 0; i < numThreads; i++) {
-        thrd_create(&threads[i], worker_thread, &ctx);
-    }
-
-    /* --- Phase 3: Progressive upload to VRAM --- */
-
-    int processedCount = 0;
-    int uploadedCount = 0;
-
-    while (processedCount < uniqueCount)
-    {
-        int readPos = atomic_load_explicit(&ctx.readPos, memory_order_acquire);
-        int writePos = atomic_load_explicit(&ctx.writePos, memory_order_acquire);
-
-        if (writePos == readPos) {
-            struct timespec ts = {.tv_sec = 0, .tv_nsec = 1000000}; // 1ms
-            thrd_sleep(&ts, NULL);
-            continue;
-        }
-
-        atomic_thread_fence(memory_order_acquire);
-
-        for (int i = readPos; i < writePos; i++) {
-            int slotIdx = ctx.readySlots[i];
-            texture_slot_t* slot = &slots[slotIdx];
-            if (slot->image.data) {
-                slot->texture = r3d_image_upload(&slot->image, slot->wrapMode, filter, is_srgb(slot->map, colorSpace));
-                if (slot->ownsImageData) {
-                    UnloadImage(slot->image);
-                    slot->image.data = NULL;
+            for (int i = readPos; i < writePos; i++) {
+                int slotIdx = ctx.readySlots[i];
+                texture_slot_t* slot = &slots[slotIdx];
+                if (slot->image.data) {
+                    slot->texture = r3d_image_upload(&slot->image, slot->wrapMode, filter, is_srgb(slot->map, colorSpace));
+                    if (slot->ownsImageData) {
+                        UnloadImage(slot->image);
+                        slot->image.data = NULL;
+                    }
+                    uploadedCount++;
                 }
-                uploadedCount++;
+                processedCount++;
             }
-            processedCount++;
+
+            atomic_store_explicit(&ctx.readPos, writePos, memory_order_release);
         }
 
-        atomic_store_explicit(&ctx.readPos, writePos, memory_order_release);
+        for (int i = 0; i < numThreads; i++) {
+            thrd_join(threads[i], NULL);
+        }
+
+        // Once done, build final cache
+        for (int i = 0; i < maxSlots; i++) {
+            int slotIdx = materialToSlot[i];
+            if (slotIdx >= 0) finalTextures[i] = slots[slotIdx].texture;
+        }
     }
 
-    for (int i = 0; i < numThreads; i++) {
-        thrd_join(threads[i], NULL);
-    }
-
-    /* --- Phase 4: Build final cache --- */
-
-    Texture2D* finalTextures = MemAlloc(materialCount * R3D_MAP_COUNT * sizeof(Texture2D));
-    for (int i = 0; i < maxSlots; i++) {
-        int slotIdx = materialToSlot[i];
-        if (slotIdx >= 0) finalTextures[i] = slots[slotIdx].texture;
+    if (oom) {
+        // Loading was aborted mid-way: any textures already uploaded
+        // to VRAM in this run are still referenced by finalTextures,
+        // free them before bailing out to avoid leaking GPU handles
+        for (int i = 0; i < maxSlots; i++) {
+            if (finalTextures[i].id != 0) UnloadTexture(finalTextures[i]);
+        }
+        MemFree(finalTextures);
+        R3D_TRACELOG(LOG_WARNING, "Failed to load texture cache: out of memory");
+        return NULL;
     }
 
     r3d_importer_texture_cache_t* cache = MemAlloc(sizeof(*cache));
+    if (!cache) {
+        for (int i = 0; i < maxSlots; i++) {
+            if (finalTextures[i].id != 0) UnloadTexture(finalTextures[i]);
+        }
+        MemFree(finalTextures);
+        R3D_TRACELOG(LOG_WARNING, "Failed to allocate texture cache handle: out of memory");
+        return NULL;
+    }
+
     cache->materialCount = materialCount;
     cache->textures = finalTextures;
-
-    /* --- Cleanup --- */
-
-    texture_entry_t* entry, *tmp;
-    HASH_ITER(hh, hashTable, entry, tmp) {
-        HASH_DEL(hashTable, entry);
-    }
-    MemFree(arenaMemory);
 
     if (uploadedCount == processedCount) {
         R3D_TRACELOG(LOG_INFO, "Model textures cached: %d/%d textures loaded successfully", 

--- a/src/importer/r3d_importer_texture.c
+++ b/src/importer/r3d_importer_texture.c
@@ -399,20 +399,25 @@ r3d_importer_texture_cache_t* r3d_importer_load_texture_cache(
     }
 
     int uniqueCount = 0, uploadedCount = 0, processedCount = 0;
-    bool oom = false;
+    bool ok;
+
+    // Worst-case scratch size for the whole scope below
+    size_t reserve =
+        (size_t)maxSlots * sizeof(texture_job_t) +
+        (size_t)maxSlots * sizeof(texture_slot_t) +
+        (size_t)maxSlots * sizeof(texture_entry_t) +
+        (size_t)maxSlots * sizeof(int) +
+        (size_t)maxSlots * sizeof(atomic_int) +       // readySlots, worst case uniqueCount == maxSlots
+        (size_t)r3d_get_cpu_count() * sizeof(thrd_t); // threads, worst case numThreads == cpu count
 
     // Collect, load, upload, build
-    R3D_STACK_SCOPE(&R3D.stack, 0)
+    R3D_STACK_SCOPE(&R3D.stack, reserve, ok)
     {
         // Pre-alloacte temp memory
         texture_job_t* jobs = r3d_stack_alloc(&R3D.stack, maxSlots * sizeof(texture_job_t));
         texture_slot_t* slots = r3d_stack_alloc(&R3D.stack, maxSlots * sizeof(texture_slot_t));
         texture_entry_t* entries = r3d_stack_alloc(&R3D.stack, maxSlots * sizeof(texture_entry_t));
         int* materialToSlot = r3d_stack_alloc(&R3D.stack, maxSlots * sizeof(int));
-        if (!jobs || !slots || !entries || !materialToSlot) {
-            oom = true;
-            R3D_STACK_SCOPE_EXIT(R3D.stack);
-        }
         for (int i = 0; i < maxSlots; i++) materialToSlot[i] = -1;
 
         // Collect all unique textures
@@ -466,11 +471,6 @@ r3d_importer_texture_cache_t* r3d_importer_load_texture_cache(
 
         thrd_t* threads = r3d_stack_alloc(&R3D.stack, numThreads * sizeof(thrd_t));
 
-        if (!ctx.readySlots || !threads) {
-            oom = true;
-            R3D_STACK_SCOPE_EXIT(R3D.stack);
-        }
-
         atomic_init(&ctx.nextJob, 0);
         atomic_init(&ctx.writePos, 0);
         atomic_init(&ctx.readPos, 0);
@@ -521,7 +521,7 @@ r3d_importer_texture_cache_t* r3d_importer_load_texture_cache(
         }
     }
 
-    if (oom) {
+    if (!ok) {
         // Loading was aborted mid-way: any textures already uploaded
         // to VRAM in this run are still referenced by finalTextures,
         // free them before bailing out to avoid leaking GPU handles

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 
 #include "../common/r3d_helper.h"
+#include "../r3d_core_state.h"
 
 // ========================================
 // SHADER CODE INCLUDES
@@ -106,11 +107,29 @@ struct r3d_mod_shader R3D_MOD_SHADER;
         : &(custom)->program->category.shader_name
 
 #define LOAD_SHADER(shader_name, vsCode, fsCode) do {                           \
-    shader_name->id = load_shader(vsCode, fsCode);                              \
+    shader_name->id = load_shader((vsCode), (fsCode));                          \
     if (shader_name->id == 0) {                                                 \
         R3D_TRACELOG(LOG_ERROR, "Failed to load shader '" #shader_name "'");    \
         return false;                                                           \
     }                                                                           \
+} while(0)
+
+#define LOAD_SHADER_EX(shader_name, desc) do {                                  \
+    bool ok = false;                                                            \
+    R3D_STACK_SCOPE(&R3D.stack, shader_source_reserve(&(desc))) {               \
+        const char *vsCode = NULL, *fsCode = NULL;                              \
+        if (!shader_source_build(&vsCode, &fsCode, &R3D.stack, &(desc))) {      \
+            R3D_TRACELOG(LOG_ERROR, "Failed to build '" #shader_name "' shader sources"); \
+            R3D_STACK_SCOPE_EXIT(R3D.stack);                                    \
+        }                                                                       \
+        shader_name->id = load_shader(vsCode, fsCode);                          \
+        if (shader_name->id == 0) {                                             \
+            R3D_TRACELOG(LOG_ERROR, "Failed to load shader '" #shader_name "'");\
+            R3D_STACK_SCOPE_EXIT(R3D.stack);                                    \
+        }                                                                       \
+        ok = true;                                                              \
+    }                                                                           \
+    if (!ok) return false;                                                      \
 } while(0)
 
 #define USE_SHADER(shader_name) do {                                            \
@@ -149,31 +168,35 @@ struct r3d_mod_shader R3D_MOD_SHADER;
 } while(0)
 
 // ========================================
+// INTERNAL STRUCTURES
+// ========================================
+
+typedef struct {
+    const char* vsTemplate; // Vertex shader template source (mandatory, must not be NULL)
+    const char** vsDefines; // Vertex shader defines (may be NULL)
+    int vsDefineCount;      // Number of vertex defines (ignored if vsDefines is NULL)
+
+    const char* fsTemplate; // Fragment shader template source (mandatory, must not be NULL)
+    const char** fsDefines; // Fragment shader defines (may be NULL)
+    int fsDefineCount;      // Number of fragment defines (ignored if fsDefines is NULL)
+
+    const char* userCode;   // Optional user code to inject (NULL if none)
+} shader_source_desc_t;
+
+// ========================================
 // INTERNAL FUNCTIONS
 // ========================================
 
-/**
- * Inject content into a string at a marker position
- * Returns newly allocated string with injected content
- * Or NULL on failure (caller must free the returned string)
- * source: Source string to modify
- * content: Content to inject
- * marker: String marker to find in source
- * mode: Injection mode: <0 = before marker, 0 = replace marker, >0 = after marker
+/*
+ * Returns the total allocation size required to build the vertex and fragment shader sources.
  */
-static char* inject_content(const char* source, const char* content, const char* marker, int mode);
-
-/**
- * Inject the provided list of definitions into the code
- * Returns newly allocated string with injected content
- * Or NULL on failure (caller must free the returned string)
- */
-static char* inject_defines(const char* code, const char* defines[], int count);
+static size_t shader_source_reserve(const shader_source_desc_t* desc);
 
 /*
- * Modifies each input stage by injecting user code if it contains the corresponding stages.
+ * Builds the vertex and fragment shader sources.
+ * May return the original template if no changes are needed, or NULL on failure.
  */
-static void inject_user_code(char** vsCode, char** fsCode, const char* userCode);
+static bool shader_source_build(const char** vsOut, const char** fsOut, r3d_stack_t** stack, const shader_source_desc_t* desc);
 
 /**
  * Initializes the sampler locations for the given shader program.
@@ -562,14 +585,18 @@ static bool load_prepare_smaa_edge_detection(r3d_shader_custom_t* custom, int in
     const char* VS_DEFINES[] = {defQualityPreset};
     const char* FS_DEFINES[] = {defQualityPreset};
 
-    char* vsCode = inject_defines(SMAA_EDGE_DETECTION_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(SMAA_EDGE_DETECTION_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
+    shader_source_desc_t desc = {
+        .vsTemplate = SMAA_EDGE_DETECTION_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = SMAA_EDGE_DETECTION_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+        .userCode = NULL,
+    };
 
     DECL_SHADER_INDEXED(r3d_shader_prepare_smaa_edge_detection_t, prepare, smaaEdgeDetection, index);
-    LOAD_SHADER(smaaEdgeDetection, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    LOAD_SHADER_EX(smaaEdgeDetection, desc);
 
     SET_UNIFORM_BUFFER(smaaEdgeDetection, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
@@ -607,14 +634,18 @@ static bool load_prepare_smaa_blending_weights(r3d_shader_custom_t* custom, int 
     const char* VS_DEFINES[] = {defQualityPreset};
     const char* FS_DEFINES[] = {defQualityPreset};
 
-    char* vsCode = inject_defines(SMAA_BLENDING_WEIGTHS_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(SMAA_BLENDING_WEIGTHS_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
+    shader_source_desc_t desc = {
+        .vsTemplate = SMAA_BLENDING_WEIGTHS_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = SMAA_BLENDING_WEIGTHS_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+        .userCode = NULL,
+    };
 
     DECL_SHADER_INDEXED(r3d_shader_prepare_smaa_blending_weights_t, prepare, smaaBlendingWeights, index);
-    LOAD_SHADER(smaaBlendingWeights, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    LOAD_SHADER_EX(smaaBlendingWeights, desc);
 
     SET_UNIFORM_BUFFER(smaaBlendingWeights, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
@@ -721,13 +752,21 @@ bool r3d_shader_load_prepare_cubemap_custom_sky(r3d_shader_custom_t* custom)
 {
     assert(custom != NULL);
 
+    if (strstr(custom->program->userCode, "void fragment()") == NULL) {
+        R3D_TRACELOG(LOG_WARNING, "Compiling a sky shader without 'fragment()' entry point");
+        return false;
+    }
+
+    shader_source_desc_t desc = {
+        .vsTemplate = CUBEMAP_VERT,
+        .fsTemplate = CUBEMAP_CUSTOM_SKY_FRAG,
+        .userCode = custom->program->userCode,
+    };
+
     r3d_shader_prepare_cubemap_custom_sky_t* cubemapCustomSky = &custom->program->prepare.cubemapCustomSky;
-    char* fragCode = inject_content(CUBEMAP_CUSTOM_SKY_FRAG, custom->program->userCode, "#define fragment()", 0);
-    LOAD_SHADER(cubemapCustomSky, CUBEMAP_VERT, fragCode);
-    MemFree(fragCode);
+    LOAD_SHADER_EX(cubemapCustomSky, desc);
 
     SET_UNIFORM_BUFFER(cubemapCustomSky, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
-
     if (strstr(custom->program->userCode, "UserBlock") != NULL) {
         SET_UNIFORM_BUFFER(cubemapCustomSky, UserBlock, R3D_SHADER_BLOCK_SLOT_USER);
     }
@@ -743,24 +782,23 @@ bool r3d_shader_load_prepare_cubemap_custom_sky(r3d_shader_custom_t* custom)
 
 bool r3d_shader_load_scene_geometry(r3d_shader_custom_t* custom)
 {
-    DECL_SHADER_SELECT(r3d_shader_scene_geometry_t, scene, geometry, custom);
-
     const char* VS_DEFINES[] = {"STAGE_VERT", "GEOMETRY"};
     const char* FS_DEFINES[] = {"STAGE_FRAG", "GEOMETRY"};
 
-    char* vsCode = inject_defines(SCENE_VERT,    VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(GEOMETRY_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
-
     const char* userCode = custom ? custom->program->userCode : NULL;
 
-    if (userCode != NULL) {
-        inject_user_code(&vsCode, &fsCode, userCode);
-    }
+    shader_source_desc_t desc = {
+        .vsTemplate = SCENE_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = GEOMETRY_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+        .userCode = userCode,
+    };
 
-    LOAD_SHADER(geometry, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    DECL_SHADER_SELECT(r3d_shader_scene_geometry_t, scene, geometry, custom);
+    LOAD_SHADER_EX(geometry, desc);
 
     SET_UNIFORM_BUFFER(geometry, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
     SET_UNIFORM_BUFFER(geometry, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
@@ -803,30 +841,29 @@ bool r3d_shader_load_scene_geometry(r3d_shader_custom_t* custom)
 
 bool r3d_shader_load_scene_forward(r3d_shader_custom_t* custom)
 {
-    DECL_SHADER_SELECT(r3d_shader_scene_forward_t, scene, forward, custom);
-
-    char defNumLightsForward[32] = {0};
+    char defNumLights[32] = {0};
     char defNumProbes[32] = {0};
 
-    r3d_string_format(defNumLightsForward, sizeof(defNumLightsForward), "MAX_LIGHTS_FORWARD %i", R3D_SHADER_LIGHT_FORWARD_UBO_CAP);
+    r3d_string_format(defNumLights, sizeof(defNumLights), "MAX_LIGHTS_FORWARD %i", R3D_SHADER_LIGHT_FORWARD_UBO_CAP);
     r3d_string_format(defNumProbes, sizeof(defNumProbes), "MAX_PROBES %i", R3D_SHADER_PROBE_UBO_CAP);
 
-    const char* VS_DEFINES[] = {"STAGE_VERT", "FORWARD", defNumLightsForward};
-    const char* FS_DEFINES[] = {"STAGE_FRAG", "FORWARD", defNumLightsForward, defNumProbes};
-
-    char* vsCode = inject_defines(SCENE_VERT,   VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(FORWARD_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
+    const char* VS_DEFINES[] = {"STAGE_VERT", "FORWARD", defNumLights};
+    const char* FS_DEFINES[] = {"STAGE_FRAG", "FORWARD", defNumLights, defNumProbes};
 
     const char* userCode = custom ? custom->program->userCode : NULL;
 
-    if (userCode != NULL) {
-        inject_user_code(&vsCode, &fsCode, userCode);
-    }
+    shader_source_desc_t desc = {
+        .vsTemplate = SCENE_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = FORWARD_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+        .userCode = userCode,
+    };
 
-    LOAD_SHADER(forward, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    DECL_SHADER_SELECT(r3d_shader_scene_forward_t, scene, forward, custom);
+    LOAD_SHADER_EX(forward, desc);
 
     SET_UNIFORM_BUFFER(forward, LightArrayBlock, R3D_SHADER_BLOCK_SLOT_LIGHT_ARRAY);
     SET_UNIFORM_BUFFER(forward, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
@@ -878,24 +915,23 @@ bool r3d_shader_load_scene_forward(r3d_shader_custom_t* custom)
 
 bool r3d_shader_load_scene_unlit(r3d_shader_custom_t *custom)
 {
-    DECL_SHADER_SELECT(r3d_shader_scene_unlit_t, scene, unlit, custom);
-
     const char* VS_DEFINES[] = {"STAGE_VERT", "UNLIT"};
     const char* FS_DEFINES[] = {"STAGE_FRAG", "UNLIT"};
 
-    char* vsCode = inject_defines(SCENE_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(UNLIT_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
-
     const char* userCode = custom ? custom->program->userCode : NULL;
 
-    if (userCode != NULL) {
-        inject_user_code(&vsCode, &fsCode, userCode);
-    }
+    shader_source_desc_t desc = {
+        .vsTemplate = SCENE_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = UNLIT_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+        .userCode = userCode,
+    };
 
-    LOAD_SHADER(unlit, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    DECL_SHADER_SELECT(r3d_shader_scene_unlit_t, scene, unlit, custom);
+    LOAD_SHADER_EX(unlit, desc);
 
     SET_UNIFORM_BUFFER(unlit, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
     SET_UNIFORM_BUFFER(unlit, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
@@ -956,24 +992,23 @@ bool r3d_shader_load_scene_skybox(r3d_shader_custom_t* custom)
 
 bool r3d_shader_load_scene_depth(r3d_shader_custom_t* custom)
 {
-    DECL_SHADER_SELECT(r3d_shader_scene_depth_t, scene, depth, custom);
-
     const char* VS_DEFINES[] = {"STAGE_VERT", "DEPTH"};
     const char* FS_DEFINES[] = {"STAGE_FRAG", "DEPTH"};
 
-    char* vsCode = inject_defines(SCENE_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(DEPTH_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
-
     const char* userCode = custom ? custom->program->userCode : NULL;
 
-    if (userCode != NULL) {
-        inject_user_code(&vsCode, &fsCode, userCode);
-    }
+    shader_source_desc_t desc = {
+        .vsTemplate = SCENE_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = DEPTH_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+        .userCode = userCode,
+    };
 
-    LOAD_SHADER(depth, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    DECL_SHADER_SELECT(r3d_shader_scene_depth_t, scene, depth, custom);
+    LOAD_SHADER_EX(depth, desc);
 
     SET_UNIFORM_BUFFER(depth, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
@@ -1006,24 +1041,23 @@ bool r3d_shader_load_scene_depth(r3d_shader_custom_t* custom)
 
 bool r3d_shader_load_scene_depth_cube(r3d_shader_custom_t* custom)
 {
-    DECL_SHADER_SELECT(r3d_shader_scene_depth_cube_t, scene, depthCube, custom);
-
     const char* VS_DEFINES[] = {"STAGE_VERT", "DEPTH_CUBE"};
     const char* FS_DEFINES[] = {"STAGE_FRAG", "DEPTH_CUBE"};
 
-    char* vsCode = inject_defines(SCENE_VERT,      VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(DEPTH_CUBE_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
-
     const char* userCode = custom ? custom->program->userCode : NULL;
 
-    if (userCode != NULL) {
-        inject_user_code(&vsCode, &fsCode, userCode);
-    }
+    shader_source_desc_t desc = {
+        .vsTemplate = SCENE_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = DEPTH_CUBE_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+        .userCode = userCode,
+    };
 
-    LOAD_SHADER(depthCube, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    DECL_SHADER_SELECT(r3d_shader_scene_depth_cube_t, scene, depthCube, custom);
+    LOAD_SHADER_EX(depthCube, desc);
 
     SET_UNIFORM_BUFFER(depthCube, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
@@ -1058,30 +1092,29 @@ bool r3d_shader_load_scene_depth_cube(r3d_shader_custom_t* custom)
 
 bool r3d_shader_load_scene_probe_forward(r3d_shader_custom_t* custom)
 {
-    DECL_SHADER_SELECT(r3d_shader_scene_probe_forward_t, scene, probeForward, custom);
-
-    char defNumLightsForward[32] = {0};
+    char defNumLights[32] = {0};
     char defNumProbes[32] = {0};
 
-    r3d_string_format(defNumLightsForward, sizeof(defNumLightsForward), "MAX_LIGHTS_FORWARD %i", R3D_SHADER_LIGHT_FORWARD_UBO_CAP);
+    r3d_string_format(defNumLights, sizeof(defNumLights), "MAX_LIGHTS_FORWARD %i", R3D_SHADER_LIGHT_FORWARD_UBO_CAP);
     r3d_string_format(defNumProbes, sizeof(defNumProbes), "MAX_PROBES %i", R3D_SHADER_PROBE_UBO_CAP);
 
-    const char* VS_DEFINES[] = {"STAGE_VERT", "PROBE", "PROBE_FORWARD", defNumLightsForward};
-    const char* FS_DEFINES[] = {"STAGE_FRAG", "PROBE", "PROBE_FORWARD", defNumLightsForward, defNumProbes};
-
-    char* vsCode = inject_defines(SCENE_VERT,   VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(FORWARD_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
+    const char* VS_DEFINES[] = {"STAGE_VERT", "PROBE", "PROBE_FORWARD", defNumLights};
+    const char* FS_DEFINES[] = {"STAGE_FRAG", "PROBE", "PROBE_FORWARD", defNumLights, defNumProbes};
 
     const char* userCode = custom ? custom->program->userCode : NULL;
 
-    if (userCode != NULL) {
-        inject_user_code(&vsCode, &fsCode, userCode);
-    }
+    shader_source_desc_t desc = {
+        .vsTemplate = SCENE_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = FORWARD_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+        .userCode = userCode,
+    };
 
-    LOAD_SHADER(probeForward, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    DECL_SHADER_SELECT(r3d_shader_scene_probe_forward_t, scene, probeForward, custom);
+    LOAD_SHADER_EX(probeForward, desc);
 
     SET_UNIFORM_BUFFER(probeForward, LightArrayBlock, R3D_SHADER_BLOCK_SLOT_LIGHT_ARRAY);
     SET_UNIFORM_BUFFER(probeForward, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
@@ -1137,24 +1170,23 @@ bool r3d_shader_load_scene_probe_forward(r3d_shader_custom_t* custom)
 
 bool r3d_shader_load_scene_probe_unlit(r3d_shader_custom_t *custom)
 {
-    DECL_SHADER_SELECT(r3d_shader_scene_probe_unlit_t, scene, probeUnlit, custom);
-
     const char* VS_DEFINES[] = {"STAGE_VERT", "PROBE", "PROBE_UNLIT"};
     const char* FS_DEFINES[] = {"STAGE_FRAG", "PROBE", "PROBE_UNLIT"};
 
-    char* vsCode = inject_defines(SCENE_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(UNLIT_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
-
     const char* userCode = custom ? custom->program->userCode : NULL;
 
-    if (userCode != NULL) {
-        inject_user_code(&vsCode, &fsCode, userCode);
-    }
+    shader_source_desc_t desc = {
+        .vsTemplate = SCENE_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = UNLIT_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+        .userCode = userCode,
+    };
 
-    LOAD_SHADER(probeUnlit, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    DECL_SHADER_SELECT(r3d_shader_scene_probe_unlit_t, scene, probeUnlit, custom);
+    LOAD_SHADER_EX(probeUnlit, desc);
 
     SET_UNIFORM_BUFFER(probeUnlit, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
     SET_UNIFORM_BUFFER(probeUnlit, FxBlock, R3D_SHADER_BLOCK_SLOT_FX);
@@ -1190,24 +1222,23 @@ bool r3d_shader_load_scene_probe_unlit(r3d_shader_custom_t *custom)
 
 bool r3d_shader_load_scene_decal(r3d_shader_custom_t* custom)
 {
-    DECL_SHADER_SELECT(r3d_shader_scene_decal_t, scene, decal, custom);
-
     const char* VS_DEFINES[] = {"STAGE_VERT", "DECAL"};
     const char* FS_DEFINES[] = {"STAGE_FRAG", "DECAL"};
 
-    char* vsCode = inject_defines(SCENE_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(DECAL_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
-
     const char* userCode = custom ? custom->program->userCode : NULL;
 
-    if (userCode != NULL) {
-        inject_user_code(&vsCode, &fsCode, userCode);
-    }
+    shader_source_desc_t desc = {
+        .vsTemplate = SCENE_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = DECAL_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+        .userCode = userCode,
+    };
 
-    LOAD_SHADER(decal, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    DECL_SHADER_SELECT(r3d_shader_scene_decal_t, scene, decal, custom);
+    LOAD_SHADER_EX(decal, desc);
 
     SET_UNIFORM_BUFFER(decal, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
     SET_UNIFORM_BUFFER(decal, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
@@ -1252,15 +1283,20 @@ bool r3d_shader_load_scene_decal(r3d_shader_custom_t* custom)
 
 bool r3d_shader_load_deferred_ambient(r3d_shader_custom_t* custom)
 {
-    DECL_SHADER(r3d_shader_deferred_ambient_t, deferred, ambient);
-
     char defNumProbes[32] = {0};
     r3d_string_format(defNumProbes, sizeof(defNumProbes), "MAX_PROBES %i", R3D_SHADER_PROBE_UBO_CAP);
 
     const char* FS_DEFINES[] = {defNumProbes};
-    char* fsCode = inject_defines(AMBIENT_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
-    LOAD_SHADER(ambient, SCREEN_VERT, fsCode);
-    MemFree(fsCode);
+
+    shader_source_desc_t desc = {
+        .vsTemplate = SCREEN_VERT,
+        .fsTemplate = AMBIENT_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+    };
+
+    DECL_SHADER(r3d_shader_deferred_ambient_t, deferred, ambient);
+    LOAD_SHADER_EX(ambient, desc);
 
     SET_UNIFORM_BUFFER(ambient, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
     SET_UNIFORM_BUFFER(ambient, EnvBlock, R3D_SHADER_BLOCK_SLOT_ENV);
@@ -1424,10 +1460,18 @@ bool r3d_shader_load_post_screen(r3d_shader_custom_t* custom)
 {
     assert(custom != NULL);
 
+    if (strstr(custom->program->userCode, "void fragment()") == NULL) {
+        R3D_TRACELOG(LOG_WARNING, "Compiling a screen shader without 'fragment()' entry point");
+    }
+
+    shader_source_desc_t desc = {
+        .vsTemplate = SCREEN_VERT,
+        .fsTemplate = SCREEN_FRAG,
+        .userCode = custom->program->userCode,
+    };
+
     r3d_shader_post_screen_t* screen = &custom->program->post.screen;
-    char* fragCode = inject_content(SCREEN_FRAG, custom->program->userCode, "#define fragment()", 0);
-    LOAD_SHADER(screen, SCREEN_VERT, fragCode);
-    MemFree(fragCode);
+    LOAD_SHADER_EX(screen, desc);
 
     SET_UNIFORM_BUFFER(screen, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
     SET_UNIFORM_BUFFER(screen, ViewBlock, R3D_SHADER_BLOCK_SLOT_VIEW);
@@ -1465,12 +1509,16 @@ static bool load_post_fxaa(r3d_shader_custom_t* custom, int index)
     r3d_string_format(defQualityPreset, sizeof(defQualityPreset), "QUALITY_PRESET %i", index);
 
     const char* FS_DEFINES[] = {defQualityPreset};
-    char* fsCode = inject_defines(FXAA_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
+
+    shader_source_desc_t desc = {
+        .vsTemplate = SCREEN_VERT,
+        .fsTemplate = FXAA_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+    };
 
     DECL_SHADER_INDEXED(r3d_shader_post_fxaa_t, post, fxaa, index);
-    LOAD_SHADER(fxaa, SCREEN_VERT, fsCode);
-
-    MemFree(fsCode);
+    LOAD_SHADER_EX(fxaa, desc);
 
     SET_UNIFORM_BUFFER(fxaa, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
@@ -1508,14 +1556,17 @@ static bool load_post_smaa(r3d_shader_custom_t* custom, int index)
     const char* VS_DEFINES[] = {defQualityPreset};
     const char* FS_DEFINES[] = {defQualityPreset};
 
-    char* vsCode = inject_defines(SMAA_VERT, VS_DEFINES, ARRAY_SIZE(VS_DEFINES));
-    char* fsCode = inject_defines(SMAA_FRAG, FS_DEFINES, ARRAY_SIZE(FS_DEFINES));
+    shader_source_desc_t desc = {
+        .vsTemplate = SMAA_VERT,
+        .vsDefines = VS_DEFINES,
+        .vsDefineCount = ARRAY_SIZE(VS_DEFINES),
+        .fsTemplate = SMAA_FRAG,
+        .fsDefines = FS_DEFINES,
+        .fsDefineCount = ARRAY_SIZE(FS_DEFINES),
+    };
 
     DECL_SHADER_INDEXED(r3d_shader_post_smaa_t, post, smaa, index);
-    LOAD_SHADER(smaa, vsCode, fsCode);
-
-    MemFree(vsCode);
-    MemFree(fsCode);
+    LOAD_SHADER_EX(smaa, desc);
 
     SET_UNIFORM_BUFFER(smaa, FrameBlock, R3D_SHADER_BLOCK_SLOT_FRAME);
 
@@ -1969,146 +2020,163 @@ void r3d_shader_invalidate_cache(void)
 // INTERNAL FUNCTIONS
 // ========================================
 
-char* inject_content(const char* source, const char* content, const char* marker, int mode)
+static size_t shader_inject_defines(char* dest, size_t destCap, const char* code, const char* defines[], int count)
 {
-    if (!source || !content || !marker) return NULL;
+    if (!code || count < 0) return 0;
 
-    // Find marker position
-    const char* markerPos = strstr(source, marker);
-    if (!markerPos) return NULL;
-
-    size_t markerLen = strlen(marker);
-    size_t contentLen = strlen(content);
-    size_t sourceLen = strlen(source);
-
-    // Calculate new string length
-    size_t prefixLen = markerPos - source;
-    size_t newLen;
-
-    if (mode == 0) {
-        // Replace mode: remove marker
-        newLen = sourceLen - markerLen + contentLen;
-    } else {
-        // Before/after mode: keep marker
-        newLen = sourceLen + contentLen;
-    }
-
-    // Allocate new string
-    char* result = MemAlloc(newLen + 1);
-    if (!result) return NULL;
-
-    char* ptr = result;
-
-    if (mode < 0) {
-        // Insert BEFORE marker: [prefix][content][marker][suffix]
-        memcpy(ptr, source, prefixLen);
-        ptr += prefixLen;
-
-        memcpy(ptr, content, contentLen);
-        ptr += contentLen;
-        
-        memcpy(ptr, markerPos, sourceLen - prefixLen);
-        ptr += sourceLen - prefixLen;
-    }
-    else if (mode == 0) {
-        // REPLACE marker: [prefix][content][suffix]
-        memcpy(ptr, source, prefixLen);
-        ptr += prefixLen;
-        
-        memcpy(ptr, content, contentLen);
-        ptr += contentLen;
-        
-        size_t suffixLen = sourceLen - prefixLen - markerLen;
-        memcpy(ptr, markerPos + markerLen, suffixLen);
-        ptr += suffixLen;
-    }
-    else {
-        // Insert AFTER marker: [prefix][marker][content][suffix]
-        size_t upToMarkerEnd = prefixLen + markerLen;
-        memcpy(ptr, source, upToMarkerEnd);
-        ptr += upToMarkerEnd;
-        
-        memcpy(ptr, content, contentLen);
-        ptr += contentLen;
-        
-        size_t suffixLen = sourceLen - upToMarkerEnd;
-        memcpy(ptr, markerPos + markerLen, suffixLen);
-        ptr += suffixLen;
-    }
-    
-    *ptr = '\0';
-    return result;
-}
-
-char* inject_defines(const char* code, const char* defines[], int count)
-{
-    if (!code || count < 0) return NULL;
-
-    // Find the end of the #version line
     const char* versionStart = strstr(code, "#version");
     assert(versionStart && "Shader must have version");
 
     const char* versionEnd = strchr(versionStart, '\n');
     if (!versionEnd) versionEnd = versionStart + strlen(versionStart);
-    else versionEnd++; // Include the \n
+    else versionEnd++;
 
-    // Calculate sizes
     static const char DEFINE_PREFIX[] = "#define ";
-    static const size_t DEFINE_PREFIX_LEN = sizeof(DEFINE_PREFIX) - 1; // -1 to exclude '\0'
-    
+    static const size_t DEFINE_PREFIX_LEN = sizeof(DEFINE_PREFIX) - 1;
+
     size_t prefixLen = versionEnd - code;
     size_t definesLen = 0;
     for (int i = 0; i < count; i++) {
-        if (defines[i]) {
-            definesLen += DEFINE_PREFIX_LEN + strlen(defines[i]) + 1; // +1 for \n
-        }
+        if (defines[i]) definesLen += DEFINE_PREFIX_LEN + strlen(defines[i]) + 1;
     }
     size_t suffixLen = strlen(versionEnd);
-    
-    // Allocate and build the new shader
-    char* newShader = (char*)MemAlloc(prefixLen + definesLen + suffixLen + 1);
-    if (!newShader) return NULL;
+    size_t newLen = prefixLen + definesLen + suffixLen;
 
-    char* dest = newShader;
-    
-    // Copy the part before defines (up to after #version)
-    memcpy(dest, code, prefixLen);
-    dest += prefixLen;
+    if (!dest) return newLen;
+    assert(destCap > newLen && "shader_inject_defines: destination buffer too small");
 
-    // Add the defines
+    char* d = dest;
+    memcpy(d, code, prefixLen); d += prefixLen;
+
     for (int i = 0; i < count; i++) {
         if (defines[i]) {
-            memcpy(dest, DEFINE_PREFIX, DEFINE_PREFIX_LEN);
-            dest += DEFINE_PREFIX_LEN;
-            
+            memcpy(d, DEFINE_PREFIX, DEFINE_PREFIX_LEN); d += DEFINE_PREFIX_LEN;
             size_t defineLen = strlen(defines[i]);
-            memcpy(dest, defines[i], defineLen);
-            dest += defineLen;
-            
-            *dest++ = '\n';
+            memcpy(d, defines[i], defineLen); d += defineLen;
+            *d++ = '\n';
         }
     }
 
-    // Copy the rest of the shader
-    memcpy(dest, versionEnd, suffixLen);
-    dest[suffixLen] = '\0';
+    memcpy(d, versionEnd, suffixLen); d += suffixLen;
+    *d = '\0';
 
-    return newShader;
+    return newLen;
 }
 
-void inject_user_code(char** vsCode, char** fsCode, const char* userCode)
+static size_t shader_inject_content(char* dest, size_t destCap, const char* source, const char* content, const char* marker, int mode)
 {
-    if (strstr(userCode, "void vertex()") != NULL) {
-        char* vsUser = inject_content(*vsCode, userCode, "#define vertex()", 0);
-        MemFree(*vsCode);
-        *vsCode = vsUser;
+    if (!source || !content || !marker) return 0;
+
+    const char* markerPos = strstr(source, marker);
+    if (!markerPos) return 0;
+
+    size_t markerLen = strlen(marker);
+    size_t contentLen = strlen(content);
+    size_t sourceLen = strlen(source);
+    size_t prefixLen = markerPos - source;
+
+    size_t newLen = (mode == 0)
+        ? sourceLen - markerLen + contentLen
+        : sourceLen + contentLen;
+
+    if (!dest) return newLen;
+    assert(destCap > newLen && "shader_inject_content: destination buffer too small");
+
+    char* ptr = dest;
+
+    if (mode < 0) {
+        // [prefix][content][marker][suffix]
+        memcpy(ptr, source, prefixLen); ptr += prefixLen;
+        memcpy(ptr, content, contentLen); ptr += contentLen;
+        memcpy(ptr, markerPos, sourceLen - prefixLen); ptr += sourceLen - prefixLen;
+    }
+    else if (mode == 0) {
+        // [prefix][content][suffix]
+        memcpy(ptr, source, prefixLen); ptr += prefixLen;
+        memcpy(ptr, content, contentLen); ptr += contentLen;
+        size_t suffixLen = sourceLen - prefixLen - markerLen;
+        memcpy(ptr, markerPos + markerLen, suffixLen); ptr += suffixLen;
+    }
+    else {
+        // [prefix][marker][content][suffix]
+        size_t upToMarkerEnd = prefixLen + markerLen;
+        memcpy(ptr, source, upToMarkerEnd); ptr += upToMarkerEnd;
+        memcpy(ptr, content, contentLen); ptr += contentLen;
+        size_t suffixLen = sourceLen - upToMarkerEnd;
+        memcpy(ptr, markerPos + markerLen, suffixLen); ptr += suffixLen;
     }
 
-    if (strstr(userCode, "void fragment()")) {
-        char* fsUser = inject_content(*fsCode, userCode, "#define fragment()", 0);
-        MemFree(*fsCode);
-        *fsCode = fsUser;
+    *ptr = '\0';
+    return newLen;
+}
+
+static inline bool shader_stage_needs_processing(const char* tmpl, const char** defines, int defineCount, const char* userCode, const char* funcSig)
+{
+    assert(tmpl && "shader stage template must not be NULL");
+    bool hasDefines = (defines && defineCount > 0);
+    bool hasUserFunc = (userCode && strstr(userCode, funcSig) != NULL);
+    return hasDefines || hasUserFunc;
+}
+
+static size_t shader_stage_reserve(const char* tmpl, const char** defines, int defineCount, const char* userCode, const char* funcSig)
+{
+    if (!shader_stage_needs_processing(tmpl, defines, defineCount, userCode, funcSig)) return 0;
+
+    size_t len = shader_inject_defines(NULL, 0, tmpl, defines, defines ? defineCount : 0);
+    size_t reserve = len + 1;
+
+    if (userCode && strstr(userCode, funcSig)) {
+        reserve += len + strlen(userCode) + 1; // worst case for replace-mode injection
     }
+
+    return reserve;
+}
+
+static const char* shader_stage_build(r3d_stack_t** stack, const char* tmpl, const char** defines, int defineCount, const char* userCode, const char* funcSig, const char* marker)
+{
+    if (!shader_stage_needs_processing(tmpl, defines, defineCount, userCode, funcSig)) return tmpl;
+
+    size_t len = shader_inject_defines(NULL, 0, tmpl, defines, defines ? defineCount : 0);
+    char* code = r3d_stack_alloc(stack, len + 1);
+    if (!code) return NULL;
+    shader_inject_defines(code, len + 1, tmpl, defines, defines ? defineCount : 0);
+
+    if (userCode && strstr(userCode, funcSig)) {
+        size_t userLen = shader_inject_content(NULL, 0, code, userCode, marker, 0);
+        if (userLen > 0) { // marker actually present in 'code'
+            char* buf = r3d_stack_alloc(stack, userLen + 1);
+            if (!buf) return NULL;
+            shader_inject_content(buf, userLen + 1, code, userCode, marker, 0);
+            code = buf;
+        }
+    }
+
+    return code;
+}
+
+size_t shader_source_reserve(const shader_source_desc_t* desc)
+{
+    return shader_stage_reserve(desc->vsTemplate, desc->vsDefines, desc->vsDefineCount, desc->userCode, "void vertex()")
+         + shader_stage_reserve(desc->fsTemplate, desc->fsDefines, desc->fsDefineCount, desc->userCode, "void fragment()");
+}
+
+bool shader_source_build(const char** vsOut, const char** fsOut, r3d_stack_t** stack, const shader_source_desc_t* desc)
+{
+    *vsOut = shader_stage_build(
+        stack, desc->vsTemplate,
+        desc->vsDefines, desc->vsDefineCount,
+        desc->userCode, "void vertex()", "#define vertex()"
+    );
+    if (*vsOut == NULL) return false;
+
+    *fsOut = shader_stage_build(
+        stack, desc->fsTemplate,
+        desc->fsDefines, desc->fsDefineCount,
+        desc->userCode, "void fragment()", "#define fragment()"
+    );
+    if (*fsOut == NULL) return false;
+
+    return true;
 }
 
 void set_custom_samplers(GLuint id, r3d_shader_custom_t* custom)

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -115,8 +115,8 @@ struct r3d_mod_shader R3D_MOD_SHADER;
 } while(0)
 
 #define LOAD_SHADER_EX(shader_name, desc) do {                                  \
-    bool ok = false;                                                            \
-    R3D_STACK_SCOPE(&R3D.stack, shader_source_reserve(&(desc))) {               \
+    bool ok;                                                                    \
+    R3D_STACK_SCOPE(&R3D.stack, shader_source_reserve(&(desc)), ok) {           \
         const char *vsCode = NULL, *fsCode = NULL;                              \
         if (!shader_source_build(&vsCode, &fsCode, &R3D.stack, &(desc))) {      \
             R3D_TRACELOG(LOG_ERROR, "Failed to build '" #shader_name "' shader sources"); \
@@ -127,7 +127,6 @@ struct r3d_mod_shader R3D_MOD_SHADER;
             R3D_TRACELOG(LOG_ERROR, "Failed to load shader '" #shader_name "'");\
             R3D_STACK_SCOPE_EXIT(R3D.stack);                                    \
         }                                                                       \
-        ok = true;                                                              \
     }                                                                           \
     if (!ok) return false;                                                      \
 } while(0)

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -19,6 +19,7 @@
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_env.h"
 #include "./r3d_core_state.h"
+#include "common/r3d_stack.h"
 
 // ========================================
 // CONSTANTS
@@ -160,6 +161,12 @@ bool R3D_Init(int resWidth, int resHeight)
         }
     }
 
+    R3D.stack = r3d_stack_create(4096);
+    if (R3D.stack == NULL) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to create internal stack allocator");
+        return false;
+    }
+
     if (!r3d_texture_init()) { R3D_TRACELOG(LOG_ERROR, "Failed to init texture module"); return false; }
     if (!r3d_target_init(resWidth, resHeight)) { R3D_TRACELOG(LOG_ERROR, "Failed to init target module"); return false; }
     if (!r3d_shader_init()) { R3D_TRACELOG(LOG_ERROR, "Failed to init shader module"); return false; }
@@ -177,6 +184,7 @@ bool R3D_Init(int resWidth, int resHeight)
 
 void R3D_Close(void)
 {
+    r3d_stack_destroy(R3D.stack);
     r3d_texture_quit();
     r3d_target_quit();
     r3d_shader_quit();

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -19,7 +19,6 @@
 #include "./modules/r3d_light.h"
 #include "./modules/r3d_env.h"
 #include "./r3d_core_state.h"
-#include "common/r3d_stack.h"
 
 // ========================================
 // CONSTANTS

--- a/src/r3d_core.c
+++ b/src/r3d_core.c
@@ -161,7 +161,7 @@ bool R3D_Init(int resWidth, int resHeight)
         }
     }
 
-    R3D.stack = r3d_stack_create(4096);
+    R3D.stack = r3d_stack_create(1024 * 1024);
     if (R3D.stack == NULL) {
         R3D_TRACELOG(LOG_ERROR, "Failed to create internal stack allocator");
         return false;

--- a/src/r3d_core_state.h
+++ b/src/r3d_core_state.h
@@ -18,6 +18,8 @@
 #include <r3d_config.h>
 #include <raylib.h>
 
+#include "./common/r3d_stack.h"
+
 // ========================================
 // HELPER MACROS
 // ========================================
@@ -71,6 +73,7 @@ extern struct r3d_core_state {
     R3D_ColorSpace colorSpace;          //< Color space that must be considered for supplied colors or surface colors
     Matrix matCubeViews[6];             //< Pre-computed view matrices for cubemap faces
     r3d_hint_t hints[R3D_HINT_COUNT];   //< User-configurable hints, resolved at R3D_Init()
+    r3d_stack_t* stack;                 //< Main thread stack allocator
     bool initialized;                   //< Indicates if R3D has been initialized successfully
 } R3D;
 

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -18,6 +18,7 @@
 #include "./r3d_core_state.h"
 
 #include "./common/r3d_helper.h"
+#include "./common/r3d_stack.h"
 #include "./common/r3d_pass.h"
 #include "./common/r3d_math.h"
 
@@ -303,8 +304,9 @@ void R3D_End(void)
     case R3D_OUTPUT_DOF: visualize_to_screen(R3D_TARGET_DOF_COC); break;
     }
 
-    /* --- Reset states changed by R3D --- */
+    /* --- Reset internal stuff and states changed by R3D --- */
 
+    r3d_stack_reset(R3D.stack);
     cleanup_after_render();
 }
 

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -1846,15 +1846,12 @@ void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType type)
     }
 
     size_t bufferSize = meshData->vertexCount * sizeof(Vector3);
+    bool ok;
 
-    R3D_STACK_SCOPE(&R3D.stack, bufferSize)
+    R3D_STACK_SCOPE(&R3D.stack, bufferSize, ok)
     {
         // Accumulate in float to avoid precision loss
         Vector3* normals = r3d_stack_alloc(&R3D.stack, bufferSize);
-        if (normals == NULL) {
-            R3D_TRACELOG(LOG_ERROR, "Failed to allocated temporary normal vertices buffer");
-            R3D_STACK_SCOPE_EXIT(R3D.stack);
-        }
         memset(normals, 0, bufferSize);
 
         int count = meshData->indexCount > 0 ? meshData->indexCount : meshData->vertexCount;
@@ -1894,6 +1891,10 @@ void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType type)
         for (int i = 0; i < meshData->vertexCount; i++) {
             R3D_PackNormal((int8_t*)meshData->vertices[i].normal, Vector3Normalize(normals[i]));
         }
+    }
+
+    if (!ok) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to allocate temporary vertex buffer to generate normals");
     }
 }
 
@@ -1953,22 +1954,14 @@ void R3D_GenMeshDataTangents(R3D_MeshData* meshData, R3D_PrimitiveType type)
     }
 
     size_t bufferSize = meshData->vertexCount * sizeof(Vector3);
+    bool ok;
 
-    R3D_STACK_SCOPE(&R3D.stack, 2 * bufferSize)
+    R3D_STACK_SCOPE(&R3D.stack, 2 * bufferSize, ok)
     {
         Vector3* tangents = r3d_stack_alloc(&R3D.stack, bufferSize);
-        if (tangents == NULL) {
-            R3D_TRACELOG(LOG_ERROR, "Failed to allocated temporary tangent vertices buffer");
-            R3D_STACK_SCOPE_EXIT(R3D.stack);
-        }
+        memset(tangents, 0, bufferSize);
 
         Vector3* bitangents = r3d_stack_alloc(&R3D.stack, bufferSize);
-        if (bitangents == NULL) {
-            R3D_TRACELOG(LOG_ERROR, "Failed to allocated temporary bitangent vertices buffer");
-            R3D_STACK_SCOPE_EXIT(R3D.stack);
-        }
-
-        memset(tangents, 0, bufferSize);
         memset(bitangents, 0, bufferSize);
 
         int count = meshData->indexCount > 0
@@ -2026,6 +2019,10 @@ void R3D_GenMeshDataTangents(R3D_MeshData* meshData, R3D_PrimitiveType type)
             float handedness = Vector3DotProduct(Vector3CrossProduct(n, t), bitangents[i]) < 0.0f ? -1.0f : 1.0f;
             R3D_PackTangent((int8_t*)meshData->vertices[i].tangent, (Vector4){t.x, t.y, t.z, handedness});
         }
+    }
+
+    if (!ok) {
+        R3D_TRACELOG(LOG_ERROR, "Failed to allocate temporary vertex buffer to generate tangents");
     }
 }
 

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -15,8 +15,6 @@
 
 #include "./common/r3d_math.h"
 #include "./r3d_core_state.h"
-#include "common/r3d_stack.h"
-#include "raylib.h"
 
 // ========================================
 // INTERNAL FUNCTIONS

--- a/src/r3d_mesh_data.c
+++ b/src/r3d_mesh_data.c
@@ -14,6 +14,9 @@
 #include <float.h>
 
 #include "./common/r3d_math.h"
+#include "./r3d_core_state.h"
+#include "common/r3d_stack.h"
+#include "raylib.h"
 
 // ========================================
 // INTERNAL FUNCTIONS
@@ -1842,49 +1845,56 @@ void R3D_GenMeshDataNormals(R3D_MeshData* meshData, R3D_PrimitiveType type)
         return;
     }
 
-    // Accumulate in float to avoid precision loss
-    Vector3* normals = MemAlloc(meshData->vertexCount * sizeof(Vector3));
-    if (normals == NULL) return;
+    size_t bufferSize = meshData->vertexCount * sizeof(Vector3);
 
-    int count = meshData->indexCount > 0 ? meshData->indexCount : meshData->vertexCount;
+    R3D_STACK_SCOPE(&R3D.stack, bufferSize)
+    {
+        // Accumulate in float to avoid precision loss
+        Vector3* normals = r3d_stack_alloc(&R3D.stack, bufferSize);
+        if (normals == NULL) {
+            R3D_TRACELOG(LOG_ERROR, "Failed to allocated temporary normal vertices buffer");
+            R3D_STACK_SCOPE_EXIT(R3D.stack);
+        }
+        memset(normals, 0, bufferSize);
 
-    switch (type) {
-    case R3D_PRIMITIVE_TRIANGLES:
-        for (int i = 0; i + 2 < count; i += 3) {
-            accumulate_face_normal(normals, meshData,
-                get_index(meshData, i),
-                get_index(meshData, i + 1),
-                get_index(meshData, i + 2)
-            );
+        int count = meshData->indexCount > 0 ? meshData->indexCount : meshData->vertexCount;
+
+        switch (type) {
+        case R3D_PRIMITIVE_TRIANGLES:
+            for (int i = 0; i + 2 < count; i += 3) {
+                accumulate_face_normal(normals, meshData,
+                    get_index(meshData, i),
+                    get_index(meshData, i + 1),
+                    get_index(meshData, i + 2)
+                );
+            }
+            break;
+        case R3D_PRIMITIVE_TRIANGLE_STRIP:
+            for (int i = 0; i + 2 < count; i++) {
+                uint32_t i0 = get_index(meshData, i % 2 == 0 ? i     : i + 1);
+                uint32_t i1 = get_index(meshData, i % 2 == 0 ? i + 1 : i    );
+                uint32_t i2 = get_index(meshData, i + 2);
+                accumulate_face_normal(normals, meshData, i0, i1, i2);
+            }
+            break;
+        case R3D_PRIMITIVE_TRIANGLE_FAN: {
+            uint32_t center = get_index(meshData, 0);
+            for (int i = 1; i + 1 < count; i++) {
+                accumulate_face_normal(normals, meshData,
+                    center,
+                    get_index(meshData, i),
+                    get_index(meshData, i + 1)
+                );
+            }
+        } break;
+        default:
+            break;
         }
-        break;
-    case R3D_PRIMITIVE_TRIANGLE_STRIP:
-        for (int i = 0; i + 2 < count; i++) {
-            uint32_t i0 = get_index(meshData, i % 2 == 0 ? i     : i + 1);
-            uint32_t i1 = get_index(meshData, i % 2 == 0 ? i + 1 : i    );
-            uint32_t i2 = get_index(meshData, i + 2);
-            accumulate_face_normal(normals, meshData, i0, i1, i2);
+
+        for (int i = 0; i < meshData->vertexCount; i++) {
+            R3D_PackNormal((int8_t*)meshData->vertices[i].normal, Vector3Normalize(normals[i]));
         }
-        break;
-    case R3D_PRIMITIVE_TRIANGLE_FAN: {
-        uint32_t center = get_index(meshData, 0);
-        for (int i = 1; i + 1 < count; i++) {
-            accumulate_face_normal(normals, meshData,
-                center,
-                get_index(meshData, i),
-                get_index(meshData, i + 1)
-            );
-        }
-    } break;
-    default:
-        break;
     }
-
-    for (int i = 0; i < meshData->vertexCount; i++) {
-        R3D_PackNormal((int8_t*)meshData->vertices[i].normal, Vector3Normalize(normals[i]));
-    }
-
-    MemFree(normals);
 }
 
 static void process_triangle_tangents(Vector3* tangents, Vector3* bitangents, R3D_MeshData* meshData, uint32_t i0, uint32_t i1, uint32_t i2)
@@ -1942,72 +1952,81 @@ void R3D_GenMeshDataTangents(R3D_MeshData* meshData, R3D_PrimitiveType type)
         return;
     }
 
-    Vector3* tangents = MemAlloc(meshData->vertexCount * sizeof(Vector3));
-    Vector3* bitangents = MemAlloc(meshData->vertexCount * sizeof(Vector3));
-    if (tangents == NULL || bitangents == NULL) {
-        R3D_TRACELOG(LOG_ERROR, "Failed to allocate memory for tangent calculation");
-        MemFree(tangents);
-        MemFree(bitangents);
-        return;
-    }
+    size_t bufferSize = meshData->vertexCount * sizeof(Vector3);
 
-    int count = meshData->indexCount > 0 ? meshData->indexCount : meshData->vertexCount;
-
-    switch (type) {
-    case R3D_PRIMITIVE_TRIANGLES:
-        for (int i = 0; i + 2 < count; i += 3) {
-            process_triangle_tangents(tangents, bitangents, meshData,
-                get_index(meshData, i),
-                get_index(meshData, i + 1),
-                get_index(meshData, i + 2)
-            );
-        }
-        break;
-    case R3D_PRIMITIVE_TRIANGLE_STRIP:
-        for (int i = 0; i + 2 < count; i++) {
-            uint32_t i0 = get_index(meshData, i % 2 == 0 ? i     : i + 1);
-            uint32_t i1 = get_index(meshData, i % 2 == 0 ? i + 1 : i    );
-            uint32_t i2 = get_index(meshData, i + 2);
-            process_triangle_tangents(tangents, bitangents, meshData, i0, i1, i2);
-        }
-        break;
-    case R3D_PRIMITIVE_TRIANGLE_FAN: {
-        uint32_t center = get_index(meshData, 0);
-        for (int i = 1; i + 1 < count; i++) {
-            process_triangle_tangents(tangents, bitangents, meshData,
-                center,
-                get_index(meshData, i),
-                get_index(meshData, i + 1)
-            );
-        }
-    } break;
-    default:
-        break;
-    }
-
-    // Orthogonalization (Gram-Schmidt) and handedness calculation
-    for (int i = 0; i < meshData->vertexCount; i++)
+    R3D_STACK_SCOPE(&R3D.stack, 2 * bufferSize)
     {
-        Vector3 n = R3D_UnpackNormal((int8_t*)meshData->vertices[i].normal);
-        Vector3 t = tangents[i];
-
-        // Gram-Schmidt orthogonalization
-        t = Vector3Subtract(t, Vector3Scale(n, Vector3DotProduct(n, t)));
-        float tLength = Vector3Length(t);
-        if (tLength > 1e-6f) {
-            t = Vector3Scale(t, 1.0f / tLength);
-        } else {
-            // Fallback: generate an arbitrary tangent perpendicular to the normal
-            t = fabsf(n.x) < 0.9f ? (Vector3){1.0f, 0.0f, 0.0f} : (Vector3){0.0f, 1.0f, 0.0f};
-            t = Vector3Normalize(Vector3Subtract(t, Vector3Scale(n, Vector3DotProduct(n, t))));
+        Vector3* tangents = r3d_stack_alloc(&R3D.stack, bufferSize);
+        if (tangents == NULL) {
+            R3D_TRACELOG(LOG_ERROR, "Failed to allocated temporary tangent vertices buffer");
+            R3D_STACK_SCOPE_EXIT(R3D.stack);
         }
 
-        float handedness = Vector3DotProduct(Vector3CrossProduct(n, t), bitangents[i]) < 0.0f ? -1.0f : 1.0f;
-        R3D_PackTangent((int8_t*)meshData->vertices[i].tangent, (Vector4){t.x, t.y, t.z, handedness});
-    }
+        Vector3* bitangents = r3d_stack_alloc(&R3D.stack, bufferSize);
+        if (bitangents == NULL) {
+            R3D_TRACELOG(LOG_ERROR, "Failed to allocated temporary bitangent vertices buffer");
+            R3D_STACK_SCOPE_EXIT(R3D.stack);
+        }
 
-    MemFree(tangents);
-    MemFree(bitangents);
+        memset(tangents, 0, bufferSize);
+        memset(bitangents, 0, bufferSize);
+
+        int count = meshData->indexCount > 0
+            ? meshData->indexCount : meshData->vertexCount;
+
+        switch (type) {
+        case R3D_PRIMITIVE_TRIANGLES:
+            for (int i = 0; i + 2 < count; i += 3) {
+                process_triangle_tangents(tangents, bitangents, meshData,
+                    get_index(meshData, i),
+                    get_index(meshData, i + 1),
+                    get_index(meshData, i + 2)
+                );
+            }
+            break;
+        case R3D_PRIMITIVE_TRIANGLE_STRIP:
+            for (int i = 0; i + 2 < count; i++) {
+                uint32_t i0 = get_index(meshData, i % 2 == 0 ? i     : i + 1);
+                uint32_t i1 = get_index(meshData, i % 2 == 0 ? i + 1 : i    );
+                uint32_t i2 = get_index(meshData, i + 2);
+                process_triangle_tangents(tangents, bitangents, meshData, i0, i1, i2);
+            }
+            break;
+        case R3D_PRIMITIVE_TRIANGLE_FAN: {
+            uint32_t center = get_index(meshData, 0);
+            for (int i = 1; i + 1 < count; i++) {
+                process_triangle_tangents(tangents, bitangents, meshData,
+                    center,
+                    get_index(meshData, i),
+                    get_index(meshData, i + 1)
+                );
+            }
+        } break;
+        default:
+            break;
+        }
+
+        // Orthogonalization (Gram-Schmidt) and handedness calculation
+        for (int i = 0; i < meshData->vertexCount; i++)
+        {
+            Vector3 n = R3D_UnpackNormal((int8_t*)meshData->vertices[i].normal);
+            Vector3 t = tangents[i];
+
+            // Gram-Schmidt orthogonalization
+            t = Vector3Subtract(t, Vector3Scale(n, Vector3DotProduct(n, t)));
+            float tLength = Vector3Length(t);
+            if (tLength > 1e-6f) {
+                t = Vector3Scale(t, 1.0f / tLength);
+            } else {
+                // Fallback: generate an arbitrary tangent perpendicular to the normal
+                t = fabsf(n.x) < 0.9f ? (Vector3){1.0f, 0.0f, 0.0f} : (Vector3){0.0f, 1.0f, 0.0f};
+                t = Vector3Normalize(Vector3Subtract(t, Vector3Scale(n, Vector3DotProduct(n, t))));
+            }
+
+            float handedness = Vector3DotProduct(Vector3CrossProduct(n, t), bitangents[i]) < 0.0f ? -1.0f : 1.0f;
+            R3D_PackTangent((int8_t*)meshData->vertices[i].tangent, (Vector4){t.x, t.y, t.z, handedness});
+        }
+    }
 }
 
 BoundingBox R3D_CalculateMeshDataBoundingBox(R3D_MeshData meshData)


### PR DESCRIPTION
Added an internal temporary allocator used for shader source processing, textures loading from models/materials, and mesh normal/tangent generation for meshes.

The initial capacity at startup is 1 MB.