### PR TITLE
Adopt Filament PBR functions

### DIFF
--- a/shaders/deferred/ambient.frag
+++ b/shaders/deferred/ambient.frag
@@ -54,7 +54,7 @@ struct UpsampleWeights {
     float invWSum;
 };
 
-UpsampleWeights ComputeUpsampleWeights(float refDepth, float NdotV)
+UpsampleWeights ComputeUpsampleWeights(float refDepth, float NoV)
 {
     ivec2 depthRes = textureSize(uDepthTex, 1);
     ivec2 maxCoord = depthRes - ivec2(1);
@@ -85,7 +85,7 @@ UpsampleWeights ComputeUpsampleWeights(float refDepth, float NdotV)
 
     const float kMinNdotV = 0.05;
     const float kDepthEdgeToleranceMeters = 0.05;
-    float depthSharpness = max(NdotV, kMinNdotV) / kDepthEdgeToleranceMeters; // = 1.0 / (t / max(NdotV, min))
+    float depthSharpness = max(NoV, kMinNdotV) / kDepthEdgeToleranceMeters; // = 1.0 / (t / max(NoV, min))
 
     w *= exp(-abs(d - vec4(refDepth)) * depthSharpness);
 
@@ -122,15 +122,15 @@ void main()
     vec3 P = V_GetWorldPosition(vTexCoord, depth);
     vec3 N = V_GetWorldNormal(uNormalTex, pixCoord);
     vec3 V = normalize(uView.position - P);
-    float NdotV = max(dot(N, V), 0.0);
+    float NoV = max(dot(N, V), 0.0);
 
-    vec3 F0 = PBR_ComputeF0(orm.z, orm.w, albedo);
+    vec3 F0 = PBR_F0(orm.z, orm.w, albedo);
     vec3 kD = albedo * (1.0 - orm.z);
 
     vec4 io = vec4(0.0, 0.0, 0.0, 1.0);
     if (uSsil.enabled || uSsao.enabled || uSsgi.enabled)
     {
-        UpsampleWeights uw = ComputeUpsampleWeights(depth, NdotV);
+        UpsampleWeights uw = ComputeUpsampleWeights(depth, NoV);
         if (uSsil.enabled) {
             io = Upsample(uSsilTex, uw);
             io.rgb *= uSsil.giIntensity;
@@ -150,7 +150,7 @@ void main()
 
     vec3 diff = vec3(0.0);
     vec3 spec = vec3(0.0);
-    E_ComputeAmbientAndProbes(diff, spec, kD, orm.rgb, F0, P, N, V, NdotV);
+    E_ComputeAmbientAndProbes(diff, spec, kD, orm.rgb, F0, P, N, V, NoV);
 
     FragDiffuse = vec4(diff + io.rgb, 1.0);
     FragSpecular = vec4(spec, 1.0);

--- a/shaders/deferred/compose.frag
+++ b/shaders/deferred/compose.frag
@@ -44,7 +44,7 @@ void main()
     vec4 orm = texelFetch(uOrmTex, ivec2(gl_FragCoord).xy, 0);
     vec4 ssr = textureLod(uSsrTex, vTexCoord, orm.y * uSsrNumLevels);
 
-    vec3 F0 = PBR_ComputeF0(orm.z, orm.w, albedo);
+    vec3 F0 = PBR_F0(orm.z, orm.w, albedo);
     vec3 kS_approx = F0 * (1.0 - orm.y * 0.5);
 
     FragColor = diffuse + mix(specular, kS_approx * ssr.rgb, ssr.a);

--- a/shaders/deferred/lighting.frag
+++ b/shaders/deferred/lighting.frag
@@ -60,9 +60,9 @@ void main()
     float Ldist = length(Ldelta);
 
     vec3 L = (uLight.type == LIGHT_DIR) ? -uLight.direction : Ldelta / max(Ldist, 1e-4);
-    float NdotL = dot(N, L);
+    float NoL = dot(N, L);
 
-    if (NdotL <= 0.0) {
+    if (NoL <= 0.0) {
         FragDiff = vec4(0.0);
         FragSpec = vec4(0.0);
         return;
@@ -76,14 +76,14 @@ void main()
     /* Compute view direction and the dot product of the normal and view direction */
 
     vec3 V = normalize(uView.position - P);
-    float NdotV = max(dot(N, V), 1e-4);
+    float NoV = max(dot(N, V), 1e-4);
 
     /* Compute the halfway vector between the view and light directions */
 
     vec3 H = normalize(V + L);
 
-    float LdotH = max(dot(L, H), 0.0);
-    float NdotH = max(dot(N, H), 0.0);
+    float LoH = max(dot(L, H), 0.0);
+    float NoH = max(dot(N, H), 0.0);
 
     /* Compute light color energy */
 
@@ -91,13 +91,13 @@ void main()
 
     /* Compute diffuse lighting */
 
-    vec3 diff = L_Diffuse(LdotH, NdotV, NdotL, orm.g);
+    vec3 diff = L_Diffuse(orm.g, NoV, NoL, LoH);
     diff *= albedo * lightColE * (1.0 - orm.b);
 
     /* Compute specular lighting */
 
-    vec3 F0 = PBR_ComputeF0(orm.b, orm.w, albedo);
-    vec3 spec = L_Specular(F0, LdotH, NdotH, NdotV, NdotL, orm.g);
+    vec3 F0 = PBR_F0(orm.b, orm.w, albedo);
+    vec3 spec = L_Specular(F0, orm.g, NoV, NoL, NoH, LoH);
     spec *= lightColE * uLight.specular;
 
     /* Compute shadow factor */
@@ -118,9 +118,9 @@ void main()
     if (uLight.shadowLayer >= 0 && uLight.shadowOpacity != 0.0 && shadow > 1e-4) {
         mat2 diskRot = L_ShadowDebandingMatrix(gl_FragCoord.xy);
         switch (uLight.type) {
-        case LIGHT_DIR:  shadow *= L_SampleShadowDir(uLight, P, depth, NdotL, diskRot); break;
-        case LIGHT_SPOT: shadow *= L_SampleShadowSpot(uLight, P, NdotL, diskRot); break;
-        case LIGHT_OMNI: shadow *= L_SampleShadowOmni(uLight, P, NdotL, diskRot); break;
+        case LIGHT_DIR:  shadow *= L_SampleShadowDir(uLight, P, depth, NoL, diskRot); break;
+        case LIGHT_SPOT: shadow *= L_SampleShadowSpot(uLight, P, NoL, diskRot); break;
+        case LIGHT_OMNI: shadow *= L_SampleShadowOmni(uLight, P, NoL, diskRot); break;
         }
     }
 

--- a/shaders/include/lib/ibl.glsl
+++ b/shaders/include/lib/ibl.glsl
@@ -6,10 +6,10 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-float IBL_GetSpecularOcclusion(float NdotV, float ao, float roughness)
+float IBL_GetSpecularOcclusion(float NoV, float ao, float roughness)
 {
     // Lagarde method: https://seblagarde.wordpress.com/wp-content/uploads/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf
-    return clamp(pow(NdotV + ao, exp2(-16.0 * roughness - 1.0)) - 1.0 + ao, 0.0, 1.0);
+    return clamp(pow(NoV + ao, exp2(-16.0 * roughness - 1.0)) - 1.0 + ao, 0.0, 1.0);
 }
 
 vec3 IBL_SampleIrradiance(samplerCubeArray irradiance, int index, vec3 N)
@@ -34,7 +34,7 @@ vec3 IBL_SamplePrefilter(samplerCubeArray prefilter, int index, vec3 V, vec3 N, 
     return textureLod(prefilter, vec4(M_Rotate3D(reflect(-V, N), rotation), float(index)), mipLevel).rgb;
 }
 
-void IBL_MultiScattering(inout vec3 irradiance, inout vec3 radiance, vec3 diffuse, vec3 F0, vec2 brdf, float NdotV, float roughness)
+void IBL_MultiScattering(inout vec3 irradiance, inout vec3 radiance, vec3 diffuse, vec3 F0, vec2 brdf, float NoV, float roughness)
 {
     // Adapted from Fdez-Aguera method without the roughness-dependent Fresnel
     // See: https://jcgt.org/published/0008/01/03/paper.pdf

--- a/shaders/include/lib/math.glsl
+++ b/shaders/include/lib/math.glsl
@@ -18,6 +18,12 @@
 
 /* === Functions === */
 
+float M_Pow5(float x)
+{
+	float x2 = x * x;
+	return x2 * x2 * x;
+}
+
 vec3 M_Rotate3D(vec3 v, vec4 q)
 {
     vec3 t = 2.0 * cross(q.xyz, v);

--- a/shaders/include/lib/pbr.glsl
+++ b/shaders/include/lib/pbr.glsl
@@ -10,31 +10,48 @@
 
 /* === Functions === */
 
-float PBR_DistributionGGX(float cosTheta, float alpha)
+float PBR_D_GGX(float NoH, float roughness)
 {
-    // Standard GGX/Trowbridge-Reitz distribution - optimized form
-
-    float a = cosTheta * alpha;
-    float k = alpha / (1.0 - cosTheta * cosTheta + a * a);
-    return k * k * (1.0 / M_PI);
+	float a2 = roughness * roughness;
+	float f  = (NoH * a2 - NoH) * NoH + 1.0;
+	return a2 / (M_PI * f * f);
 }
 
-float PBR_GeometryGGX(float NdotL, float NdotV, float roughness)
+float PBR_V_SmithGGXCorrelated(float NoV, float NoL, float roughness)
 {
-    // Hammon's optimized approximation for GGX Smith geometry term
-    // SEE: https://www.gdcvault.com/play/1024478/PBR-Diffuse-Lighting-for-GGX
-
-    return 0.5 / mix(2.0 * NdotL * NdotV, NdotL + NdotV, roughness);
+	float a2   = roughness * roughness;
+	float GGXV = NoL * sqrt(NoV * NoV * (1.0 - a2) + a2);
+	float GGXL = NoV * sqrt(NoL * NoL * (1.0 - a2) + a2);
+	return 0.5 / max(GGXV + GGXL, 1e-5);
 }
 
-float PBR_SchlickFresnel(float u)
+vec3 PBR_F_Schlick(const vec3 f0, float f90, float VoH)
 {
-    float m = 1.0 - u;
-    float m2 = m * m;
-    return m2 * m2 * m; // pow(m,5)
+	// Schlick 1994, "An Inexpensive BRDF Model for Physically-Based Rendering"
+	return f0 + (f90 - f0) * M_Pow5(1.0 - VoH);
 }
 
-vec3 PBR_ComputeF0(float metallic, float specular, vec3 albedo)
+vec3 PBR_F_Schlick(const vec3 f0, float VoH)
+{
+	float f = M_Pow5(1.0 - VoH);
+	return f + f0 * (1.0 - f);
+}
+
+float PBR_F_Schlick(float f0, float f90, float VoH)
+{
+	return f0 + (f90 - f0) * M_Pow5(1.0 - VoH);
+}
+
+float PBR_Fd_Burley(float roughness, float NoV, float NoL, float LoH)
+{
+	// Burley 2012, "Physically-Based Shading at Disney"
+	float f90 = 0.5 + 2.0 * roughness * LoH * LoH;
+	float lightScatter = PBR_F_Schlick(1.0, f90, NoL);
+	float viewScatter  = PBR_F_Schlick(1.0, f90, NoV);
+	return lightScatter * viewScatter * (1.0 / M_PI);
+}
+
+vec3 PBR_F0(float metallic, float specular, vec3 albedo)
 {
     // use (albedo * metallic) as colored specular reflectance at 0 angle for metallic materials
     // SEE: https://google.github.io/filament/Filament.md.html

--- a/shaders/include/wrap/env.glsl
+++ b/shaders/include/wrap/env.glsl
@@ -30,7 +30,7 @@ void E_SampleProbe(inout vec3 irr, inout vec3 rad, inout float wIrr, inout float
     }
 }
 
-void E_ComputeAmbientAndProbes(inout vec3 diffuse, inout vec3 specular, vec3 kD, vec3 orm, vec3 F0, vec3 P, vec3 N, vec3 V, float NdotV)
+void E_ComputeAmbientAndProbes(inout vec3 diffuse, inout vec3 specular, vec3 kD, vec3 orm, vec3 F0, vec3 P, vec3 N, vec3 V, float NoV)
 {
     float occlusion = orm.x;
     float roughness = orm.y;
@@ -71,16 +71,16 @@ void E_ComputeAmbientAndProbes(inout vec3 diffuse, inout vec3 specular, vec3 kD,
     }
 
     irradiance *= occlusion * uAmbient.energy;
-    radiance *= IBL_GetSpecularOcclusion(NdotV, occlusion, roughness);
+    radiance *= IBL_GetSpecularOcclusion(NoV, occlusion, roughness);
 
-    vec2 brdf = texture(uBrdfLutTex, vec2(NdotV, roughness)).xy;
-    IBL_MultiScattering(irradiance, radiance, kD, F0, brdf, NdotV, roughness);
+    vec2 brdf = texture(uBrdfLutTex, vec2(NoV, roughness)).xy;
+    IBL_MultiScattering(irradiance, radiance, kD, F0, brdf, NoV, roughness);
 
     diffuse += irradiance;
     specular += radiance;
 }
 
-void E_ComputeAmbientOnly(inout vec3 diffuse, inout vec3 specular, vec3 kD, vec3 orm, vec3 F0, vec3 P, vec3 N, vec3 V, float NdotV)
+void E_ComputeAmbientOnly(inout vec3 diffuse, inout vec3 specular, vec3 kD, vec3 orm, vec3 F0, vec3 P, vec3 N, vec3 V, float NoV)
 {
     float occlusion = orm.x;
     float roughness = orm.y;
@@ -94,11 +94,11 @@ void E_ComputeAmbientOnly(inout vec3 diffuse, inout vec3 specular, vec3 kD, vec3
     vec3 radiance = vec3(0.0);
     if (uAmbient.prefilter >= 0) {
         radiance = IBL_SamplePrefilter(uPrefilterTex, uAmbient.prefilter, V, N, uAmbient.rotation, roughness, uNumPrefilterLevels).rgb;
-        radiance *= IBL_GetSpecularOcclusion(NdotV, occlusion, roughness);
+        radiance *= IBL_GetSpecularOcclusion(NoV, occlusion, roughness);
     }
 
-    vec2 brdf = texture(uBrdfLutTex, vec2(NdotV, roughness)).xy;
-    IBL_MultiScattering(irradiance, radiance, kD, F0, brdf, NdotV, roughness);
+    vec2 brdf = texture(uBrdfLutTex, vec2(NoV, roughness)).xy;
+    IBL_MultiScattering(irradiance, radiance, kD, F0, brdf, NoV, roughness);
 
     diffuse += irradiance;
     specular += radiance;

--- a/shaders/include/wrap/light.glsl
+++ b/shaders/include/wrap/light.glsl
@@ -11,28 +11,18 @@
 
 /* === Lighting === */
 
-vec3 L_Diffuse(float LdotH, float NdotV, float NdotL, float roughness)
+vec3 L_Diffuse(float roughness, float NoV, float NoL, float LoH)
 {
-    float FD90_minus_1 = 2.0 * LdotH * LdotH * roughness - 0.5;
-    float FdV = 1.0 + FD90_minus_1 * PBR_SchlickFresnel(NdotV);
-    float FdL = 1.0 + FD90_minus_1 * PBR_SchlickFresnel(NdotL);
-
-    return vec3(M_INV_PI * (FdV * FdL * NdotL)); // Diffuse BRDF (Burley)
+    return vec3(PBR_Fd_Burley(roughness, NoV, NoL, LoH) * NoL);
 }
 
-vec3 L_Specular(vec3 F0, float LdotH, float cNdotH, float NdotV, float NdotL, float roughness)
+vec3 L_Specular(vec3 F0, float roughness, float NoV, float NoL, float NoH, float LoH)
 {
-    roughness = max(roughness, 0.02); // 'roughness > 0.01' to avoid FP16 overflow after GGX distribution
+	float D = PBR_D_GGX(NoH, roughness);
+	float V = PBR_V_SmithGGXCorrelated(NoV, NoL, roughness);
+	vec3  F = PBR_F_Schlick(F0, LoH);
 
-    float alphaGGX = roughness * roughness;
-    float D = PBR_DistributionGGX(cNdotH, alphaGGX);
-    float G = PBR_GeometryGGX(NdotL, NdotV, alphaGGX);
-
-    float cLdotH5 = PBR_SchlickFresnel(LdotH);
-    float F90 = clamp(50.0 * F0.g, 0.0, 1.0);
-    vec3 F = F0 + (F90 - F0) * cLdotH5;
-
-    return NdotL * D * F * G; // Specular BRDF (Schlick GGX)
+	return (D * V) * F * NoL;
 }
 
 /* === Shadows === */
@@ -57,11 +47,11 @@ mat2 L_ShadowDebandingMatrix(vec2 fragCoord)
     return mat2(vec2(cr, -sr), vec2(sr, cr));
 }
 
-float L_SampleShadowDir(Light light, vec3 Pws, float Zvs, float NdotL, mat2 diskRot)
+float L_SampleShadowDir(Light light, vec3 Pws, float Zvs, float NoL, mat2 diskRot)
 {
     vec4 Pls = light.viewProj * vec4(Pws, 1.0);
     vec3 projCoords = Pls.xyz / Pls.w * 0.5 + 0.5;
-    float bias = light.shadowDepthBias + light.shadowSlopeBias * (1.0 - NdotL);
+    float bias = light.shadowDepthBias + light.shadowSlopeBias * (1.0 - NoL);
     float compareDepth = projCoords.z - bias;
 
     float shadow = 0.0;
@@ -78,11 +68,11 @@ float L_SampleShadowDir(Light light, vec3 Pws, float Zvs, float NdotL, mat2 disk
     return mix(1.0, shadow, edgeFade * distFade * light.shadowOpacity);
 }
 
-float L_SampleShadowSpot(Light light, vec3 Pws, float NdotL, mat2 diskRot)
+float L_SampleShadowSpot(Light light, vec3 Pws, float NoL, mat2 diskRot)
 {
     vec4 Pls = light.viewProj * vec4(Pws, 1.0);
     vec3 projCoords = Pls.xyz / Pls.w * 0.5 + 0.5;
-    float bias = light.shadowDepthBias + light.shadowSlopeBias * (1.0 - NdotL);
+    float bias = light.shadowDepthBias + light.shadowSlopeBias * (1.0 - NoL);
     float compareDepth = projCoords.z - bias;
 
     float shadow = 0.0;
@@ -95,12 +85,12 @@ float L_SampleShadowSpot(Light light, vec3 Pws, float NdotL, mat2 diskRot)
     return mix(1.0, shadow, light.shadowOpacity);
 }
 
-float L_SampleShadowOmni(Light light, vec3 Pws, float NdotL, mat2 diskRot)
+float L_SampleShadowOmni(Light light, vec3 Pws, float NoL, mat2 diskRot)
 {
     vec3 lightToFrag = Pws - light.position;
     float currentDepth = length(lightToFrag);
 
-    float bias = light.shadowDepthBias + light.shadowSlopeBias * (1.0 - NdotL);
+    float bias = light.shadowDepthBias + light.shadowSlopeBias * (1.0 - NoL);
     float compareDepth = (currentDepth - bias) / light.far;
 
     mat3 OBN = M_OrthonormalBasis(lightToFrag / currentDepth);

--- a/shaders/prepare/cubemap_prefilter.frag
+++ b/shaders/prepare/cubemap_prefilter.frag
@@ -36,11 +36,11 @@ out vec4 FragColor;
 
 float DistributionGGX(vec3 N, vec3 H, float a2)
 {
-    float NdotH = max(dot(N, H), 0.0);
-    float NdotH2 = NdotH * NdotH;
+    float NoH = max(dot(N, H), 0.0);
+    float NoH2 = NoH * NoH;
 
     float nom = a2;
-    float denom = (NdotH2 * (a2 - 1.0) + 1.0);
+    float denom = (NoH2 * (a2 - 1.0) + 1.0);
     denom = M_PI * denom * denom;
 
     return nom / max(denom, EPSILON);
@@ -120,21 +120,21 @@ void main()
         vec3 H = ImportanceSampleGGX(Xi, a, OBN);
         vec3 L = normalize(reflect(-V, H));
 
-        float NdotL = max(dot(N, L), 0.0);
+        float NoL = max(dot(N, L), 0.0);
 
-        if (NdotL > EPSILON)
+        if (NoL > EPSILON)
         {
             float D = DistributionGGX(N, H, a2);
-            float NdotH = max(dot(N, H), 0.0);
+            float NoH = max(dot(N, H), 0.0);
             float HdotV = max(dot(H, V), 0.0);
 
-            float pdf = (D * NdotH) / max(4.0 * HdotV, EPSILON);
+            float pdf = (D * NoH) / max(4.0 * HdotV, EPSILON);
             float mipLevel = ComputeMipLevel(pdf, uSourceFaceSize);
             mipLevel = clamp(mipLevel, 0.0, uSourceNumLevels - 1.0);
 
             vec3 sampleColor = textureLod(uSourceTex, L, mipLevel).rgb;
-            prefilteredColor += sampleColor * NdotL;
-            totalWeight += NdotL;
+            prefilteredColor += sampleColor * NoL;
+            totalWeight += NoL;
         }
     }
 

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -130,12 +130,12 @@ void main()
 
         /* Compute diffuse lighting */
 
-        vec3 diffLight = L_Diffuse(ROUGHNESS, NoV, NoL, LoH);
+        vec3 diffLight = L_Diffuse(ORM.g, NoV, NoL, LoH);
         diffLight *= lightColE * dielectric;
 
         /* Compute specular lighting */
 
-        vec3 specLight =  L_Specular(F0, ROUGHNESS, NoV, NoL, NoH, LoH);
+        vec3 specLight =  L_Specular(F0, ORM.g, NoV, NoL, NoH, LoH);
         specLight *= lightColE * light.specular;
 
         /* Compute shadow factor */

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -83,7 +83,7 @@ void main()
 
     /* Compute F0 (reflectance at normal incidence) and diffuse coefficient */
 
-    vec3 F0 = PBR_ComputeF0(METALNESS, SPECULAR, ALBEDO);
+    vec3 F0 = PBR_F0(METALNESS, SPECULAR, ALBEDO);
     vec3 kD = dielectric * ALBEDO;
 
     /* Sample normal map and compute final normal */
@@ -94,7 +94,7 @@ void main()
     /* Compute view direction and the dot product of the normal and view direction */
 
     vec3 V = normalize(uViewPosition - vPosition);
-    float NdotV = max(dot(N, V), 1e-4);
+    float NoV = max(dot(N, V), 1e-4);
 
     /* Loop through all light sources accumulating diffuse and specular light */
 
@@ -113,16 +113,16 @@ void main()
         float Ldist = length(Ldelta);
 
         vec3 L = (light.type == LIGHT_DIR) ? -light.direction : Ldelta / max(Ldist, 1e-4);
-        float NdotL = dot(N, L);
+        float NoL = dot(N, L);
 
-        if (NdotL <= 0.0) continue;
+        if (NoL <= 0.0) continue;
 
         /* Compute the halfway vector between the view and light directions */
 
         vec3 H = normalize(V + L);
 
-        float LdotH = max(dot(L, H), 0.0);
-        float NdotH = max(dot(N, H), 0.0);
+        float LoH = max(dot(L, H), 0.0);
+        float NoH = max(dot(N, H), 0.0);
 
         /* Compute light color energy */
 
@@ -130,12 +130,12 @@ void main()
 
         /* Compute diffuse lighting */
 
-        vec3 diffLight = L_Diffuse(LdotH, NdotV, NdotL, ROUGHNESS);
+        vec3 diffLight = L_Diffuse(ROUGHNESS, NoV, NoL, LoH);
         diffLight *= lightColE * dielectric;
 
         /* Compute specular lighting */
 
-        vec3 specLight =  L_Specular(F0, LdotH, NdotH, NdotV, NdotL, ROUGHNESS);
+        vec3 specLight =  L_Specular(F0, ROUGHNESS, NoV, NoL, NoH, LoH);
         specLight *= lightColE * light.specular;
 
         /* Compute shadow factor */
@@ -155,9 +155,9 @@ void main()
 
         if (light.shadowLayer >= 0 && light.shadowOpacity != 0.0 && shadow > 1e-4) {
             switch (light.type) {
-            case LIGHT_DIR:  shadow *= L_SampleShadowDir(light, vPosition, vLinearDepth, NdotL, diskRot); break;
-            case LIGHT_SPOT: shadow *= L_SampleShadowSpot(light, vPosition, NdotL, diskRot); break;
-            case LIGHT_OMNI: shadow *= L_SampleShadowOmni(light, vPosition, NdotL, diskRot); break;
+            case LIGHT_DIR:  shadow *= L_SampleShadowDir(light, vPosition, vLinearDepth, NoL, diskRot); break;
+            case LIGHT_SPOT: shadow *= L_SampleShadowSpot(light, vPosition, NoL, diskRot); break;
+            case LIGHT_OMNI: shadow *= L_SampleShadowOmni(light, vPosition, NoL, diskRot); break;
             }
         }
 
@@ -171,9 +171,9 @@ void main()
 
 #if defined(PROBE)
     if (uProbeInterior) E_ComputeAmbientColor(diff, kD, OCCLUSION);
-    else E_ComputeAmbientOnly(diff, spec, kD, ORM.rgb, F0, vPosition, N, V, NdotV);
+    else E_ComputeAmbientOnly(diff, spec, kD, ORM.rgb, F0, vPosition, N, V, NoV);
 #else
-    E_ComputeAmbientAndProbes(diff, spec, kD, ORM.rgb, F0, vPosition, N, V, NdotV);
+    E_ComputeAmbientAndProbes(diff, spec, kD, ORM.rgb, F0, vPosition, N, V, NoV);
 #endif
 
     /* Compute the final fragment color */

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1122,10 +1122,10 @@ void raster_probe_forward(const r3d_render_call_t* call, const r3d_env_probe_t* 
 
     R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uEmissionEnergy, material->emission.energy);
     R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uNormalScale, material->normal.scale);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uOcclusion, material->orm.occlusion);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uRoughness, material->orm.roughness);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uMetalness, material->orm.metalness);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uSpecular, material->orm.specular);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uOcclusion, Clamp(material->orm.occlusion, 0.0f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uRoughness, Clamp(material->orm.roughness, 0.045f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uMetalness, Clamp(material->orm.metalness, 0.0f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uSpecular, Clamp(material->orm.specular, 0.0f, 1.0f));
 
     /* --- Set texcoord offset/scale --- */
 
@@ -1274,10 +1274,10 @@ void raster_geometry(const r3d_render_call_t* call, bool matchPrepass)
 
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uEmissionEnergy, material->emission.energy);
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uNormalScale, material->normal.scale);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uOcclusion, material->orm.occlusion);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uRoughness, material->orm.roughness);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uMetalness, material->orm.metalness);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uSpecular, material->orm.specular);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uOcclusion, Clamp(material->orm.occlusion, 0.0f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uRoughness, Clamp(material->orm.roughness, 0.045f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uMetalness, Clamp(material->orm.metalness, 0.0f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uSpecular, Clamp(material->orm.specular, 0.0f, 1.0f));
 
     /* --- Set misc material values --- */
 
@@ -1353,10 +1353,10 @@ void raster_decal(const r3d_render_call_t* call)
 
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uEmissionEnergy, decal->emission.energy);
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uNormalScale, decal->normal.scale);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uOcclusion, decal->orm.occlusion);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uRoughness, decal->orm.roughness);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uMetalness, decal->orm.metalness);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uSpecular, decal->orm.specular);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uOcclusion, Clamp(decal->orm.occlusion, 0.0f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uRoughness, Clamp(decal->orm.roughness, 0.045f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uMetalness, Clamp(decal->orm.metalness, 0.0f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uSpecular, Clamp(decal->orm.specular, 0.0f, 1.0f));
 
     /* --- Set misc material values --- */
 
@@ -1440,10 +1440,10 @@ void raster_forward(const r3d_render_call_t* call)
 
     R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uEmissionEnergy, material->emission.energy);
     R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uNormalScale, material->normal.scale);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uOcclusion, material->orm.occlusion);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uRoughness, material->orm.roughness);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uMetalness, material->orm.metalness);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uSpecular, material->orm.specular);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uOcclusion, Clamp(material->orm.occlusion, 0.0f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uRoughness, Clamp(material->orm.roughness, 0.045f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uMetalness, Clamp(material->orm.metalness, 0.0f, 1.0f));
+    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uSpecular, Clamp(material->orm.specular, 0.0f, 1.0f));
 
     /* --- Set texcoord offset/scale --- */
 


### PR DESCRIPTION
Replace the old `pbr.glsl` functions with the ones from [Filament](https://github.com/google/filament/blob/main/shaders/src/surface_brdf.fs).

The calculations differ slightly, but the results are very close overall. The main difference is the specular term, which no longer uses the Hammon 2017 approximation, standard on desktop.
