### PR TITLE
Fix: R3D_RaycastModel check local ray instead of global

### DIFF
--- a/src/r3d_shape.c
+++ b/src/r3d_shape.c
@@ -1167,7 +1167,8 @@ RayCollision R3D_RaycastModel(Ray ray, R3D_Model model, Matrix transform)
         if (mesh.vertices == NULL) continue;
 
         // Per-mesh AABB culling
-        RayCollision meshBoxCol = GetRayCollisionBox(ray, model.meshes[meshIdx].aabb);
+        Ray local_ray = {.position = localOrigin, .direction = localDirection};
+        RayCollision meshBoxCol = GetRayCollisionBox(local_ray, model.meshes[meshIdx].aabb);
         if (!meshBoxCol.hit) continue;
 
         int triangleCount = mesh.indices ? (mesh.indexCount / 3) : (mesh.vertexCount / 3);


### PR DESCRIPTION
In R3D_RaycastModel global ray was used to check collision with local space mesh.aabb

Before:
<img width="800" height="450" alt="before" src="https://github.com/user-attachments/assets/a6ecce05-775e-4ade-8bcd-eb4e425e4342" />
After:
<img width="800" height="450" alt="after" src="https://github.com/user-attachments/assets/d9acd304-1747-4704-bd79-795f505dc57a" />
