### PR TITLE
Remove lumen <-> energy conversion functions

### DIFF
--- a/include/r3d/r3d_lighting.h
+++ b/include/r3d/r3d_lighting.h
@@ -128,38 +128,11 @@ R3DAPI bool R3D_IsShadowMapValid(R3D_ShadowMap shadowMap);
  * This function is only relevant for spotlights and omni-lights.
  * 
  * @note This function should be called while using the default 3D rendering mode of raylib, 
- *       not with R3D's rendering mode. It uses raylib's 3D drawing functions to render the light's shape.
+ *       not with r3d's rendering mode. It uses raylib's 3D drawing functions to render the light's shape.
  *
  * @param light The light to visualize (see R3D_Light).
  */
 R3DAPI void R3D_DrawLightDebug(R3D_Light light);
-
-// ----------------------------------------
-// LIGHTING: Math Helper Functions
-// ----------------------------------------
-
-/**
- * @brief Converts a luminous flux to an energy factor.
- *
- * Computes the illuminance in lux at the given reference distance from an isotropic
- * point source: `energy = lumens / (4 * pi * distance * distance)`
- *
- * @param lumens The luminous flux in lumens.
- * @param referenceDistance The reference distance in scene units (1 unit = 1 meter).
- * @return The corresponding energy factor.
- */
-R3DAPI float R3D_LumensToEnergy(float lumens, float referenceDistance);
-
-/**
- * @brief Converts an energy factor back to a luminous flux.
- *
- * Inverse of @ref R3D_LumensToEnergy: `lumens = energy * 4 * pi * distance * distance`
- *
- * @param energy The energy factor.
- * @param referenceDistance The reference distance in scene units (1 unit = 1 meter).
- * @return The corresponding luminous flux in lumens.
- */
-R3DAPI float R3D_EnergyToLumens(float energy, float referenceDistance);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/r3d_lighting.c
+++ b/src/r3d_lighting.c
@@ -288,17 +288,3 @@ void R3D_DrawLightDebug(R3D_Light light)
         break;
     }
 }
-
-// ----------------------------------------
-// LIGHTING: Math Helper Functions
-// ----------------------------------------
-
-float R3D_LumensToEnergy(float lumens, float referenceDistance)
-{
-    return lumens / (4.0f * PI * referenceDistance * referenceDistance);
-}
-
-float R3D_EnergyToLumens(float energy, float referenceDistance)
-{
-    return energy * (4.0f * PI * referenceDistance * referenceDistance);
-}


### PR DESCRIPTION
Remove the energy <-> lumen conversion functions, as they are too specific and simple enough to be written when needed.