### PR TITLE
Transparency modes review

### DIFF
--- a/docs/shaders/surface_shader.md
+++ b/docs/shaders/surface_shader.md
@@ -18,7 +18,7 @@ Surface shaders are custom shaders that can be applied to materials and decals i
 
 ## Overview
 
-A surface shader is a simplified shader interface that allows you to modify vertex and fragment behavior without worrying about the underlying render pipeline. R3D automatically handles multiple render passes (opaque, transparent, shadows, etc.) from a single shader definition.
+A surface shader is a simplified shader interface that allows you to modify vertex and fragment behavior without worrying about the underlying render pipeline. R3D automatically handles multiple render passes (opaque, blend, shadows, etc.) from a single shader definition.
 
 ### Basic Example
 
@@ -420,31 +420,30 @@ void fragment() {
 
 ## Usage Hints
 
-R3D compiles multiple shader variants for different render passes (opaque, transparent, shadows, etc.). By default, only the opaque variant is pre-compiled; others compile on-demand when needed.
+R3D compiles multiple shader variants for different render passes (opaque, blend, shadows, etc.). By default, only the opaque variant is pre-compiled; others compile on-demand when needed.
 
 ### The Problem
 
-On-demand compilation can cause stuttering when a new variant is first used. For example, if your shader is used on a transparent object, the transparent variant compiles when the object first becomes visible.
+On-demand compilation can cause stuttering when a new variant is first used. For example, if your shader is used on a transparent object, the `blend` variant compiles when the object first becomes visible.
 
 ### The Solution
 
 Use `#pragma usage` to specify which variants should be pre-compiled:
 
 ```glsl
-#pragma usage transparent shadow
+#pragma usage blend shadow
 ```
 
 ### Available Usage Hints
 
 | Hint | Description |
 |------|-------------|
-| `opaque` | Opaque rendering for **lit objects** (default if no pragma specified) |
-| `prepass` | Transparent pre-pass rendering for **lit objects** |
-| `transparent` | Transparent rendering (color/alpha blending) for **lit objects** |
-| `unlit` | Unlit rendering (handles both opaque and transparent **unlit objects**) |
-| `shadow` | Shadow map rendering |
-| `decal` | Decal rendering |
-| `probe` | Reflection probe rendering |
+| `opaque` | Opaque rendering for **lit objects** (default if no pragma specified). Supports alpha cutoff. |
+| `blend` | Forward blended rendering (color/alpha blending) for **lit objects**. |
+| `unlit` | Unlit rendering (handles opaque, cutoff, and blended **unlit objects**). |
+| `shadow` | Shadow map depth rendering. |
+| `decal` | Decal projection rendering into G-Buffer targets. |
+| `probe` | Reflection probe capture rendering. |
 
 ### Examples
 
@@ -460,7 +459,7 @@ void fragment() {
 
 **Transparent object:**
 ```glsl
-#pragma usage transparent
+#pragma usage blend
 
 void fragment() {
     ALBEDO = vec3(0.0, 0.5, 1.0);
@@ -491,8 +490,8 @@ void fragment() {
 ### Important Notes
 
 - Usage hints are **optional**; missing variants will still compile on-demand
-- Multiple hints can be specified: `#pragma usage opaque transparent shadow`
-- Rendering mode separation: `opaque`, `prepass`, and `transparent` apply to **lit objects** only, while `unlit` applies to **unlit objects** regardless of opacity
+- Multiple hints can be specified: `#pragma usage opaque blend shadow`
+- Rendering mode separation: `opaque` and `blend` apply to **lit objects** only, while `unlit` applies to **unlit objects** regardless of opacity
 - If no pragma is specified, only `opaque` is pre-compiled
 - Variants not in the pragma can still be used; they just compile lazily
 
@@ -539,7 +538,7 @@ void R3D_SetSurfaceShaderSampler(R3D_SurfaceShader* shader, const char* name, Te
 
 ### Shader Structure
 ```glsl
-#pragma usage <hints>           // Optional: opaque, transparent, shadow, etc.
+#pragma usage <hints>           // Optional: opaque, blend, shadow, etc.
 #define R3D_NO_AUTO_FETCH       // Optional: disable automatic material sampling
 
 uniform <type> <name>;          // Uniforms

--- a/examples/dof.c
+++ b/examples/dof.c
@@ -1,4 +1,3 @@
-#include "raylib.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 #include <stdlib.h>

--- a/examples/dof.c
+++ b/examples/dof.c
@@ -1,3 +1,4 @@
+#include "raylib.h"
 #include <r3d/r3d.h>
 #include <raymath.h>
 #include <stdlib.h>
@@ -44,7 +45,7 @@ int main(void)
         for (int y = 0; y < Y_INSTANCES; y++)
         {
             positions[idx] = (Vector3) {x * spacing - offsetX, 0, y * spacing - offsetZ};
-            colors[idx] = (Color){rand()%256, rand()%256, rand()%256, 255};
+            colors[idx] = ColorFromHSV((float)(rand()%3600) * .1f, 0.6f, 1.0f);
             idx++;
         }
     }

--- a/examples/particles.c
+++ b/examples/particles.c
@@ -1,4 +1,3 @@
-#include "r3d/r3d_material.h"
 #include <r3d/r3d.h>
 #include <math.h>
 

--- a/examples/particles.c
+++ b/examples/particles.c
@@ -1,3 +1,4 @@
+#include "r3d/r3d_material.h"
 #include <r3d/r3d.h>
 #include <math.h>
 
@@ -32,6 +33,7 @@ int main(void)
 
     // Setup particle material
     R3D_Material material = R3D_GetDefaultMaterial();
+    material.transparencyMode = R3D_TRANSPARENCY_BLEND;
     material.billboardMode    = R3D_BILLBOARD_FRONT;
     material.blendMode        = R3D_BLEND_ADDITIVE;
     material.albedo.texture   = R3D_GetBlackTexture();

--- a/examples/stencil.c
+++ b/examples/stencil.c
@@ -37,7 +37,7 @@ int main(void)
     matXrayGhost.depth.mode = R3D_COMPARE_ALWAYS;
     matXrayGhost.stencil.mode = R3D_COMPARE_NOTEQUAL;
     matXrayGhost.stencil.ref = 0x01;
-    matXrayGhost.transparencyMode = R3D_TRANSPARENCY_ALPHA;
+    matXrayGhost.transparencyMode = R3D_TRANSPARENCY_BLEND;
     matXrayGhost.unlit = true;
 
     // Main outline sphere material

--- a/examples/transparency.c
+++ b/examples/transparency.c
@@ -13,7 +13,7 @@ int main(void)
     // Create cube model
     R3D_Mesh cube = R3D_GenMeshCube(1, 1, 1);
     R3D_Material matCube = R3D_MATERIAL_BASE;
-    matCube.transparencyMode = R3D_TRANSPARENCY_ALPHA;
+    matCube.transparencyMode = R3D_TRANSPARENCY_BLEND;
     matCube.albedo.color = (Color){150, 150, 255, 100};
     matCube.orm.occlusion = 1.0f;
     matCube.orm.roughness = 0.2f;

--- a/include/r3d/r3d_material.h
+++ b/include/r3d/r3d_material.h
@@ -54,7 +54,7 @@
         },                                              \
         .uvOffset = {0.0f, 0.0f},                       \
         .uvScale = {1.0f, 1.0f},                        \
-        .alphaCutoff = 0.01f,                           \
+        .alphaCutoff = 0.5f,                            \
         .depth = {                                      \
             .mode = R3D_COMPARE_LESS,                   \
             .offsetFactor = 0.0f,                       \

--- a/include/r3d/r3d_material.h
+++ b/include/r3d/r3d_material.h
@@ -70,9 +70,9 @@
             .opZFail = R3D_STENCIL_KEEP,                \
             .opPass = R3D_STENCIL_REPLACE,              \
         },                                              \
-        .transparencyMode = R3D_TRANSPARENCY_DISABLED,  \
+        .transparencyMode = R3D_TRANSPARENCY_OPAQUE,    \
         .billboardMode = R3D_BILLBOARD_DISABLED,        \
-        .blendMode = R3D_BLEND_MIX,                     \
+        .blendMode = R3D_BLEND_ALPHA,                   \
         .cullMode = R3D_CULL_BACK,                      \
         .unlit = false,                                 \
         .priority = 0,                                  \
@@ -84,16 +84,14 @@
 // ========================================
 
 /**
- * @brief Transparency modes.
+ * @brief Material transparency handling modes.
  *
- * This enumeration defines how a material handles transparency during rendering.
- * It controls whether transparency is disabled, rendered using a depth pre-pass,
- * or rendered with standard alpha blending.
+ * Defines how material opacity and blending are processed during rendering.
  */
 typedef enum R3D_TransparencyMode {
-    R3D_TRANSPARENCY_DISABLED,      ///< No transparency, supports alpha cutoff.
-    R3D_TRANSPARENCY_PREPASS,       ///< Supports transparency with shadows. Writes shadows for alpha > 0.1 and depth for alpha > 0.99.
-    R3D_TRANSPARENCY_ALPHA,         ///< Standard transparency without shadows or depth writes.
+    R3D_TRANSPARENCY_OPAQUE,        ///< Fully opaque in G-Buffer (supports hard alpha cutoff/masking). Ignores blend mode.
+    R3D_TRANSPARENCY_HYBRID,        ///< Two-pass rendering: opaque cutoff in G-Buffer + forward blending.
+    R3D_TRANSPARENCY_BLEND,         ///< Blended only (forward pass, no depth write / shadow casting).
 } R3D_TransparencyMode;
 
 /**
@@ -112,14 +110,15 @@ typedef enum R3D_BillboardMode {
 /**
  * @brief Blend modes.
  *
- * Defines common blending modes used in 3D rendering to combine source and destination colors.
- * @note The blend mode is applied only if you are in forward rendering mode or auto-detect mode.
+ * Defines common blending modes to combine source and destination colors.
+ * @note Ignored when R3D_TRANSPARENCY_OPAQUE is selected.
  */
 typedef enum R3D_BlendMode {
-    R3D_BLEND_MIX,                  ///< Default mode: the result will be opaque or alpha blended depending on the transparency mode.
-    R3D_BLEND_ADDITIVE,             ///< Additive blending: source color is added to the destination, making bright effects.
-    R3D_BLEND_MULTIPLY,             ///< Multiply blending: source color is multiplied with the destination, darkening the image.
-    R3D_BLEND_PREMULTIPLIED_ALPHA   ///< Premultiplied alpha blending: source color is blended with the destination assuming the source color is already multiplied by its alpha.
+    R3D_BLEND_ALPHA,                ///< Standard alpha blending: source color is blended using its alpha channel.
+    R3D_BLEND_ADDITIVE,             ///< Pure additive blending: source color is added directly to destination (ignores alpha).
+    R3D_BLEND_ADD_ALPHA,            ///< Alpha-modulated additive blending: source color scaled by alpha before adding to destination.
+    R3D_BLEND_MULTIPLY,             ///< Multiply blending: source color is multiplied with destination, darkening the image.
+    R3D_BLEND_PREMULTIPLIED_ALPHA   ///< Premultiplied alpha blending: assumes source color is already multiplied by its alpha.
 } R3D_BlendMode;
 
 /**

--- a/shaders/include/user/scene.frag
+++ b/shaders/include/user/scene.frag
@@ -104,8 +104,15 @@ void FetchMaterial(vec2 texCoord)
 
 #define fragment()
 
-void SceneFragment(vec2 texCoord, mat3 tbn, float alphaCutoff)
+void SceneFragment(vec2 texCoord, mat3 tbn, float alphaCutoff, float cutoffSign)
 {
+    // CutoffSign:
+    //  -> +1.0 : Opaque cutoff
+    //  -> -1.0 : Inverted test for hybrid blended
+    //  ->  0.0 : Disables alpha test
+
+#define ALPHA_TEST(alpha) if (cutoffSign * (alpha - alphaCutoff) < 0.0) discard;
+
     /* --- Fill input variables --- */
 
     TEXCOORD  = texCoord;
@@ -117,7 +124,7 @@ void SceneFragment(vec2 texCoord, mat3 tbn, float alphaCutoff)
 
 #if !defined(R3D_NO_AUTO_FETCH)
     vec4 color = vColor * texture(uAlbedoMap, texCoord);
-    if (color.a < alphaCutoff) discard;
+    ALPHA_TEST(color.a);
     ALBEDO = color.rgb;
     ALPHA = color.a;
 
@@ -143,5 +150,7 @@ void SceneFragment(vec2 texCoord, mat3 tbn, float alphaCutoff)
     fragment();
 
     // Alpha cutoff again after user code
-    if (ALPHA < alphaCutoff) discard;
+    ALPHA_TEST(ALPHA);
+
+#undef ALPHA_TEST
 }

--- a/shaders/scene/decal.frag
+++ b/shaders/scene/decal.frag
@@ -112,7 +112,7 @@ void main()
     if (difference < 0.0) discard;
 
     /* Sample material maps with alpha cutoff */
-    SceneFragment(decalTexCoord, TBN, uAlphaCutoff);
+    SceneFragment(decalTexCoord, TBN, uAlphaCutoff, 1.0);
 
     /* Compute fade factor */
     float fadeAlpha = clamp(difference / uFadeWidth, 0.0, 1.0) * ALPHA;

--- a/shaders/scene/depth.frag
+++ b/shaders/scene/depth.frag
@@ -42,5 +42,5 @@ uniform float uAlphaCutoff;
 void main()
 {
     // NOTE: The depth is automatically written
-    SceneFragment(vTexCoord, mat3(1.0), uAlphaCutoff);
+    SceneFragment(vTexCoord, mat3(1.0), uAlphaCutoff, 1.0);
 }

--- a/shaders/scene/depth_cube.frag
+++ b/shaders/scene/depth_cube.frag
@@ -43,6 +43,6 @@ uniform float uFar;
 
 void main()
 {
-    SceneFragment(vTexCoord, mat3(1.0), uAlphaCutoff);
+    SceneFragment(vTexCoord, mat3(1.0), uAlphaCutoff, 1.0);
     gl_FragDepth = length(vPosition - uViewPosition) / uFar;
 }

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -57,6 +57,8 @@ uniform samplerCubeArray uIrradianceTex;
 uniform samplerCubeArray uPrefilterTex;
 uniform sampler2D uBrdfLutTex;
 
+uniform float uAlphaCutoff;
+uniform float uCutoffSign;
 uniform float uNormalScale;
 uniform float uOcclusion;
 uniform float uRoughness;
@@ -91,7 +93,7 @@ void main()
 {
     /* Sample material maps */
 
-    SceneFragment(vTexCoord, vTBN, 0.0);
+    SceneFragment(vTexCoord, vTBN, uAlphaCutoff, uCutoffSign);
 
     vec3 ORM = vec3(OCCLUSION, ROUGHNESS, METALNESS);
     mat3 TBN = mat3(TANGENT, BITANGENT, NORMAL);

--- a/shaders/scene/geometry.frag
+++ b/shaders/scene/geometry.frag
@@ -66,7 +66,7 @@ uniform float uSpecular;
 
 void main()
 {
-    SceneFragment(vTexCoord, vTBN, uAlphaCutoff);
+    SceneFragment(vTexCoord, vTBN, uAlphaCutoff, 1.0);
 
     mat3 TBN = mat3(TANGENT, BITANGENT, NORMAL);
     vec3 N = normalize(TBN * M_NormalScale(NORMAL_MAP * 2.0 - 1.0, uNormalScale));

--- a/shaders/scene/unlit.frag
+++ b/shaders/scene/unlit.frag
@@ -37,6 +37,7 @@ layout(location = 0) out vec4 FragColor;
 
 uniform sampler2D uAlbedoMap;
 uniform float uAlphaCutoff;
+uniform float uCutoffSign;
 
 // ================================
 // User Override
@@ -50,7 +51,7 @@ uniform float uAlphaCutoff;
 
 void main()
 {
-    SceneFragment(vTexCoord, mat3(1.0), uAlphaCutoff);
+    SceneFragment(vTexCoord, mat3(1.0), uAlphaCutoff, uCutoffSign);
 
     FragColor = vec4(ALBEDO, ALPHA);
     FragColor = FogColorMix(FragColor, vLinearDepth);

--- a/src/importer/r3d_importer_material.c
+++ b/src/importer/r3d_importer_material.c
@@ -178,8 +178,8 @@ static void load_param_blend_mode(R3D_Material* material, const struct aiMateria
         }
         if (strcmp(alphaMode.data, "BLEND") == 0)
         {
-            material->transparencyMode = R3D_TRANSPARENCY_PREPASS;
-            material->blendMode = R3D_BLEND_MIX;
+            material->transparencyMode = R3D_TRANSPARENCY_HYBRID;
+            material->blendMode = R3D_BLEND_ALPHA;
             return;
         }
     }
@@ -192,12 +192,12 @@ static void load_param_blend_mode(R3D_Material* material, const struct aiMateria
         {
         case aiBlendMode_Default:
             // sColor*sAlpha + dColor*(1-sAlpha)
-            material->transparencyMode = R3D_TRANSPARENCY_PREPASS;
-            material->blendMode = R3D_BLEND_MIX;
+            material->transparencyMode = R3D_TRANSPARENCY_HYBRID;
+            material->blendMode = R3D_BLEND_ALPHA;
             return;
         case aiBlendMode_Additive:
             // sColor*1 + dColor*1
-            material->transparencyMode = R3D_TRANSPARENCY_DISABLED;
+            material->transparencyMode = R3D_TRANSPARENCY_BLEND;
             material->blendMode = R3D_BLEND_ADDITIVE;
             return;
         default:
@@ -209,8 +209,8 @@ static void load_param_blend_mode(R3D_Material* material, const struct aiMateria
     // alpha == 0 is likely a degenerate material, ignore it
     if (material->albedo.color.a > 0 && material->albedo.color.a < 255)
     {
-        material->transparencyMode = R3D_TRANSPARENCY_ALPHA;
-        material->blendMode = R3D_BLEND_MIX;
+        material->transparencyMode = R3D_TRANSPARENCY_BLEND;
+        material->blendMode = R3D_BLEND_ALPHA;
     }
 }
 

--- a/src/modules/r3d_driver.c
+++ b/src/modules/r3d_driver.c
@@ -13,6 +13,7 @@
 #include <glad.h>
 
 #include "../common/r3d_helper.h"
+#include "r3d/r3d_material.h"
 
 // ========================================
 // CONFIGURATION
@@ -483,29 +484,18 @@ void r3d_driver_set_stencil_state(R3D_StencilState state)
     r3d_driver_set_stencil_op(glOpFail, glOpZFail, glOpPass);
 }
 
-void r3d_driver_set_blend_mode(R3D_BlendMode blend, R3D_TransparencyMode transparency)
+void r3d_driver_set_blend_mode(R3D_BlendMode blend)
 {
     switch (blend)
     {
-    case R3D_BLEND_MIX:
-        if (transparency == R3D_TRANSPARENCY_DISABLED)
-        {
-            r3d_driver_set_blend_func(GL_FUNC_ADD, GL_ONE, GL_ZERO);
-        }
-        else
-        {
-            r3d_driver_set_blend_func(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        }
+    case R3D_BLEND_ALPHA:
+        r3d_driver_set_blend_func(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
         break;
     case R3D_BLEND_ADDITIVE:
-        if (transparency == R3D_TRANSPARENCY_DISABLED)
-        {
-            r3d_driver_set_blend_func(GL_FUNC_ADD, GL_ONE, GL_ONE);
-        }
-        else
-        {
-            r3d_driver_set_blend_func(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE);
-        }
+        r3d_driver_set_blend_func(GL_FUNC_ADD, GL_ONE, GL_ONE);
+        break;
+    case R3D_BLEND_ADD_ALPHA:
+        r3d_driver_set_blend_func(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE);
         break;
     case R3D_BLEND_MULTIPLY:
         r3d_driver_set_blend_func(GL_FUNC_ADD, GL_DST_COLOR, GL_ZERO);

--- a/src/modules/r3d_driver.c
+++ b/src/modules/r3d_driver.c
@@ -13,7 +13,6 @@
 #include <glad.h>
 
 #include "../common/r3d_helper.h"
-#include "r3d/r3d_material.h"
 
 // ========================================
 // CONFIGURATION

--- a/src/modules/r3d_driver.h
+++ b/src/modules/r3d_driver.h
@@ -127,9 +127,8 @@ void r3d_driver_set_stencil_state(R3D_StencilState state);
 /*
  * Applies the given blend mode.
  * Assumes that GL_BLEND is already enabled.
- * Some modes like MIX or ADD behave differently depending on the transparency mode.
  */
-void r3d_driver_set_blend_mode(R3D_BlendMode blend, R3D_TransparencyMode transparency);
+void r3d_driver_set_blend_mode(R3D_BlendMode blend);
 
 /*
  * Applies the given cull mode.

--- a/src/modules/r3d_render.c
+++ b/src/modules/r3d_render.c
@@ -762,15 +762,15 @@ static inline void sort_fill_state_data(r3d_render_sort_state_t* state, const r3
 
 static void sort_fill_cache_front_to_back(r3d_render_list_enum_t list)
 {
-    R3D_ASSERT(list < R3D_RENDER_LIST_NON_INST_COUNT && "Instantiated render lists should not be sorted by distance");
+    R3D_ASSERT(list < R3D_RENDER_LIST_OPAQUE_INST && "Instantiated render lists should not be sorted by distance");
     R3D_ASSERT(list != R3D_RENDER_LIST_DECAL && "Decal render list should not be sorted by distance");
 
-    r3d_render_list_t* drawList = &R3D_MOD_RENDER.list[list];
-    size_t count = R3D_LIST_LENGTH(drawList->calls);
+    r3d_list_t* drawList = R3D_MOD_RENDER.list[list];
+    size_t count = R3D_LIST_LENGTH(drawList);
 
     for (size_t i = 0; i < count; i++)
     {
-        int callIndex = R3D_LIST_GET(drawList->calls, int, i);
+        int callIndex = R3D_LIST_GET(drawList, int, i);
         const r3d_render_call_t* call = &R3D_LIST_GET(R3D_MOD_RENDER.calls, r3d_render_call_t, callIndex);
         const r3d_render_group_t* group = r3d_render_get_call_group(call);
         r3d_render_sort_t* sortData = &R3D_LIST_GET(R3D_MOD_RENDER.sortCache, r3d_render_sort_t, callIndex);
@@ -785,15 +785,15 @@ static void sort_fill_cache_front_to_back(r3d_render_list_enum_t list)
 
 static void sort_fill_cache_back_to_front(r3d_render_list_enum_t list)
 {
-    R3D_ASSERT(list < R3D_RENDER_LIST_NON_INST_COUNT && "Instantiated render lists should not be sorted by distance");
+    R3D_ASSERT(list < R3D_RENDER_LIST_OPAQUE_INST && "Instantiated render lists should not be sorted by distance");
     R3D_ASSERT(list != R3D_RENDER_LIST_DECAL && "Decal render list should not be sorted by distance");
 
-    r3d_render_list_t* drawList = &R3D_MOD_RENDER.list[list];
-    size_t count = R3D_LIST_LENGTH(drawList->calls);
+    r3d_list_t* drawList = R3D_MOD_RENDER.list[list];
+    size_t count = R3D_LIST_LENGTH(drawList);
 
     for (size_t i = 0; i < count; i++)
     {
-        int callIndex = R3D_LIST_GET(drawList->calls, int, i);
+        int callIndex = R3D_LIST_GET(drawList, int, i);
         const r3d_render_call_t* call = &R3D_LIST_GET(R3D_MOD_RENDER.calls, r3d_render_call_t, callIndex);
         const r3d_render_group_t* group = r3d_render_get_call_group(call);
         r3d_render_sort_t* sortData = &R3D_LIST_GET(R3D_MOD_RENDER.sortCache, r3d_render_sort_t, callIndex);
@@ -813,12 +813,12 @@ static void sort_fill_cache_back_to_front(r3d_render_list_enum_t list)
 
 static void sort_fill_cache_by_material(r3d_render_list_enum_t list)
 {
-    r3d_render_list_t* drawList = &R3D_MOD_RENDER.list[list];
-    size_t count = R3D_LIST_LENGTH(drawList->calls);
+    r3d_list_t* drawList = R3D_MOD_RENDER.list[list];
+    size_t count = R3D_LIST_LENGTH(drawList);
 
     for (size_t i = 0; i < count; i++)
     {
-        int callIndex = R3D_LIST_GET(drawList->calls, int, i);
+        int callIndex = R3D_LIST_GET(drawList, int, i);
         const r3d_render_call_t* call = &R3D_LIST_GET(R3D_MOD_RENDER.calls, r3d_render_call_t, callIndex);
         r3d_render_sort_t* sortData = &R3D_LIST_GET(R3D_MOD_RENDER.sortCache, r3d_render_sort_t, callIndex);
 
@@ -899,7 +899,7 @@ bool r3d_render_init(void)
 
     for (int i = 0; i < R3D_RENDER_LIST_COUNT; i++)
     {
-        R3D_MOD_RENDER.list[i].calls = R3D_LIST_CREATE(int, cap);
+        R3D_MOD_RENDER.list[i] = R3D_LIST_CREATE(int, cap);
     }
 
     R3D_MOD_RENDER.calls        = R3D_LIST_CREATE(r3d_render_call_t, cap);
@@ -953,7 +953,7 @@ void r3d_render_quit(void)
 
     for (int i = 0; i < R3D_RENDER_LIST_COUNT; i++)
     {
-        R3D_LIST_DESTROY(R3D_MOD_RENDER.list[i].calls);
+        R3D_LIST_DESTROY(R3D_MOD_RENDER.list[i]);
     }
 
     R3D_LIST_DESTROY(R3D_MOD_RENDER.groupVisibility);
@@ -1215,7 +1215,7 @@ void r3d_render_clear(void)
 {
     for (int i = 0; i < R3D_RENDER_LIST_COUNT; i++)
     {
-        R3D_LIST_CLEAR(R3D_MOD_RENDER.list[i].calls);
+        R3D_LIST_CLEAR(R3D_MOD_RENDER.list[i]);
     }
 
     R3D_LIST_CLEAR(R3D_MOD_RENDER.clusters);
@@ -1227,9 +1227,6 @@ void r3d_render_clear(void)
     R3D_LIST_CLEAR(R3D_MOD_RENDER.sortCache);
 
     R3D_MOD_RENDER.groupCulled = false;
-    R3D_MOD_RENDER.hasDeferred = false;
-    R3D_MOD_RENDER.hasPrepass  = false;
-    R3D_MOD_RENDER.hasForward  = false;
 }
 
 bool r3d_render_cluster_begin(BoundingBox aabb)
@@ -1280,34 +1277,43 @@ void r3d_render_call_push(const r3d_render_call_t* call)
 
     // Get call index and set call group indices
     int callIndex = (int)R3D_LIST_LENGTH(R3D_MOD_RENDER.calls);
-    if (indices->numCall == 0)
-    {
-        indices->firstCall = callIndex;
-    }
-    ++indices->numCall;
+    if (indices->numCall == 0) indices->firstCall = callIndex;
+    indices->numCall += 1;
 
-    // Set group index for this draw call
+    // Push this draw call and its group index
     R3D_LIST_PUSH(R3D_MOD_RENDER.groupIndices, groupIndex);
-
-    // Determine the draw call list
-    r3d_render_list_enum_t list = R3D_RENDER_LIST_OPAQUE;
-    if (r3d_render_is_decal(call)) list = R3D_RENDER_LIST_DECAL;
-    else if (!r3d_render_is_opaque(call)) list = R3D_RENDER_LIST_TRANSPARENT;
-    if (r3d_render_has_instances(group)) list += R3D_RENDER_LIST_NON_INST_COUNT;
-
-    // Update internal flags
-    if (r3d_render_is_deferred(call)) R3D_MOD_RENDER.hasDeferred = true;
-    else if (r3d_render_is_prepass(call)) R3D_MOD_RENDER.hasPrepass = true;
-    else if (r3d_render_is_forward(call)) R3D_MOD_RENDER.hasForward = true;
-
-    // Push the draw call and its index to the list
     R3D_LIST_PUSH(R3D_MOD_RENDER.calls, *call);
 
-    // Reserve a matching slot in the sort cache (filled in later by r3d_render_sort_list)
-    r3d_render_sort_t emptySort = {0};
-    R3D_LIST_PUSH(R3D_MOD_RENDER.sortCache, emptySort);
+    // Push draw call index in the passes lists
+    bool instanced = r3d_render_has_instances(group);
 
-    R3D_LIST_PUSH(R3D_MOD_RENDER.list[list].calls, callIndex);
+    if (call->type == R3D_RENDER_CALL_DECAL)
+    {
+        r3d_render_list_enum_t list = instanced ? R3D_RENDER_LIST_DECAL_INST : R3D_RENDER_LIST_DECAL;
+        R3D_LIST_PUSH(R3D_MOD_RENDER.list[list], callIndex);
+    }
+    else
+    {
+        r3d_render_list_enum_t opaqueList = instanced ? R3D_RENDER_LIST_OPAQUE_INST : R3D_RENDER_LIST_OPAQUE;
+        r3d_render_list_enum_t blendList  = instanced ? R3D_RENDER_LIST_BLEND_INST  : R3D_RENDER_LIST_BLEND;
+
+        switch (call->mesh.material.transparencyMode)
+        {
+        case R3D_TRANSPARENCY_OPAQUE:
+            R3D_LIST_PUSH(R3D_MOD_RENDER.list[opaqueList], callIndex);
+            break;
+        case R3D_TRANSPARENCY_HYBRID:
+            R3D_LIST_PUSH(R3D_MOD_RENDER.list[opaqueList], callIndex);
+            R3D_LIST_PUSH(R3D_MOD_RENDER.list[blendList], callIndex);
+            break;
+        case R3D_TRANSPARENCY_BLEND:
+            R3D_LIST_PUSH(R3D_MOD_RENDER.list[blendList], callIndex);
+            break;
+        }
+    }
+
+    // Reserve a matching slot in the sort cache (filled in later by r3d_render_sort_list)
+    R3D_LIST_PUSH(R3D_MOD_RENDER.sortCache, (r3d_render_sort_t) {0});
 }
 
 r3d_render_group_t* r3d_render_get_call_group(const r3d_render_call_t* call)
@@ -1427,7 +1433,7 @@ void r3d_render_sort_list(r3d_render_list_enum_t list, Vector3 viewPosition, r3d
     G_sortViewPosition = viewPosition;
 
     int (*compareFunc)(const void *a, const void *b) = NULL;
-    r3d_list_t* drawListCalls = R3D_MOD_RENDER.list[list].calls;
+    r3d_list_t* drawListCalls = R3D_MOD_RENDER.list[list];
 
     switch (mode)
     {

--- a/src/modules/r3d_render.h
+++ b/src/modules/r3d_render.h
@@ -478,7 +478,7 @@ static inline bool r3d_render_has_blended(void)
  * Check whether there are any decal draw calls queued for the current frame.
  * Includes both instanced and non-instanced variants.
  */
-static inline bool r3d_render_has_decal(void)
+static inline bool r3d_render_has_decals(void)
 {
     return
         (!R3D_LIST_EMPTY(R3D_MOD_RENDER.list[R3D_RENDER_LIST_DECAL])) ||

--- a/src/modules/r3d_render.h
+++ b/src/modules/r3d_render.h
@@ -25,26 +25,6 @@
 // ========================================
 
 /*
- * A set of all lists that can be rendered in probe captures.
- * May require check per draw call depending on the context.
- */
-#define R3D_RENDER_PACKLIST_PROBE         \
-    R3D_RENDER_LIST_OPAQUE_INST,          \
-    R3D_RENDER_LIST_OPAQUE,               \
-    R3D_RENDER_LIST_TRANSPARENT_INST,     \
-    R3D_RENDER_LIST_TRANSPARENT
-
-/*
- * A set of all lists that can be rendered in shadow maps.
- * May require check per draw call depending on the context.
- */
-#define R3D_RENDER_PACKLIST_SHADOW        \
-    R3D_RENDER_LIST_OPAQUE_INST,          \
-    R3D_RENDER_LIST_TRANSPARENT_INST,     \
-    R3D_RENDER_LIST_OPAQUE,               \
-    R3D_RENDER_LIST_TRANSPARENT
-
-/*
  * Iterate over multiple render lists in the order specified by the variadic arguments,
  * yielding a pointer to each r3d_render_call_t.
  *
@@ -56,14 +36,14 @@
 #define R3D_RENDER_FOR_EACH(call, cond, frustum, ...)                                               \
     for (int _lists[] = {__VA_ARGS__}, _list_idx = 0, _i = 0, _keep = 1;                            \
          _list_idx < (int)(sizeof(_lists)/sizeof(_lists[0]));                                       \
-         ((size_t)_i >= R3D_LIST_LENGTH(R3D_MOD_RENDER.list[_lists[_list_idx]].calls) ?             \
+         ((size_t)_i >= R3D_LIST_LENGTH(R3D_MOD_RENDER.list[_lists[_list_idx]]) ?                   \
           (_list_idx++, _i = 0) : 0))                                                               \
         for (; _list_idx < (int)(sizeof(_lists)/sizeof(_lists[0])) &&                               \
-               (size_t)_i < R3D_LIST_LENGTH(R3D_MOD_RENDER.list[_lists[_list_idx]].calls);          \
+               (size_t)_i < R3D_LIST_LENGTH(R3D_MOD_RENDER.list[_lists[_list_idx]]);                \
              _i++, _keep = 1)                                                                       \
             for (const r3d_render_call_t* call =                                                    \
                  &R3D_LIST_GET(R3D_MOD_RENDER.calls, r3d_render_call_t,                             \
-                     R3D_LIST_GET(R3D_MOD_RENDER.list[_lists[_list_idx]].calls, int, _i));          \
+                     R3D_LIST_GET(R3D_MOD_RENDER.list[_lists[_list_idx]], int, _i));                \
                  _keep && (cond) && (!(frustum) || r3d_render_call_is_visible(call, (frustum)));    \
                  _keep = 0)
 
@@ -135,19 +115,13 @@ typedef enum {
  * Lists are separated by rendering path and instancing mode.
  */
 typedef enum {
-
     R3D_RENDER_LIST_OPAQUE,
-    R3D_RENDER_LIST_TRANSPARENT,
+    R3D_RENDER_LIST_BLEND,
     R3D_RENDER_LIST_DECAL,
-
-    R3D_RENDER_LIST_NON_INST_COUNT,
-
-    R3D_RENDER_LIST_OPAQUE_INST = R3D_RENDER_LIST_NON_INST_COUNT,
-    R3D_RENDER_LIST_TRANSPARENT_INST,
+    R3D_RENDER_LIST_OPAQUE_INST,
+    R3D_RENDER_LIST_BLEND_INST,
     R3D_RENDER_LIST_DECAL_INST,
-
-    R3D_RENDER_LIST_COUNT
-
+    R3D_RENDER_LIST_COUNT,
 } r3d_render_list_enum_t;
 
 // ========================================
@@ -253,13 +227,6 @@ typedef struct {
 } r3d_render_call_t;
 
 /*
- * A render list stores indices into the global draw call array.
- */
-typedef struct {
-    r3d_list_t* calls;   //< Indices of draw calls (list<int>)
-} r3d_render_list_t;
-
-/*
  * Sort key derived from a rendering state.
  * Fields are declared in priority order: the first differing field
  * encountered during comparison determines the sort result.
@@ -319,15 +286,12 @@ extern struct r3d_mod_render {
     r3d_list_t* callIndices;                            //< Array of draw call index ranges for each render group (list<r3d_render_indices_t>, automatically managed)
     r3d_list_t* groups;                                 //< Array of render groups (list<r3d_render_group_t>, shared data across draw calls)
 
-    r3d_render_list_t list[R3D_RENDER_LIST_COUNT];      //< Lists of draw call indices organized by rendering category
+    r3d_list_t* list[R3D_RENDER_LIST_COUNT];            //< List of draw call indices per render pass (list<int>)
     r3d_list_t* sortCache;                              //< Draw call sorting data cache array (list<r3d_render_sort_t>)
     r3d_list_t* calls;                                  //< Array of draw calls (list<r3d_render_call_t>)
     r3d_list_t* groupIndices;                           //< Array of group indices for each draw call (list<int>, automatically managed)
 
     bool groupCulled;                                   //< Indicates if groups already culled (controls visibility reset)
-    bool hasDeferred;                                   //< If there are any deferred calls (lit opaque)
-    bool hasPrepass;                                    //< If there are any prepass calls (lit opaque / lit transparent)
-    bool hasForward;                                    //< If there are any forward calls (unlit opaque / transparent)
 
 } R3D_MOD_RENDER;
 
@@ -489,30 +453,25 @@ static inline bool r3d_render_has_instances(const r3d_render_group_t* group)
 }
 
 /*
- * Check whether there are any deferred draw calls queued for the current frame.
+ * Check whether there are any opaque draw calls queued for the current frame.
  * Includes both instanced and non-instanced variants.
  */
-static inline bool r3d_render_has_deferred(void)
+static inline bool r3d_render_has_opaque(void)
 {
-    return R3D_MOD_RENDER.hasDeferred;
+    return
+        (!R3D_LIST_EMPTY(R3D_MOD_RENDER.list[R3D_RENDER_LIST_OPAQUE])) ||
+        (!R3D_LIST_EMPTY(R3D_MOD_RENDER.list[R3D_RENDER_LIST_OPAQUE_INST]));
 }
 
 /*
- * Check whether there are any prepass draw calls queued for the current frame.
+ * Check whether there are any blended draw calls queued for the current frame.
  * Includes both instanced and non-instanced variants.
  */
-static inline bool r3d_render_has_prepass(void)
+static inline bool r3d_render_has_blended(void)
 {
-    return R3D_MOD_RENDER.hasPrepass;
-}
-
-/*
- * Check whether there are any forward draw calls queued for the current frame.
- * Includes both instanced and non-instanced variants.
- */
-static inline bool r3d_render_has_forward(void)
-{
-    return R3D_MOD_RENDER.hasForward;
+    return
+        (!R3D_LIST_EMPTY(R3D_MOD_RENDER.list[R3D_RENDER_LIST_BLEND])) ||
+        (!R3D_LIST_EMPTY(R3D_MOD_RENDER.list[R3D_RENDER_LIST_BLEND_INST]));
 }
 
 /*
@@ -522,73 +481,8 @@ static inline bool r3d_render_has_forward(void)
 static inline bool r3d_render_has_decal(void)
 {
     return
-        (!R3D_LIST_EMPTY(R3D_MOD_RENDER.list[R3D_RENDER_LIST_DECAL].calls)) ||
-        (!R3D_LIST_EMPTY(R3D_MOD_RENDER.list[R3D_RENDER_LIST_DECAL_INST].calls));
-}
-
-/*
- * Indicates whether a draw call corresponds to a decal.
- */
-static inline bool r3d_render_is_decal(const r3d_render_call_t* call)
-{
-    return call->type == R3D_RENDER_CALL_DECAL;
-}
-
-/*
- * Indicates whether a draw call corresponds to an object that is only rendered in deferred.
- * Always check if an object is prepassed before checking if it is deferred.
- */
-static inline bool r3d_render_is_deferred(const r3d_render_call_t* call)
-{
-    if (call->type != R3D_RENDER_CALL_MESH) return false;
-    if (call->mesh.material.unlit) return false;
-
-    if (call->mesh.material.blendMode != R3D_BLEND_MIX) {
-        return false;
-    }
-
-    return call->mesh.material.transparencyMode == R3D_TRANSPARENCY_DISABLED;
-}
-
-/*
- * Indicates whether a draw call corresponds to an opaque object (lit or unlit)
- */
-static inline bool r3d_render_is_opaque(const r3d_render_call_t* call)
-{
-    if (call->type != R3D_RENDER_CALL_MESH) return false;
-
-    if (call->mesh.material.blendMode != R3D_BLEND_MIX) {
-        return false;
-    }
-
-    return call->mesh.material.transparencyMode == R3D_TRANSPARENCY_DISABLED;
-}
-
-/*
- * Indicates whether a draw call corresponds to an illuminated object rendered in multiple passes (deferred / forward)
- */
-static inline bool r3d_render_is_prepass(const r3d_render_call_t* call)
-{
-    if (call->type != R3D_RENDER_CALL_MESH) return false;
-    if (call->mesh.material.unlit) return false;
-
-    return call->mesh.material.transparencyMode == R3D_TRANSPARENCY_PREPASS;
-}
-
-/*
- * Indicates whether a draw call corresponds to an object rendered only in forward (unlit opaque / transparent)
- * Always check if an object is prepassed before checking if it is forwarded.
- */
-static inline bool r3d_render_is_forward(const r3d_render_call_t* call)
-{
-    if (call->type != R3D_RENDER_CALL_MESH) return false;
-    if (call->mesh.material.unlit) return true;
-
-    if (call->mesh.material.blendMode != R3D_BLEND_MIX) {
-        return true;
-    }
-
-    return call->mesh.material.transparencyMode == R3D_TRANSPARENCY_ALPHA;
+        (!R3D_LIST_EMPTY(R3D_MOD_RENDER.list[R3D_RENDER_LIST_DECAL])) ||
+        (!R3D_LIST_EMPTY(R3D_MOD_RENDER.list[R3D_RENDER_LIST_DECAL_INST]));
 }
 
 /*
@@ -596,8 +490,8 @@ static inline bool r3d_render_is_forward(const r3d_render_call_t* call)
  */
 static inline bool r3d_render_should_cast_shadow(const r3d_render_call_t* call)
 {
-    return (call->mesh.material.transparencyMode == R3D_TRANSPARENCY_DISABLED) ||
-           (call->mesh.material.transparencyMode == R3D_TRANSPARENCY_PREPASS);
+    return (call->mesh.material.transparencyMode == R3D_TRANSPARENCY_OPAQUE) ||
+           (call->mesh.material.transparencyMode == R3D_TRANSPARENCY_HYBRID);
 }
 
 #endif // R3D_MODULE_RENDER_H

--- a/src/modules/r3d_shader.c
+++ b/src/modules/r3d_shader.c
@@ -931,6 +931,8 @@ bool r3d_shader_load_scene_forward(r3d_shader_custom_t* custom)
     GET_LOCATION(forward, uInstancing);
     GET_LOCATION(forward, uSkinning);
     GET_LOCATION(forward, uBillboard);
+    GET_LOCATION(forward, uAlphaCutoff);
+    GET_LOCATION(forward, uCutoffSign);
     GET_LOCATION(forward, uNormalScale);
     GET_LOCATION(forward, uOcclusion);
     GET_LOCATION(forward, uRoughness);
@@ -998,6 +1000,7 @@ bool r3d_shader_load_scene_unlit(r3d_shader_custom_t *custom)
     GET_LOCATION(unlit, uSkinning);
     GET_LOCATION(unlit, uBillboard);
     GET_LOCATION(unlit, uAlphaCutoff);
+    GET_LOCATION(unlit, uCutoffSign);
 
     USE_SHADER(unlit);
 
@@ -1199,6 +1202,8 @@ bool r3d_shader_load_scene_probe_forward(r3d_shader_custom_t* custom)
     GET_LOCATION(probeForward, uInstancing);
     GET_LOCATION(probeForward, uSkinning);
     GET_LOCATION(probeForward, uBillboard);
+    GET_LOCATION(probeForward, uAlphaCutoff);
+    GET_LOCATION(probeForward, uCutoffSign);
     GET_LOCATION(probeForward, uNormalScale);
     GET_LOCATION(probeForward, uOcclusion);
     GET_LOCATION(probeForward, uRoughness);
@@ -1269,6 +1274,7 @@ bool r3d_shader_load_scene_probe_unlit(r3d_shader_custom_t *custom)
     GET_LOCATION(probeUnlit, uSkinning);
     GET_LOCATION(probeUnlit, uBillboard);
     GET_LOCATION(probeUnlit, uAlphaCutoff);
+    GET_LOCATION(probeUnlit, uCutoffSign);
 
     USE_SHADER(probeUnlit);
 

--- a/src/modules/r3d_shader.h
+++ b/src/modules/r3d_shader.h
@@ -857,6 +857,8 @@ typedef struct {
     r3d_shader_uniform_sampler_t uIrradianceTex;
     r3d_shader_uniform_sampler_t uPrefilterTex;
     r3d_shader_uniform_sampler_t uBrdfLutTex;
+    r3d_shader_uniform_float_t uAlphaCutoff;
+    r3d_shader_uniform_float_t uCutoffSign;
     r3d_shader_uniform_float_t uNormalScale;
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
@@ -878,6 +880,7 @@ typedef struct {
     r3d_shader_uniform_int_t uBillboard;
     r3d_shader_uniform_sampler_t uAlbedoMap;
     r3d_shader_uniform_float_t uAlphaCutoff;
+    r3d_shader_uniform_float_t uCutoffSign;
 } r3d_shader_scene_unlit_t;
 
 typedef struct {
@@ -940,6 +943,8 @@ typedef struct {
     r3d_shader_uniform_sampler_t uIrradianceTex;
     r3d_shader_uniform_sampler_t uPrefilterTex;
     r3d_shader_uniform_sampler_t uBrdfLutTex;
+    r3d_shader_uniform_float_t uAlphaCutoff;
+    r3d_shader_uniform_float_t uCutoffSign;
     r3d_shader_uniform_float_t uNormalScale;
     r3d_shader_uniform_float_t uOcclusion;
     r3d_shader_uniform_float_t uRoughness;
@@ -965,6 +970,7 @@ typedef struct {
     r3d_shader_uniform_int_t uBillboard;
     r3d_shader_uniform_sampler_t uAlbedoMap;
     r3d_shader_uniform_float_t uAlphaCutoff;
+    r3d_shader_uniform_float_t uCutoffSign;
 } r3d_shader_scene_probe_unlit_t;
 
 typedef struct {

--- a/src/modules/r3d_target.c
+++ b/src/modules/r3d_target.c
@@ -372,9 +372,9 @@ r3d_target_t r3d_target_swap_scene(r3d_target_t scene)
     return R3D_TARGET_SCENE_0;
 }
 
-void r3d_target_clear(const r3d_target_t* targets, int count, int level, bool depth)
+void r3d_target_bind_clear(const r3d_target_t* targets, int count, int level, bool depth)
 {
-    r3d_target_bind(targets, count, level, depth);
+    r3d_target_bind_load(targets, count, level, depth);
 
     for (int i = 0; i < count; i++)
     {
@@ -387,7 +387,7 @@ void r3d_target_clear(const r3d_target_t* targets, int count, int level, bool de
     }
 }
 
-void r3d_target_bind(const r3d_target_t* targets, int count, int level, bool depth)
+void r3d_target_bind_load(const r3d_target_t* targets, int count, int level, bool depth)
 {
     R3D_ASSERT(count > 0 || depth);
 

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -75,10 +75,6 @@ typedef enum {
     R3D_TARGET_GEOM_NORMAL,     \
     R3D_TARGET_DEPTH            \
 
-#define R3D_TARGET_LIGHTING     \
-    R3D_TARGET_DIFFUSE,         \
-    R3D_TARGET_SPECULAR         \
-
 #define R3D_TARGET_DECAL        \
     R3D_TARGET_ALBEDO,          \
     R3D_TARGET_DIFFUSE,         \

--- a/src/modules/r3d_target.h
+++ b/src/modules/r3d_target.h
@@ -94,15 +94,15 @@ typedef enum {
 #define R3D_TARGET_TEXEL_W  R3D_MOD_TARGET.txlW
 #define R3D_TARGET_TEXEL_H  R3D_MOD_TARGET.txlH
 
-#define R3D_TARGET_CLEAR(level, depth, ...)                             \
-    r3d_target_clear(                                                   \
+#define R3D_TARGET_BIND_CLEAR(level, depth, ...)                        \
+    r3d_target_bind_clear(                                              \
         (r3d_target_t[]) {__VA_ARGS__},                                 \
         sizeof((r3d_target_t[]) {__VA_ARGS__}) / sizeof(r3d_target_t),  \
         (level), (depth)                                                \
     )
 
-#define R3D_TARGET_BIND(level, depth, ...)                              \
-    r3d_target_bind(                                                    \
+#define R3D_TARGET_BIND_LOAD(level, depth, ...)                         \
+    r3d_target_bind_load(                                               \
         (r3d_target_t[]){ __VA_ARGS__ },                                \
         sizeof((r3d_target_t[]) {__VA_ARGS__}) / sizeof(r3d_target_t),  \
         (level), (depth)                                                \
@@ -114,7 +114,7 @@ typedef enum {
  */
 #define R3D_TARGET_BIND_AND_SWAP_SCENE(target)  \
 do {                                            \
-    R3D_TARGET_BIND(0, false, target);          \
+    R3D_TARGET_BIND_LOAD(0, false, target);     \
     target = r3d_target_swap_scene(target);     \
 } while(0)
 
@@ -226,7 +226,7 @@ r3d_target_t r3d_target_swap_scene(r3d_target_t scene);
  * Ensure that the provided target combination is compatible with the specified level.
  * The depth buffer can only be attached when the level is zero.
  */
-void r3d_target_clear(const r3d_target_t* targets, int count, int level, bool depth);
+void r3d_target_bind_clear(const r3d_target_t* targets, int count, int level, bool depth);
 
 /*
  * Creates (or retrieves) and binds an FBO with the requested attachment combination.
@@ -236,7 +236,7 @@ void r3d_target_clear(const r3d_target_t* targets, int count, int level, bool de
  * Ensure that the provided target combination is compatible with the specified level.
  * The depth buffer can only be attached when the level is zero.
  */
-void r3d_target_bind(const r3d_target_t* targets, int count, int level, bool depth);
+void r3d_target_bind_load(const r3d_target_t* targets, int count, int level, bool depth);
 
 /*
  * Sets the viewport according to the specified level.

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -191,9 +191,6 @@ void R3D_End(void)
 
     /* --- Clear all G-Buffer before writing in it --- */
 
-    r3d_driver_enable(GL_DEPTH_TEST);
-    r3d_driver_enable(GL_STENCIL_TEST);
-
     r3d_driver_set_depth_mask(GL_TRUE);
     r3d_driver_set_stencil_mask(0xFF);
 
@@ -1816,6 +1813,8 @@ void pass_prepare_pyramid(void)
     r3d_driver_disable(GL_BLEND);
 
     r3d_driver_enable(GL_DEPTH_TEST);
+
+    r3d_driver_set_stencil_mask(0x00);
     r3d_driver_set_depth_mask(GL_TRUE);
     r3d_driver_set_depth_func(GL_ALWAYS);
 
@@ -1838,6 +1837,8 @@ void pass_prepare_downsample(r3d_target_t target, int level)
     r3d_driver_disable(GL_BLEND);
 
     r3d_driver_enable(GL_DEPTH_TEST);
+
+    r3d_driver_set_stencil_mask(0x00);
     r3d_driver_set_depth_mask(GL_FALSE);
     r3d_driver_set_depth_func(GL_GREATER);
 
@@ -1858,6 +1859,8 @@ r3d_target_t pass_prepare_ssao(void)
     r3d_driver_disable(GL_BLEND);
 
     r3d_driver_enable(GL_DEPTH_TEST);
+
+    r3d_driver_set_stencil_mask(0x00);
     r3d_driver_set_depth_mask(GL_FALSE);
     r3d_driver_set_depth_func(GL_GREATER);
 
@@ -1901,6 +1904,8 @@ r3d_target_t pass_prepare_ssil(void)
     r3d_driver_disable(GL_BLEND);
 
     r3d_driver_enable(GL_DEPTH_TEST);
+
+    r3d_driver_set_stencil_mask(0x00);
     r3d_driver_set_depth_mask(GL_FALSE);
     r3d_driver_set_depth_func(GL_GREATER);
 
@@ -1952,6 +1957,8 @@ r3d_target_t pass_prepare_ssgi(void)
     r3d_driver_disable(GL_BLEND);
 
     r3d_driver_enable(GL_DEPTH_TEST);
+
+    r3d_driver_set_stencil_mask(0x00);
     r3d_driver_set_depth_mask(GL_FALSE);
     r3d_driver_set_depth_func(GL_GREATER);
 
@@ -2039,6 +2046,8 @@ r3d_target_t pass_prepare_ssr(void)
     r3d_driver_disable(GL_BLEND);
 
     r3d_driver_enable(GL_DEPTH_TEST);
+
+    r3d_driver_set_stencil_mask(0x00);
     r3d_driver_set_depth_mask(GL_FALSE);
     r3d_driver_set_depth_func(GL_GREATER);
 
@@ -2194,8 +2203,10 @@ void pass_deferred_compose(r3d_target_t sceneTarget, r3d_target_t ssrSource)
     r3d_driver_disable(GL_BLEND);
 
     r3d_driver_enable(GL_DEPTH_TEST);
-    r3d_driver_set_depth_func(GL_GREATER);
+
+    r3d_driver_set_stencil_mask(0x00);
     r3d_driver_set_depth_mask(GL_FALSE);
+    r3d_driver_set_depth_func(GL_GREATER);
 
     R3D_TARGET_BIND_CLEAR(0, true, sceneTarget);
     R3D_SHADER_USE(deferred.compose);

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -2317,12 +2317,10 @@ void pass_scene_forward(r3d_target_t sceneTarget)
     r3d_driver_set_depth_mask(GL_TRUE);
 
     #define COND (IS_MESH_VISIBLE_CAMERA(call->mesh.instance) && (call->mesh.material.unlit))
-
     R3D_RENDER_FOR_EACH(call, COND, &R3D.viewState.frustum, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
     {
         raster_unlit(call);
     }
-
     #undef COND
 
     /* --- Render all lit/unlit blended --- */

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -70,7 +70,7 @@ static void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_prob
 static void raster_geometry(const r3d_render_call_t* call);
 static void raster_decal(const r3d_render_call_t* call);
 static void raster_forward(const r3d_render_call_t* call);
-static void raster_unlit(const r3d_render_call_t* call);
+static void raster_unlit(const r3d_render_call_t* call, bool opaque);
 
 static void pass_scene_shadows(void);
 static void pass_scene_probes(void);
@@ -1533,7 +1533,7 @@ void raster_forward(const r3d_render_call_t* call)
     }
 }
 
-void raster_unlit(const r3d_render_call_t* call)
+void raster_unlit(const r3d_render_call_t* call, bool opaque)
 {
     R3D_ASSERT(call->type == R3D_RENDER_CALL_MESH); //< Paranoid assert, should be fine
 
@@ -1575,9 +1575,12 @@ void raster_unlit(const r3d_render_call_t* call)
 
     /* --- Set color material maps --- */
 
+    bool hybrid = (material->transparencyMode == R3D_TRANSPARENCY_HYBRID);
+    float cutoffSign = opaque ? 1.0f : (hybrid ? -1.0f : 0.0f);
+
     R3D_SHADER_SET_COL4_SELECT(scene.unlit, shader, uAlbedoColor, material->albedo.color);
     R3D_SHADER_SET_FLOAT_SELECT(scene.unlit, shader, uAlphaCutoff, material->alphaCutoff);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.unlit, shader, uCutoffSign, (material->transparencyMode == R3D_TRANSPARENCY_HYBRID) ? -1.0f : 1.0f);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.unlit, shader, uCutoffSign, cutoffSign);
 
     /* --- Bind active texture maps --- */
 
@@ -2332,7 +2335,7 @@ void pass_scene_forward(r3d_target_t sceneTarget)
     #define COND (IS_MESH_VISIBLE_CAMERA(call->mesh.instance) && (call->mesh.material.unlit))
     R3D_RENDER_FOR_EACH(call, COND, &R3D.viewState.frustum, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
     {
-        raster_unlit(call);
+        raster_unlit(call, true);
     }
     #undef COND
 
@@ -2349,7 +2352,7 @@ void pass_scene_forward(r3d_target_t sceneTarget)
         }
         else
         {
-            raster_unlit(call);
+            raster_unlit(call, false);
         }
     }
 

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -189,6 +189,16 @@ void R3D_End(void)
     r3d_render_sort_list(R3D_RENDER_LIST_BLEND_INST, R3D.viewState.camera.position, R3D_RENDER_SORT_MATERIAL_ONLY);
     r3d_render_sort_list(R3D_RENDER_LIST_DECAL_INST, R3D.viewState.camera.position, R3D_RENDER_SORT_MATERIAL_ONLY);
 
+    /* --- Clear all G-Buffer before writing in it --- */
+
+    r3d_driver_enable(GL_DEPTH_TEST);
+    r3d_driver_enable(GL_STENCIL_TEST);
+
+    r3d_driver_set_depth_mask(GL_TRUE);
+    r3d_driver_set_stencil_mask(0xFF);
+
+    R3D_TARGET_BIND_CLEAR(0, true, R3D_TARGET_ALL_DEFERRED);
+
     /* --- Deferred path for opaques and decals --- */
 
     r3d_target_t sceneTarget = R3D_TARGET_SCENE_0;
@@ -200,7 +210,11 @@ void R3D_End(void)
     if (r3d_render_has_opaque())
     {
         pass_scene_opaque();
-        pass_deferred_lights();
+
+        if (r3d_light_has_visible())
+        {
+            pass_deferred_lights();
+        }
 
         bool ssao = R3D.environment.ssao.enabled;
         bool ssil = R3D.environment.ssil.enabled;
@@ -228,16 +242,7 @@ void R3D_End(void)
     }
     else
     {
-        r3d_driver_enable(GL_DEPTH_TEST);
-        r3d_driver_enable(GL_STENCIL_TEST);
-
-        r3d_driver_set_depth_mask(GL_TRUE);
-        r3d_driver_set_stencil_mask(0xFF);
-
-        // Clear g-buffer and those for deferred passes to keep clean state
-        R3D_TARGET_BIND_CLEAR(0, true, R3D_TARGET_ALL_DEFERRED);
-
-        // And clear all depth levels (needed for next passes like DoF)
+        // And clear all depth levels, needed for next passes like DoF
         int numLevels = r3d_target_get_num_levels(R3D_TARGET_DEPTH);
         for (int i = 1; i < numLevels; i++)
         {
@@ -1767,14 +1772,14 @@ void pass_scene_opaque(void)
     r3d_driver_set_depth_mask(GL_TRUE);
     r3d_driver_set_stencil_mask(0xFF);
 
-    R3D_TARGET_BIND_CLEAR(0, true, R3D_TARGET_GBUFFER);
+    R3D_TARGET_BIND_LOAD(0, true, R3D_TARGET_GBUFFER);
 
     #define COND (IS_MESH_VISIBLE_CAMERA(call->mesh.instance) && (!call->mesh.material.unlit))
-
     R3D_RENDER_FOR_EACH(call, COND, &R3D.viewState.frustum, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
     {
         raster_geometry(call);
     }
+    #undef COND
 
     r3d_driver_set_depth_offset(0.0f, 0.0f);
     r3d_driver_set_depth_range(0.0f, 1.0f);
@@ -1800,8 +1805,6 @@ void pass_scene_opaque(void)
 
         glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
     }
-
-    #undef COND
 }
 
 void pass_prepare_pyramid(void)
@@ -2087,27 +2090,22 @@ r3d_target_t pass_prepare_ssr(void)
 
 void pass_deferred_lights(void)
 {
-    /* --- Bind and clear lighting buffers --- */
-
-    r3d_driver_enable(GL_DEPTH_TEST);
-    r3d_driver_set_depth_mask(GL_FALSE);
-    R3D_TARGET_BIND_CLEAR(0, true, R3D_TARGET_LIGHTING);
-
-    if (!r3d_light_has_visible()) return;
-
     /* --- Setup OpenGL pipeline --- */
 
     r3d_driver_disable(GL_STENCIL_TEST);
     r3d_driver_disable(GL_CULL_FACE);
 
     r3d_driver_enable(GL_SCISSOR_TEST);
+    r3d_driver_enable(GL_DEPTH_TEST);
     r3d_driver_enable(GL_BLEND);
 
     r3d_driver_set_blend_func(GL_FUNC_ADD, GL_ONE, GL_ONE);
     r3d_driver_set_depth_func(GL_GREATER);
+    r3d_driver_set_depth_mask(GL_FALSE);
 
-    /* --- Enable shader and setup constant stuff --- */
+    /* --- Bind FBO and shader then setup constant stuff --- */
 
+    R3D_TARGET_BIND_LOAD(0, true, R3D_TARGET_DIFFUSE, R3D_TARGET_SPECULAR);
     R3D_SHADER_USE(deferred.lighting);
 
     R3D_SHADER_BIND_SAMPLER(deferred.lighting, uAlbedoTex, r3d_target_get_level(R3D_TARGET_ALBEDO, 0));
@@ -2173,7 +2171,7 @@ void pass_deferred_ambient(r3d_target_t ssaoSource, r3d_target_t ssilSource, r3d
 
     /* --- Calculation and composition of ambient/indirect lighting --- */
 
-    R3D_TARGET_BIND_LOAD(0, true, R3D_TARGET_LIGHTING);
+    R3D_TARGET_BIND_LOAD(0, true, R3D_TARGET_DIFFUSE, R3D_TARGET_SPECULAR);
     R3D_SHADER_USE(deferred.ambient);
 
     R3D_SHADER_BIND_SAMPLER(deferred.ambient, uAlbedoTex, r3d_target_get_level(R3D_TARGET_ALBEDO, 0));

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -67,16 +67,14 @@ static void raster_depth(const r3d_render_call_t* call, const Matrix* viewProj, 
 static void raster_depth_cube(const r3d_render_call_t* call, const Matrix* viewProj, const r3d_light_shadow_job_t* shadowJob);
 static void raster_probe_forward(const r3d_render_call_t* call, const r3d_env_probe_job_t* job, int face);
 static void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_probe_job_t* job, int face);
-static void raster_geometry(const r3d_render_call_t* call, bool matchPrepass);
+static void raster_geometry(const r3d_render_call_t* call);
 static void raster_decal(const r3d_render_call_t* call);
 static void raster_forward(const r3d_render_call_t* call);
 static void raster_unlit(const r3d_render_call_t* call);
 
 static void pass_scene_shadows(void);
 static void pass_scene_probes(void);
-static void pass_scene_geometry(void);
-static void pass_scene_prepass(void);
-static void pass_scene_decals(void);
+static void pass_scene_opaque(void);
 
 static void pass_prepare_pyramid(void);
 static void pass_prepare_downsample(r3d_target_t target, int level);
@@ -199,17 +197,10 @@ void R3D_End(void)
     r3d_target_t ssgiSource  = R3D_TARGET_INVALID;
     r3d_target_t ssrSource   = R3D_TARGET_INVALID;
 
-    r3d_driver_set_depth_mask(GL_TRUE);
-    r3d_driver_set_stencil_mask(0xFF);
-
-    R3D_TARGET_CLEAR(0, true, R3D_TARGET_ALL_DEFERRED);
-
     if (r3d_render_has_deferred() || r3d_render_has_prepass())
     {
-        if (r3d_render_has_deferred()) pass_scene_geometry();
-        if (r3d_render_has_prepass())  pass_scene_prepass();
-        if (r3d_render_has_decal())    pass_scene_decals();
-        if (r3d_light_has_visible())   pass_deferred_lights();
+        pass_scene_opaque();
+        pass_deferred_lights();
 
         bool ssao = R3D.environment.ssao.enabled;
         bool ssil = R3D.environment.ssil.enabled;
@@ -237,10 +228,20 @@ void R3D_End(void)
     }
     else
     {
+        r3d_driver_enable(GL_DEPTH_TEST);
+        r3d_driver_enable(GL_STENCIL_TEST);
+
+        r3d_driver_set_depth_mask(GL_TRUE);
+        r3d_driver_set_stencil_mask(0xFF);
+
+        // Clear g-buffer and those for deferred passes to keep clean state
+        R3D_TARGET_BIND_CLEAR(0, true, R3D_TARGET_ALL_DEFERRED);
+
+        // And clear all depth levels (needed for next passes like DoF)
         int numLevels = r3d_target_get_num_levels(R3D_TARGET_DEPTH);
         for (int i = 1; i < numLevels; i++)
         {
-            R3D_TARGET_CLEAR(i, true, R3D_TARGET_DEPTH);
+            R3D_TARGET_BIND_CLEAR(i, true, R3D_TARGET_DEPTH);
         }
     }
 
@@ -981,6 +982,7 @@ void upload_fx_block(void)
 void raster_depth(const r3d_render_call_t* call, const Matrix* viewProj, const r3d_light_shadow_job_t* shadowJob)
 {
     R3D_ASSERT(call->type == R3D_RENDER_CALL_MESH); //< Paranoid assert, should be fine
+    R3D_ASSERT(shadowJob != NULL);                  //< Only used for shadow maps
 
     const r3d_render_group_t* group = r3d_render_get_call_group(call);
     const R3D_Material* material = &call->mesh.material;
@@ -1025,28 +1027,11 @@ void raster_depth(const r3d_render_call_t* call, const Matrix* viewProj, const r
 
     R3D_SHADER_BIND_SAMPLER_SELECT(scene.depth, shader, uAlbedoMap, R3D_TEXTURE_SELECT(material->albedo.texture.id, WHITE));
     R3D_SHADER_SET_COL4_SELECT(scene.depth, shader, uAlbedoColor, material->albedo.color);
-
-    if (material->transparencyMode == R3D_TRANSPARENCY_PREPASS)
-    {
-        R3D_SHADER_SET_FLOAT_SELECT(scene.depth, shader, uAlphaCutoff, (shadowJob != NULL) ? 0.1f : 0.99f);
-    }
-    else
-    {
-        R3D_SHADER_SET_FLOAT_SELECT(scene.depth, shader, uAlphaCutoff, material->alphaCutoff);
-    }
+    R3D_SHADER_SET_FLOAT_SELECT(scene.depth, shader, uAlphaCutoff, material->alphaCutoff);
 
     /* --- Applying material parameters that are independent of shaders --- */
 
-    if (shadowJob != NULL)
-    {
-        r3d_driver_set_shadow_cast_mode(mesh->shadowCastMode, material->cullMode);
-    }
-    else
-    {
-        r3d_driver_set_depth_state(material->depth);
-        r3d_driver_set_stencil_state(material->stencil);
-        r3d_driver_set_cull_mode(material->cullMode);
-    }
+    r3d_driver_set_shadow_cast_mode(mesh->shadowCastMode, material->cullMode);
 
     /* --- Rendering the object corresponding to the draw call --- */
 
@@ -1065,6 +1050,7 @@ void raster_depth(const r3d_render_call_t* call, const Matrix* viewProj, const r
 void raster_depth_cube(const r3d_render_call_t* call, const Matrix* viewProj, const r3d_light_shadow_job_t* shadowJob)
 {
     R3D_ASSERT(call->type == R3D_RENDER_CALL_MESH); //< Paranoid assert, should be fine
+    R3D_ASSERT(shadowJob != NULL);                  //< Only used for shadow maps
 
     const r3d_render_group_t* group = r3d_render_get_call_group(call);
     const R3D_Material* material = &call->mesh.material;
@@ -1077,11 +1063,8 @@ void raster_depth_cube(const r3d_render_call_t* call, const Matrix* viewProj, co
 
     /* --- Set shadow related data --- */
 
-    if (shadowJob != NULL)
-    {
-        R3D_SHADER_SET_FLOAT_SELECT(scene.depthCube, shader, uFar, shadowJob->far);
-        R3D_SHADER_SET_VEC3_SELECT(scene.depthCube, shader, uViewPosition, shadowJob->position);
-    }
+    R3D_SHADER_SET_FLOAT_SELECT(scene.depthCube, shader, uFar, shadowJob->far);
+    R3D_SHADER_SET_VEC3_SELECT(scene.depthCube, shader, uViewPosition, shadowJob->position);
 
     /* --- Send matrices --- */
 
@@ -1117,28 +1100,11 @@ void raster_depth_cube(const r3d_render_call_t* call, const Matrix* viewProj, co
 
     R3D_SHADER_BIND_SAMPLER_SELECT(scene.depthCube, shader, uAlbedoMap, R3D_TEXTURE_SELECT(material->albedo.texture.id, WHITE));
     R3D_SHADER_SET_COL4_SELECT(scene.depthCube, shader, uAlbedoColor, material->albedo.color);
-
-    if (material->transparencyMode == R3D_TRANSPARENCY_PREPASS)
-    {
-        R3D_SHADER_SET_FLOAT_SELECT(scene.depthCube, shader, uAlphaCutoff, (shadowJob != NULL) ? 0.1f : 0.99f);
-    }
-    else
-    {
-        R3D_SHADER_SET_FLOAT_SELECT(scene.depthCube, shader, uAlphaCutoff, material->alphaCutoff);
-    }
+    R3D_SHADER_SET_FLOAT_SELECT(scene.depthCube, shader, uAlphaCutoff, material->alphaCutoff);
 
     /* --- Applying material parameters that are independent of shaders --- */
 
-    if (shadowJob != NULL)
-    {
-        r3d_driver_set_shadow_cast_mode(mesh->shadowCastMode, material->cullMode);
-    }
-    else
-    {
-        r3d_driver_set_depth_state(material->depth);
-        r3d_driver_set_stencil_state(material->stencil);
-        r3d_driver_set_cull_mode(material->cullMode);
-    }
+    r3d_driver_set_shadow_cast_mode(mesh->shadowCastMode, material->cullMode);
 
     /* --- Rendering the object corresponding to the draw call --- */
 
@@ -1282,10 +1248,6 @@ void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_probe_job_t
 
     R3D_SHADER_SET_INT_SELECT(scene.probeUnlit, shader, uBillboard, material->billboardMode);
 
-    /* --- Set misc material values --- */
-
-    R3D_SHADER_SET_FLOAT_SELECT(scene.probeUnlit, shader, uAlphaCutoff, material->alphaCutoff);
-
     /* --- Set texcoord offset/scale --- */
 
     R3D_SHADER_SET_VEC2_SELECT(scene.probeUnlit, shader, uTexCoordOffset, material->uvOffset);
@@ -1294,6 +1256,7 @@ void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_probe_job_t
     /* --- Set color material maps --- */
 
     R3D_SHADER_SET_COL4_SELECT(scene.probeUnlit, shader, uAlbedoColor, material->albedo.color);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.probeUnlit, shader, uAlphaCutoff, material->alphaCutoff);
 
     /* --- Bind active texture maps --- */
 
@@ -1320,7 +1283,7 @@ void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_probe_job_t
     }
 }
 
-void raster_geometry(const r3d_render_call_t* call, bool matchPrepass)
+void raster_geometry(const r3d_render_call_t* call)
 {
     R3D_ASSERT(call->type == R3D_RENDER_CALL_MESH); //< Paranoid assert, should be fine
 
@@ -1364,10 +1327,6 @@ void raster_geometry(const r3d_render_call_t* call, bool matchPrepass)
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uMetalness, Clamp(material->orm.metalness, 0.0f, 1.0f));
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uSpecular, Clamp(material->orm.specular, 0.0f, 1.0f));
 
-    /* --- Set misc material values --- */
-
-    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uAlphaCutoff, material->alphaCutoff);
-
     /* --- Set texcoord offset/scale --- */
 
     R3D_SHADER_SET_VEC2_SELECT(scene.geometry, shader, uTexCoordOffset, material->uvOffset);
@@ -1377,6 +1336,7 @@ void raster_geometry(const r3d_render_call_t* call, bool matchPrepass)
 
     R3D_SHADER_SET_COL4_SELECT(scene.geometry, shader, uAlbedoColor, material->albedo.color);
     R3D_SHADER_SET_COL3_SELECT(scene.geometry, shader, uEmissionColor, material->emission.color);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uAlphaCutoff, material->alphaCutoff);
 
     /* --- Bind active texture maps --- */
 
@@ -1387,18 +1347,9 @@ void raster_geometry(const r3d_render_call_t* call, bool matchPrepass)
 
     /* --- Applying material parameters that are independent of shaders --- */
 
-    if (matchPrepass)
-    {
-        r3d_driver_set_depth_offset(material->depth.offsetUnits, material->depth.offsetFactor);
-        r3d_driver_set_depth_range(material->depth.rangeNear, material->depth.rangeFar);
-    }
-    else
-    {
-        r3d_driver_set_depth_state(material->depth);
-        r3d_driver_set_stencil_state(material->stencil);
-    }
-
     r3d_driver_set_cull_mode(material->cullMode);
+    r3d_driver_set_depth_state(material->depth);
+    r3d_driver_set_stencil_state(material->stencil);
 
     /* --- Rendering the object corresponding to the draw call --- */
 
@@ -1447,10 +1398,6 @@ void raster_decal(const r3d_render_call_t* call)
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uMetalness, Clamp(decal->orm.metalness, 0.0f, 1.0f));
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uSpecular, Clamp(decal->orm.specular, 0.0f, 1.0f));
 
-    /* --- Set misc material values --- */
-
-    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uAlphaCutoff, decal->alphaCutoff);
-
     /* --- Set texcoord offset/scale --- */
 
     R3D_SHADER_SET_VEC2_SELECT(scene.decal, shader, uTexCoordOffset, decal->uvOffset);
@@ -1460,6 +1407,7 @@ void raster_decal(const r3d_render_call_t* call)
 
     R3D_SHADER_SET_COL4_SELECT(scene.decal, shader, uAlbedoColor, decal->albedo.color);
     R3D_SHADER_SET_COL3_SELECT(scene.decal, shader, uEmissionColor, decal->emission.color);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uAlphaCutoff, decal->alphaCutoff);
 
     /* --- Set decal specific values --- */
 
@@ -1610,10 +1558,6 @@ void raster_unlit(const r3d_render_call_t* call)
 
     R3D_SHADER_SET_INT_SELECT(scene.unlit, shader, uBillboard, material->billboardMode);
 
-    /* --- Set misc material values --- */
-
-    R3D_SHADER_SET_FLOAT_SELECT(scene.unlit, shader, uAlphaCutoff, material->alphaCutoff);
-
     /* --- Set texcoord offset/scale --- */
 
     R3D_SHADER_SET_VEC2_SELECT(scene.unlit, shader, uTexCoordOffset, material->uvOffset);
@@ -1622,6 +1566,7 @@ void raster_unlit(const r3d_render_call_t* call)
     /* --- Set color material maps --- */
 
     R3D_SHADER_SET_COL4_SELECT(scene.unlit, shader, uAlbedoColor, material->albedo.color);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.unlit, shader, uAlphaCutoff, material->alphaCutoff);
 
     /* --- Bind active texture maps --- */
 
@@ -1791,98 +1736,65 @@ void pass_scene_probes(void)
     }
 }
 
-void pass_scene_geometry(void)
+void pass_scene_opaque(void)
 {
-    R3D_TARGET_BIND(0, true, R3D_TARGET_GBUFFER);
-
     r3d_driver_enable(GL_STENCIL_TEST);
     r3d_driver_enable(GL_DEPTH_TEST);
-    r3d_driver_disable(GL_BLEND);
-
-    r3d_driver_set_depth_mask(GL_TRUE);
-
-    const R3D_Frustum* frustum = &R3D.viewState.frustum;
-    R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), frustum, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
-    {
-        if (!call->mesh.material.unlit)
-        {
-            raster_geometry(call, false);
-        }
-    }
-
-    r3d_driver_set_depth_offset(0.0f, 0.0f);
-    r3d_driver_set_depth_range(0.0f, 1.0f);
-}
-
-void pass_scene_prepass(void)
-{
-    /* --- First render only depth --- */
-
-    r3d_target_bind(NULL, 0, 0, true);
-
-    r3d_driver_enable(GL_STENCIL_TEST);
-    r3d_driver_enable(GL_DEPTH_TEST);
-
-    r3d_driver_set_depth_mask(GL_TRUE);
-
-    const R3D_Frustum* frustum = &R3D.viewState.frustum;
-    R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), frustum, R3D_RENDER_LIST_TRANSPARENT_INST, R3D_RENDER_LIST_TRANSPARENT)
-    {
-        if (r3d_render_is_prepass(call))
-        {
-            raster_depth(call, &R3D.viewState.viewProj, NULL);
-        }
-    }
-
-    /* --- Render opaque only with GL_EQUAL --- */
-
-    // NOTE: The transparent part will be rendered in forward
-    R3D_TARGET_BIND(0, true, R3D_TARGET_GBUFFER);
-
-    r3d_driver_disable(GL_STENCIL_TEST);
-    r3d_driver_disable(GL_BLEND);
-
-    r3d_driver_set_depth_func(GL_EQUAL);
-    r3d_driver_set_depth_mask(GL_FALSE);
-
-    R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), frustum, R3D_RENDER_LIST_TRANSPARENT_INST, R3D_RENDER_LIST_TRANSPARENT)
-    {
-        if (r3d_render_is_prepass(call))
-        {
-            raster_geometry(call, true);
-        }
-    }
-
-    /* --- Reset undesired states --- */
-
-    r3d_driver_set_depth_offset(0.0f, 0.0f);
-    r3d_driver_set_depth_range(0.0f, 1.0f);
-}
-
-void pass_scene_decals(void)
-{
-    R3D_TARGET_BIND(0, false, R3D_TARGET_DECAL);
-
-    r3d_driver_disable(GL_STENCIL_TEST);
-    r3d_driver_disable(GL_DEPTH_TEST);
     r3d_driver_enable(GL_CULL_FACE);
-    r3d_driver_enable(GL_BLEND);
+    r3d_driver_disable(GL_BLEND);
 
-    r3d_driver_set_cull_face(GL_FRONT); // Only render back faces to avoid clipping issues
+    r3d_driver_set_depth_mask(GL_TRUE);
+    r3d_driver_set_stencil_mask(0xFF);
 
-    // FIXME: The decal shader uses the alpha channel of the ORM attachment as a blend factor,
-    //        but this channel now stores the material specular (F0) written during the geometry
-    //        pass. We mask alpha writes to preserve the underlying specular, at the cost of
-    //        making orm.specular ineffective for decals.
-    glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
+    R3D_TARGET_BIND_CLEAR(0, true, R3D_TARGET_GBUFFER);
 
-    const R3D_Frustum* frustum = &R3D.viewState.frustum;
-    R3D_RENDER_FOR_EACH(call, true, frustum, R3D_RENDER_LIST_DECAL_INST, R3D_RENDER_LIST_DECAL)
+    if (r3d_render_has_deferred())
     {
-        raster_decal(call);
+        R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), NULL, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
+        {
+            if (!call->mesh.material.unlit)
+            {
+                raster_geometry(call);
+            }
+        }
     }
 
-    glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    if (r3d_render_has_prepass())
+    {
+        R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), NULL, R3D_RENDER_LIST_TRANSPARENT_INST, R3D_RENDER_LIST_TRANSPARENT)
+        {
+            if (r3d_render_is_prepass(call))
+            {
+                raster_geometry(call);
+            }
+        }
+    }
+
+    r3d_driver_set_depth_offset(0.0f, 0.0f);
+    r3d_driver_set_depth_range(0.0f, 1.0f);
+
+    if (r3d_render_has_decal())
+    {
+        r3d_driver_disable(GL_STENCIL_TEST);
+        r3d_driver_disable(GL_DEPTH_TEST);
+        r3d_driver_enable(GL_BLEND);
+
+        r3d_driver_set_cull_face(GL_FRONT); // Only render back faces to avoid clipping issues
+
+        // FIXME: The decal shader uses the alpha channel of the ORM attachment as a blend factor,
+        //        but this channel now stores the material specular (F0) written during the geometry
+        //        pass. We mask alpha writes to preserve the underlying specular, at the cost of
+        //        making orm.specular ineffective for decals.
+        glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
+
+        const R3D_Frustum* frustum = &R3D.viewState.frustum;
+        R3D_RENDER_FOR_EACH(call, true, frustum, R3D_RENDER_LIST_DECAL_INST, R3D_RENDER_LIST_DECAL)
+        {
+            raster_decal(call);
+        }
+
+        glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    }
 }
 
 void pass_prepare_pyramid(void)
@@ -1901,7 +1813,7 @@ void pass_prepare_pyramid(void)
 
     for (int iDst = 1; iDst <= maxLevel; iDst++)
     {
-        R3D_TARGET_BIND(iDst, true, R3D_TARGET_DEPTH, R3D_TARGET_SELECTOR);
+        R3D_TARGET_BIND_CLEAR(iDst, true, R3D_TARGET_DEPTH, R3D_TARGET_SELECTOR);
         R3D_SHADER_BIND_SAMPLER(prepare.pyramid, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, iDst - 1));
         R3D_RENDER_SCREEN();
     }
@@ -1910,12 +1822,16 @@ void pass_prepare_pyramid(void)
 void pass_prepare_downsample(r3d_target_t target, int level)
 {
     r3d_driver_disable(GL_STENCIL_TEST);
-    r3d_driver_disable(GL_DEPTH_TEST);
     r3d_driver_disable(GL_CULL_FACE);
     r3d_driver_disable(GL_BLEND);
 
+    r3d_driver_enable(GL_DEPTH_TEST);
+    r3d_driver_set_depth_mask(GL_FALSE);
+    r3d_driver_set_depth_func(GL_GREATER);
+
+    R3D_TARGET_BIND_CLEAR(level, true, target);
+
     R3D_SHADER_USE(prepare.downsample);
-    R3D_TARGET_BIND(level, false, target);
     R3D_SHADER_BIND_SAMPLER(prepare.downsample, uSelectorTex, r3d_target_get_level(R3D_TARGET_SELECTOR, level));
     R3D_SHADER_BIND_SAMPLER(prepare.downsample, uSourceTex, r3d_target_get_level(target, level - 1));
     R3D_RENDER_SCREEN();
@@ -1935,7 +1851,7 @@ r3d_target_t pass_prepare_ssao(void)
 
     /* --- Calculate SSAO --- */
 
-    R3D_TARGET_BIND(1, true, R3D_TARGET_SSAO_0);
+    R3D_TARGET_BIND_CLEAR(1, true, R3D_TARGET_SSAO_0);
     R3D_SHADER_USE(prepare.ssao);
 
     R3D_SHADER_BIND_SAMPLER(prepare.ssao, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
@@ -1945,7 +1861,7 @@ r3d_target_t pass_prepare_ssao(void)
 
     /* --- Denoise SSAO --- */
 
-    R3D_TARGET_BIND(1, true, R3D_TARGET_SSAO_1);
+    R3D_TARGET_BIND_CLEAR(1, true, R3D_TARGET_SSAO_1);
     R3D_SHADER_USE(prepare.denoiserSparse);
 
     R3D_SHADER_BIND_SAMPLER(prepare.denoiserSparse, uNormalTex, r3d_target_get_level(R3D_TARGET_NORMAL, 1));
@@ -1978,7 +1894,7 @@ r3d_target_t pass_prepare_ssil(void)
 
     /* --- Calculate SSIL --- */
 
-    R3D_TARGET_BIND(1, true, R3D_TARGET_SSIL_0);
+    R3D_TARGET_BIND_CLEAR(1, true, R3D_TARGET_SSIL_0);
     R3D_SHADER_USE(prepare.ssil);
 
     R3D_SHADER_BIND_SAMPLER(prepare.ssil, uDiffuseTex, r3d_target_get_level(R3D_TARGET_DIFFUSE, 1));
@@ -2003,7 +1919,7 @@ r3d_target_t pass_prepare_ssil(void)
     float radius = 16.0f;
     for (int i = 0; i < 3; i++, radius *= 0.5f)
     {
-        R3D_TARGET_BIND(1, true, dst);
+        R3D_TARGET_BIND_CLEAR(1, true, dst);
         R3D_SHADER_SET_FLOAT(prepare.denoiserSparse, uBlurRadius, radius);
         R3D_SHADER_SET_FLOAT(prepare.denoiserSparse, uInvBlurRadius2, 1.0f / (radius * radius));
         R3D_SHADER_BIND_SAMPLER(prepare.denoiserSparse, uSourceTex, r3d_target_get(src));
@@ -2029,7 +1945,7 @@ r3d_target_t pass_prepare_ssgi(void)
 
     /* --- Calculate SSGI (RAW) --- */
 
-    R3D_TARGET_BIND(1, true, R3D_TARGET_SSGI_0);
+    R3D_TARGET_BIND_CLEAR(1, true, R3D_TARGET_SSGI_0);
     R3D_SHADER_USE(prepare.ssgi);
 
     R3D_SHADER_BIND_SAMPLER(prepare.ssgi, uDiffuseTex, r3d_target_get_level(R3D_TARGET_DIFFUSE, 1));
@@ -2084,7 +2000,7 @@ r3d_target_t pass_prepare_ssgi(void)
         {
             float invStepWidth2 = 1.0f / (stepWidth[i]*stepWidth[i]);
 
-            R3D_TARGET_BIND(1, true, dst);
+            R3D_TARGET_BIND_CLEAR(1, true, dst);
             R3D_SHADER_BIND_SAMPLER(prepare.denoiserAtrous, uSourceTex, r3d_target_get(src));
             R3D_SHADER_SET_FLOAT(prepare.denoiserAtrous, uInvStepWidth2, invStepWidth2);
             R3D_SHADER_SET_INT(prepare.denoiserAtrous, uStepWidth, stepWidth[i]);
@@ -2119,7 +2035,7 @@ r3d_target_t pass_prepare_ssr(void)
 
     /* --- Calculate SSR --- */
 
-    R3D_TARGET_BIND(minLevel, true, R3D_TARGET_SSR);
+    R3D_TARGET_BIND_CLEAR(minLevel, true, R3D_TARGET_SSR);
     R3D_SHADER_USE(prepare.ssr);
 
     R3D_SHADER_BIND_SAMPLER(prepare.ssr, uDiffuseTex, r3d_target_get_level(R3D_TARGET_DIFFUSE, 1));
@@ -2164,21 +2080,24 @@ r3d_target_t pass_prepare_ssr(void)
 
 void pass_deferred_lights(void)
 {
-    /* --- Setup OpenGL pipeline --- */
+    /* --- Bind and clear lighting buffers --- */
 
-    R3D_TARGET_BIND(0, true, R3D_TARGET_LIGHTING);
+    r3d_driver_enable(GL_DEPTH_TEST);
+    r3d_driver_set_depth_mask(GL_FALSE);
+    R3D_TARGET_BIND_CLEAR(0, true, R3D_TARGET_LIGHTING);
+
+    if (!r3d_light_has_visible()) return;
+
+    /* --- Setup OpenGL pipeline --- */
 
     r3d_driver_disable(GL_STENCIL_TEST);
     r3d_driver_disable(GL_CULL_FACE);
 
     r3d_driver_enable(GL_SCISSOR_TEST);
-    r3d_driver_enable(GL_DEPTH_TEST);
     r3d_driver_enable(GL_BLEND);
 
-    // Set additive blending to accumulate light contributions
     r3d_driver_set_blend_func(GL_FUNC_ADD, GL_ONE, GL_ONE);
     r3d_driver_set_depth_func(GL_GREATER);
-    r3d_driver_set_depth_mask(GL_FALSE);
 
     /* --- Enable shader and setup constant stuff --- */
 
@@ -2247,7 +2166,7 @@ void pass_deferred_ambient(r3d_target_t ssaoSource, r3d_target_t ssilSource, r3d
 
     /* --- Calculation and composition of ambient/indirect lighting --- */
 
-    R3D_TARGET_BIND(0, true, R3D_TARGET_LIGHTING);
+    R3D_TARGET_BIND_LOAD(0, true, R3D_TARGET_LIGHTING);
     R3D_SHADER_USE(deferred.ambient);
 
     R3D_SHADER_BIND_SAMPLER(deferred.ambient, uAlbedoTex, r3d_target_get_level(R3D_TARGET_ALBEDO, 0));
@@ -2271,7 +2190,7 @@ void pass_deferred_compose(r3d_target_t sceneTarget, r3d_target_t ssrSource)
     r3d_driver_set_depth_func(GL_GREATER);
     r3d_driver_set_depth_mask(GL_FALSE);
 
-    R3D_TARGET_BIND(0, true, sceneTarget);
+    R3D_TARGET_BIND_CLEAR(0, true, sceneTarget);
     R3D_SHADER_USE(deferred.compose);
 
     R3D_SHADER_BIND_SAMPLER(deferred.compose, uAlbedoTex, r3d_target_get_level(R3D_TARGET_ALBEDO, 0));
@@ -2294,7 +2213,7 @@ void pass_deferred_fog(r3d_target_t sceneTarget)
     r3d_driver_enable(GL_BLEND);
     r3d_driver_set_blend_func(GL_FUNC_ADD, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    R3D_TARGET_BIND(0, false, sceneTarget);
+    R3D_TARGET_BIND_LOAD(0, false, sceneTarget);
     R3D_SHADER_USE(deferred.fog);
 
     R3D_SHADER_BIND_SAMPLER(deferred.fog, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 0));
@@ -2312,7 +2231,7 @@ void pass_deferred_volumetric_fog(r3d_target_t sceneTarget)
     r3d_driver_enable(GL_BLEND);
     r3d_driver_set_blend_func_separate(GL_FUNC_ADD, GL_ONE, GL_SRC_ALPHA, GL_ZERO, GL_ONE);
 
-    R3D_TARGET_BIND(0, false, sceneTarget);
+    R3D_TARGET_BIND_LOAD(0, false, sceneTarget);
 
     R3D_SHADER_USE(deferred.vfogTransmittance);
     R3D_SHADER_BIND_SAMPLER(deferred.vfogTransmittance, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 0));
@@ -2321,7 +2240,7 @@ void pass_deferred_volumetric_fog(r3d_target_t sceneTarget)
 
     /* --- Accumulate radiance in half resolution --- */
 
-    R3D_TARGET_CLEAR(1, false, R3D_TARGET_VFOG_RAD);
+    R3D_TARGET_BIND_CLEAR(1, false, R3D_TARGET_VFOG_RAD);
 
     r3d_driver_enable(GL_SCISSOR_TEST);
     r3d_driver_enable(GL_BLEND);
@@ -2368,7 +2287,7 @@ void pass_deferred_volumetric_fog(r3d_target_t sceneTarget)
 
     /* --- Compose radiance to the scene --- */
 
-    R3D_TARGET_BIND(0, false, sceneTarget);
+    R3D_TARGET_BIND_LOAD(0, false, sceneTarget);
     R3D_SHADER_USE(deferred.vfogCompose);
 
     r3d_driver_enable(GL_BLEND);
@@ -2382,7 +2301,7 @@ void pass_deferred_volumetric_fog(r3d_target_t sceneTarget)
 
 void pass_scene_forward(r3d_target_t sceneTarget)
 {
-    R3D_TARGET_BIND(0, true, sceneTarget);
+    R3D_TARGET_BIND_LOAD(0, true, sceneTarget);
 
     r3d_driver_enable(GL_STENCIL_TEST);
     r3d_driver_enable(GL_DEPTH_TEST);
@@ -2426,7 +2345,7 @@ void pass_scene_forward(r3d_target_t sceneTarget)
 
 void pass_scene_background(r3d_target_t sceneTarget)
 {
-    R3D_TARGET_BIND(0, true, sceneTarget);
+    R3D_TARGET_BIND_LOAD(0, true, sceneTarget);
 
     r3d_driver_disable(GL_STENCIL_TEST);
     r3d_driver_disable(GL_CULL_FACE);
@@ -2474,7 +2393,7 @@ r3d_target_t pass_post_dof(r3d_target_t sceneTarget)
 {
     /* --- Calculate CoC --- */
 
-    R3D_TARGET_BIND(0, false, R3D_TARGET_DOF_COC);
+    R3D_TARGET_BIND_CLEAR(0, false, R3D_TARGET_DOF_COC);
     R3D_SHADER_USE(prepare.dofCoc);
 
     R3D_SHADER_BIND_SAMPLER(prepare.dofCoc, uDepthTex, r3d_target_get_level(R3D_TARGET_DEPTH, 0));
@@ -2482,7 +2401,7 @@ r3d_target_t pass_post_dof(r3d_target_t sceneTarget)
 
     /* --- Downsample CoC to half resolution --- */
 
-    R3D_TARGET_BIND(1, false, R3D_TARGET_DOF_0);
+    R3D_TARGET_BIND_CLEAR(1, false, R3D_TARGET_DOF_0);
 
     R3D_SHADER_USE(prepare.dofDown);
     R3D_SHADER_BIND_SAMPLER(prepare.dofDown, uSceneTex, r3d_target_get(r3d_target_swap_scene(sceneTarget)));
@@ -2492,7 +2411,7 @@ r3d_target_t pass_post_dof(r3d_target_t sceneTarget)
 
     /* --- Calculate DoF in half resolution --- */
 
-    R3D_TARGET_BIND(1, false, R3D_TARGET_DOF_1);
+    R3D_TARGET_BIND_CLEAR(1, false, R3D_TARGET_DOF_1);
 
     R3D_SHADER_USE(prepare.dofBlur);
     R3D_SHADER_BIND_SAMPLER(prepare.dofBlur, uSceneTex, r3d_target_get(R3D_TARGET_DOF_0));
@@ -2527,7 +2446,7 @@ r3d_target_t pass_post_bloom(r3d_target_t sceneTarget)
 
     /* --- Karis average for the first downsampling to half res --- */
 
-    R3D_TARGET_BIND(minLevel, false, R3D_TARGET_BLOOM);
+    R3D_TARGET_BIND_CLEAR(minLevel, false, R3D_TARGET_BLOOM);
 
     R3D_SHADER_USE(prepare.bloomDown);
     R3D_SHADER_BIND_SAMPLER(prepare.bloomDown, uTexture, sceneSourceID);
@@ -2594,7 +2513,7 @@ r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget)
 
     /* --- Build log-luminance pyramid --- */
 
-    R3D_TARGET_BIND(1, false, R3D_TARGET_LUMINANCE);
+    R3D_TARGET_BIND_CLEAR(1, false, R3D_TARGET_LUMINANCE);
 
     R3D_SHADER_USE(prepare.luminance);
     R3D_SHADER_BIND_SAMPLER(prepare.luminance, uSourceTex, sceneSourceID);
@@ -2622,10 +2541,10 @@ r3d_target_t pass_post_auto_exposure(r3d_target_t sceneTarget)
 
     if (!r3d_target_exists(EXPOSURE_SRC))
     {
-        R3D_TARGET_CLEAR(r3d_target_get_max_level(EXPOSURE_SRC), false, EXPOSURE_SRC);
+        R3D_TARGET_BIND_CLEAR(r3d_target_get_max_level(EXPOSURE_SRC), false, EXPOSURE_SRC);
     }
 
-    R3D_TARGET_BIND(r3d_target_get_max_level(EXPOSURE_DST), false, EXPOSURE_DST);
+    R3D_TARGET_BIND_CLEAR(r3d_target_get_max_level(EXPOSURE_DST), false, EXPOSURE_DST);
     R3D_SHADER_USE(prepare.exposureAdapt);
 
     R3D_SHADER_BIND_SAMPLER(prepare.exposureAdapt, uMeasuredLogLumTex, r3d_target_get_level(R3D_TARGET_LUMINANCE, r3d_target_get_max_level(R3D_TARGET_LUMINANCE)));
@@ -2709,16 +2628,18 @@ r3d_target_t pass_post_smaa(r3d_target_t sceneTarget)
     // shader), then pass 2 only executes where stencil == 1.
 
     r3d_driver_enable(GL_STENCIL_TEST);
+    r3d_driver_disable(GL_DEPTH_TEST);
+
     r3d_driver_set_stencil_mask(0xFF);
 
-    R3D_TARGET_CLEAR(0, true, R3D_TARGET_SMAA_EDGES, R3D_TARGET_SMAA_BLEND);
+    R3D_TARGET_BIND_CLEAR(0, true, R3D_TARGET_SMAA_EDGES, R3D_TARGET_SMAA_BLEND);
 
     /* --- Edge detection ---  */
 
     r3d_driver_set_stencil_func(GL_ALWAYS, 1, 0xFF);
     r3d_driver_set_stencil_op(GL_KEEP, GL_KEEP, GL_REPLACE);
 
-    R3D_TARGET_BIND(0, true, R3D_TARGET_SMAA_EDGES);
+    R3D_TARGET_BIND_LOAD(0, true, R3D_TARGET_SMAA_EDGES);
     R3D_SHADER_USE(prepare.smaaEdgeDetection[R3D.aaPreset]);
 
     R3D_SHADER_BIND_SAMPLER(prepare.smaaEdgeDetection[R3D.aaPreset], uSceneTex, r3d_target_get(sceneSource));
@@ -2730,7 +2651,7 @@ r3d_target_t pass_post_smaa(r3d_target_t sceneTarget)
     r3d_driver_set_stencil_func(GL_EQUAL, 1, 0xFF);
     r3d_driver_set_stencil_op(GL_KEEP, GL_KEEP, GL_KEEP);
 
-    R3D_TARGET_BIND(0, true, R3D_TARGET_SMAA_BLEND);
+    R3D_TARGET_BIND_LOAD(0, true, R3D_TARGET_SMAA_BLEND);
     R3D_SHADER_USE(prepare.smaaBlendingWeights[R3D.aaPreset]);
 
     R3D_SHADER_BIND_SAMPLER(prepare.smaaBlendingWeights[R3D.aaPreset], uEdgesTex, r3d_target_get(R3D_TARGET_SMAA_EDGES));

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1590,7 +1590,7 @@ void raster_unlit(const r3d_render_call_t* call, bool opaque)
 
     r3d_driver_set_depth_state(material->depth);
     r3d_driver_set_stencil_state(material->stencil);
-    r3d_driver_set_blend_mode(material->blendMode);
+    if (!opaque) r3d_driver_set_blend_mode(material->blendMode);
     r3d_driver_set_cull_mode(material->cullMode);
 
     /* --- Rendering the object corresponding to the draw call --- */
@@ -2326,10 +2326,10 @@ void pass_scene_forward(r3d_target_t sceneTarget)
 
     r3d_driver_enable(GL_STENCIL_TEST);
     r3d_driver_enable(GL_DEPTH_TEST);
-    r3d_driver_enable(GL_BLEND);
 
     /* --- Render all unlit opaque --- */
 
+    r3d_driver_disable(GL_BLEND);
     r3d_driver_set_depth_mask(GL_TRUE);
 
     #define COND (IS_MESH_VISIBLE_CAMERA(call->mesh.instance) && (call->mesh.material.unlit))
@@ -2341,6 +2341,7 @@ void pass_scene_forward(r3d_target_t sceneTarget)
 
     /* --- Render all lit/unlit blended --- */
 
+    r3d_driver_enable(GL_BLEND);
     r3d_driver_set_depth_mask(GL_FALSE);
 
     R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), &R3D.viewState.frustum, R3D_RENDER_LIST_BLEND_INST, R3D_RENDER_LIST_BLEND)

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -65,8 +65,8 @@ static void upload_fx_block(void);
 
 static void raster_depth(const r3d_render_call_t* call, const Matrix* viewProj, const r3d_light_shadow_job_t* shadowJob);
 static void raster_depth_cube(const r3d_render_call_t* call, const Matrix* viewProj, const r3d_light_shadow_job_t* shadowJob);
-static void raster_probe_forward(const r3d_render_call_t* call, const r3d_env_probe_job_t* job, int face);
-static void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_probe_job_t* job, int face);
+static void raster_probe_forward(const r3d_render_call_t* call, const r3d_env_probe_job_t* job, int face, bool opaque);
+static void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_probe_job_t* job, int face, bool opaque);
 static void raster_geometry(const r3d_render_call_t* call);
 static void raster_decal(const r3d_render_call_t* call);
 static void raster_forward(const r3d_render_call_t* call);
@@ -182,11 +182,11 @@ void R3D_End(void)
     r3d_render_cull_groups(&R3D.viewState.frustum);
 
     r3d_render_sort_list(R3D_RENDER_LIST_OPAQUE, R3D.viewState.camera.position, R3D_RENDER_SORT_FRONT_TO_BACK);
-    r3d_render_sort_list(R3D_RENDER_LIST_TRANSPARENT, R3D.viewState.camera.position, R3D_RENDER_SORT_BACK_TO_FRONT);
+    r3d_render_sort_list(R3D_RENDER_LIST_BLEND, R3D.viewState.camera.position, R3D_RENDER_SORT_BACK_TO_FRONT);
     r3d_render_sort_list(R3D_RENDER_LIST_DECAL, R3D.viewState.camera.position, R3D_RENDER_SORT_MATERIAL_ONLY);
 
     r3d_render_sort_list(R3D_RENDER_LIST_OPAQUE_INST, R3D.viewState.camera.position, R3D_RENDER_SORT_MATERIAL_ONLY);
-    r3d_render_sort_list(R3D_RENDER_LIST_TRANSPARENT_INST, R3D.viewState.camera.position, R3D_RENDER_SORT_MATERIAL_ONLY);
+    r3d_render_sort_list(R3D_RENDER_LIST_BLEND_INST, R3D.viewState.camera.position, R3D_RENDER_SORT_MATERIAL_ONLY);
     r3d_render_sort_list(R3D_RENDER_LIST_DECAL_INST, R3D.viewState.camera.position, R3D_RENDER_SORT_MATERIAL_ONLY);
 
     /* --- Deferred path for opaques and decals --- */
@@ -197,7 +197,7 @@ void R3D_End(void)
     r3d_target_t ssgiSource  = R3D_TARGET_INVALID;
     r3d_target_t ssrSource   = R3D_TARGET_INVALID;
 
-    if (r3d_render_has_deferred() || r3d_render_has_prepass())
+    if (r3d_render_has_opaque())
     {
         pass_scene_opaque();
         pass_deferred_lights();
@@ -245,7 +245,7 @@ void R3D_End(void)
         }
     }
 
-    /* --- Then background/fog and transparent rendering --- */
+    /* --- Then background/fog and forward rendering --- */
 
     pass_scene_background(sceneTarget);
 
@@ -259,10 +259,7 @@ void R3D_End(void)
         pass_deferred_volumetric_fog(sceneTarget);
     }
 
-    if (r3d_render_has_forward() || r3d_render_has_prepass())
-    {
-        pass_scene_forward(sceneTarget);
-    }
+    pass_scene_forward(sceneTarget);
 
     /* --- Applying effects over the scene and final blit --- */
 
@@ -1120,7 +1117,7 @@ void raster_depth_cube(const r3d_render_call_t* call, const Matrix* viewProj, co
     }
 }
 
-void raster_probe_forward(const r3d_render_call_t* call, const r3d_env_probe_job_t* job, int face)
+void raster_probe_forward(const r3d_render_call_t* call, const r3d_env_probe_job_t* job, int face, bool opaque)
 {
     R3D_ASSERT(call->type == R3D_RENDER_CALL_MESH); //< Paranoid assert, should be fine
 
@@ -1165,7 +1162,12 @@ void raster_probe_forward(const r3d_render_call_t* call, const r3d_env_probe_job
 
     /* --- Set factor material maps --- */
 
+    bool hybrid = (material->transparencyMode == R3D_TRANSPARENCY_HYBRID);
+    float cutoffSign = opaque ? 1.0f : (hybrid ? -1.0f : 0.0f);
+
     R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uEmissionEnergy, material->emission.energy);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uAlphaCutoff, material->alphaCutoff);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uCutoffSign, cutoffSign);
     R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uNormalScale, material->normal.scale);
     R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uOcclusion, Clamp(material->orm.occlusion, 0.0f, 1.0f));
     R3D_SHADER_SET_FLOAT_SELECT(scene.probeForward, shader, uRoughness, Clamp(material->orm.roughness, 0.0f, 1.0f));
@@ -1193,7 +1195,7 @@ void raster_probe_forward(const r3d_render_call_t* call, const r3d_env_probe_job
 
     r3d_driver_set_depth_state(material->depth);
     r3d_driver_set_stencil_state(material->stencil);
-    r3d_driver_set_blend_mode(material->blendMode, material->transparencyMode);
+    r3d_driver_set_blend_mode(material->blendMode);
     r3d_driver_set_cull_mode(material->cullMode);
 
     /* --- Rendering the object corresponding to the draw call --- */
@@ -1210,7 +1212,7 @@ void raster_probe_forward(const r3d_render_call_t* call, const r3d_env_probe_job
     }
 }
 
-void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_probe_job_t* job, int face)
+void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_probe_job_t* job, int face, bool opaque)
 {
     R3D_ASSERT(call->type == R3D_RENDER_CALL_MESH); //< Paranoid assert, should be fine
 
@@ -1255,8 +1257,12 @@ void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_probe_job_t
 
     /* --- Set color material maps --- */
 
+    bool hybrid = (material->transparencyMode == R3D_TRANSPARENCY_HYBRID);
+    float cutoffSign = opaque ? 1.0f : (hybrid ? -1.0f : 0.0f);
+
     R3D_SHADER_SET_COL4_SELECT(scene.probeUnlit, shader, uAlbedoColor, material->albedo.color);
     R3D_SHADER_SET_FLOAT_SELECT(scene.probeUnlit, shader, uAlphaCutoff, material->alphaCutoff);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.probeUnlit, shader, uCutoffSign, cutoffSign);
 
     /* --- Bind active texture maps --- */
 
@@ -1266,7 +1272,7 @@ void raster_probe_unlit(const r3d_render_call_t* call, const r3d_env_probe_job_t
 
     r3d_driver_set_depth_state(material->depth);
     r3d_driver_set_stencil_state(material->stencil);
-    r3d_driver_set_blend_mode(material->blendMode, material->transparencyMode);
+    r3d_driver_set_blend_mode(material->blendMode);
     r3d_driver_set_cull_mode(material->cullMode);
 
     /* --- Rendering the object corresponding to the draw call --- */
@@ -1321,6 +1327,7 @@ void raster_geometry(const r3d_render_call_t* call)
     /* --- Set factor material maps --- */
 
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uEmissionEnergy, material->emission.energy);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uAlphaCutoff, material->alphaCutoff);
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uNormalScale, material->normal.scale);
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uOcclusion, Clamp(material->orm.occlusion, 0.0f, 1.0f));
     R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uRoughness, Clamp(material->orm.roughness, 0.0f, 1.0f));
@@ -1336,7 +1343,6 @@ void raster_geometry(const r3d_render_call_t* call)
 
     R3D_SHADER_SET_COL4_SELECT(scene.geometry, shader, uAlbedoColor, material->albedo.color);
     R3D_SHADER_SET_COL3_SELECT(scene.geometry, shader, uEmissionColor, material->emission.color);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.geometry, shader, uAlphaCutoff, material->alphaCutoff);
 
     /* --- Bind active texture maps --- */
 
@@ -1392,6 +1398,7 @@ void raster_decal(const r3d_render_call_t* call)
     /* --- Set factor material maps --- */
 
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uEmissionEnergy, decal->emission.energy);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uAlphaCutoff, decal->alphaCutoff);
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uNormalScale, decal->normal.scale);
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uOcclusion, Clamp(decal->orm.occlusion, 0.0f, 1.0f));
     R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uRoughness, Clamp(decal->orm.roughness, 0.0f, 1.0f));
@@ -1407,7 +1414,6 @@ void raster_decal(const r3d_render_call_t* call)
 
     R3D_SHADER_SET_COL4_SELECT(scene.decal, shader, uAlbedoColor, decal->albedo.color);
     R3D_SHADER_SET_COL3_SELECT(scene.decal, shader, uEmissionColor, decal->emission.color);
-    R3D_SHADER_SET_FLOAT_SELECT(scene.decal, shader, uAlphaCutoff, decal->alphaCutoff);
 
     /* --- Set decal specific values --- */
 
@@ -1479,6 +1485,8 @@ void raster_forward(const r3d_render_call_t* call)
     /* --- Set factor material maps --- */
 
     R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uEmissionEnergy, material->emission.energy);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uAlphaCutoff, material->alphaCutoff);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uCutoffSign, (material->transparencyMode == R3D_TRANSPARENCY_HYBRID) ? -1.0f : 0.0f);
     R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uNormalScale, material->normal.scale);
     R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uOcclusion, Clamp(material->orm.occlusion, 0.0f, 1.0f));
     R3D_SHADER_SET_FLOAT_SELECT(scene.forward, shader, uRoughness, Clamp(material->orm.roughness, 0.0f, 1.0f));
@@ -1506,7 +1514,7 @@ void raster_forward(const r3d_render_call_t* call)
 
     r3d_driver_set_depth_state(material->depth);
     r3d_driver_set_stencil_state(material->stencil);
-    r3d_driver_set_blend_mode(material->blendMode, material->transparencyMode);
+    r3d_driver_set_blend_mode(material->blendMode);
     r3d_driver_set_cull_mode(material->cullMode);
 
     /* --- Rendering the object corresponding to the draw call --- */
@@ -1567,6 +1575,7 @@ void raster_unlit(const r3d_render_call_t* call)
 
     R3D_SHADER_SET_COL4_SELECT(scene.unlit, shader, uAlbedoColor, material->albedo.color);
     R3D_SHADER_SET_FLOAT_SELECT(scene.unlit, shader, uAlphaCutoff, material->alphaCutoff);
+    R3D_SHADER_SET_FLOAT_SELECT(scene.unlit, shader, uCutoffSign, (material->transparencyMode == R3D_TRANSPARENCY_HYBRID) ? -1.0f : 1.0f);
 
     /* --- Bind active texture maps --- */
 
@@ -1576,7 +1585,7 @@ void raster_unlit(const r3d_render_call_t* call)
 
     r3d_driver_set_depth_state(material->depth);
     r3d_driver_set_stencil_state(material->stencil);
-    r3d_driver_set_blend_mode(material->blendMode, material->transparencyMode);
+    r3d_driver_set_blend_mode(material->blendMode);
     r3d_driver_set_cull_mode(material->cullMode);
 
     /* --- Rendering the object corresponding to the draw call --- */
@@ -1614,7 +1623,7 @@ void pass_scene_shadows(void)
         const R3D_Frustum* frustum = &job->frustum;
         r3d_render_cull_groups(frustum);
 
-        R3D_RENDER_FOR_EACH(call, COND, frustum, R3D_RENDER_PACKLIST_SHADOW)
+        R3D_RENDER_FOR_EACH(call, COND, frustum, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
         {
             if (r3d_render_should_cast_shadow(call))
             {
@@ -1635,6 +1644,19 @@ void pass_scene_shadows(void)
 
 void pass_scene_probes(void)
 {
+    #define RASTER_PROBE(opaque)                                    \
+    do {                                                            \
+        if (!call->mesh.material.unlit)                             \
+        {                                                           \
+            upload_light_array_block_for_mesh(call, job->shadows);  \
+            raster_probe_forward(call, job, iFace, (opaque));       \
+        }                                                           \
+        else                                                        \
+        {                                                           \
+            raster_probe_unlit(call, job, iFace, (opaque));         \
+        }                                                           \
+    } while(0)
+
     const R3D_EnvBackground* bg = &R3D.environment.background;
     const R3D_EnvFog* fog = &R3D.environment.fog;
 
@@ -1656,17 +1678,14 @@ void pass_scene_probes(void)
             r3d_env_probe_capture_bind_fbo(job->probeType, iFace);
             glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
-            R3D_RENDER_FOR_EACH(call, true, frustum, R3D_RENDER_PACKLIST_PROBE)
+            R3D_RENDER_FOR_EACH(call, true, frustum, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
             {
-                if (call->mesh.material.unlit)
-                {
-                    raster_probe_unlit(call, job, iFace);
-                }
-                else
-                {
-                    upload_light_array_block_for_mesh(call, job->shadows);
-                    raster_probe_forward(call, job, iFace);
-                }
+                RASTER_PROBE(true);
+            }
+
+            R3D_RENDER_FOR_EACH(call, true, frustum, R3D_RENDER_LIST_BLEND_INST, R3D_RENDER_LIST_BLEND)
+            {
+                RASTER_PROBE(false);
             }
 
             r3d_driver_set_depth_offset(0.0f, 0.0f);
@@ -1734,6 +1753,8 @@ void pass_scene_probes(void)
 
         r3d_target_invalidate_cache(); //< The IBL gen functions bind framebuffers; resetting them prevents any problems
     }
+
+    #undef RASTER_PROBE
 }
 
 void pass_scene_opaque(void)
@@ -1748,26 +1769,11 @@ void pass_scene_opaque(void)
 
     R3D_TARGET_BIND_CLEAR(0, true, R3D_TARGET_GBUFFER);
 
-    if (r3d_render_has_deferred())
-    {
-        R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), NULL, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
-        {
-            if (!call->mesh.material.unlit)
-            {
-                raster_geometry(call);
-            }
-        }
-    }
+    #define COND (IS_MESH_VISIBLE_CAMERA(call->mesh.instance) && (!call->mesh.material.unlit))
 
-    if (r3d_render_has_prepass())
+    R3D_RENDER_FOR_EACH(call, COND, &R3D.viewState.frustum, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
     {
-        R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), NULL, R3D_RENDER_LIST_TRANSPARENT_INST, R3D_RENDER_LIST_TRANSPARENT)
-        {
-            if (r3d_render_is_prepass(call))
-            {
-                raster_geometry(call);
-            }
-        }
+        raster_geometry(call);
     }
 
     r3d_driver_set_depth_offset(0.0f, 0.0f);
@@ -1787,14 +1793,15 @@ void pass_scene_opaque(void)
         //        making orm.specular ineffective for decals.
         glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
 
-        const R3D_Frustum* frustum = &R3D.viewState.frustum;
-        R3D_RENDER_FOR_EACH(call, true, frustum, R3D_RENDER_LIST_DECAL_INST, R3D_RENDER_LIST_DECAL)
+        R3D_RENDER_FOR_EACH(call, true, &R3D.viewState.frustum, R3D_RENDER_LIST_DECAL_INST, R3D_RENDER_LIST_DECAL)
         {
             raster_decal(call);
         }
 
         glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
     }
+
+    #undef COND
 }
 
 void pass_prepare_pyramid(void)
@@ -2307,33 +2314,33 @@ void pass_scene_forward(r3d_target_t sceneTarget)
     r3d_driver_enable(GL_DEPTH_TEST);
     r3d_driver_enable(GL_BLEND);
 
-    /* --- Render unlit opaque --- */
+    /* --- Render all unlit opaque --- */
 
     r3d_driver_set_depth_mask(GL_TRUE);
 
-    const R3D_Frustum* frustum = &R3D.viewState.frustum;
-    R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), frustum, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
+    #define COND (IS_MESH_VISIBLE_CAMERA(call->mesh.instance) && (call->mesh.material.unlit))
+
+    R3D_RENDER_FOR_EACH(call, COND, &R3D.viewState.frustum, R3D_RENDER_LIST_OPAQUE_INST, R3D_RENDER_LIST_OPAQUE)
     {
-        if (call->mesh.material.unlit)
-        {
-            raster_unlit(call);
-        }
+        raster_unlit(call);
     }
 
-    /* --- Render all transparent in order - (prepass/alpha treated as same) --- */
+    #undef COND
+
+    /* --- Render all lit/unlit blended --- */
 
     r3d_driver_set_depth_mask(GL_FALSE);
 
-    R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), frustum, R3D_RENDER_LIST_TRANSPARENT_INST, R3D_RENDER_LIST_TRANSPARENT)
+    R3D_RENDER_FOR_EACH(call, IS_MESH_VISIBLE_CAMERA(call->mesh.instance), &R3D.viewState.frustum, R3D_RENDER_LIST_BLEND_INST, R3D_RENDER_LIST_BLEND)
     {
-        if (call->mesh.material.unlit)
-        {
-            raster_unlit(call);
-        }
-        else
+        if (!call->mesh.material.unlit)
         {
             upload_light_array_block_for_mesh(call, true);
             raster_forward(call);
+        }
+        else
+        {
+            raster_unlit(call);
         }
     }
 

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -74,7 +74,8 @@ static void raster_unlit(const r3d_render_call_t* call, bool opaque);
 
 static void pass_scene_shadows(void);
 static void pass_scene_probes(void);
-static void pass_scene_opaque(void);
+static void pass_scene_geometry(void);
+static void pass_scene_decals(void);
 
 static void pass_prepare_pyramid(void);
 static void pass_prepare_downsample(r3d_target_t target, int level);
@@ -206,12 +207,10 @@ void R3D_End(void)
 
     if (r3d_render_has_opaque())
     {
-        pass_scene_opaque();
+        pass_scene_geometry();
 
-        if (r3d_light_has_visible())
-        {
-            pass_deferred_lights();
-        }
+        if (r3d_render_has_decals()) pass_scene_decals();
+        if (r3d_light_has_visible()) pass_deferred_lights();
 
         bool ssao = R3D.environment.ssao.enabled;
         bool ssil = R3D.environment.ssil.enabled;
@@ -1762,7 +1761,7 @@ void pass_scene_probes(void)
     #undef RASTER_PROBE
 }
 
-void pass_scene_opaque(void)
+void pass_scene_geometry(void)
 {
     r3d_driver_enable(GL_STENCIL_TEST);
     r3d_driver_enable(GL_DEPTH_TEST);
@@ -1783,30 +1782,31 @@ void pass_scene_opaque(void)
 
     r3d_driver_set_depth_offset(0.0f, 0.0f);
     r3d_driver_set_depth_range(0.0f, 1.0f);
+}
 
-    if (r3d_render_has_decal())
+void pass_scene_decals(void)
+{
+    r3d_driver_disable(GL_STENCIL_TEST);
+    r3d_driver_disable(GL_DEPTH_TEST);
+    r3d_driver_enable(GL_CULL_FACE);
+    r3d_driver_enable(GL_BLEND);
+
+    r3d_driver_set_cull_face(GL_FRONT); // Only render back faces to avoid clipping issues
+
+    R3D_TARGET_BIND_LOAD(0, true, R3D_TARGET_DECAL);
+
+    // FIXME: The decal shader uses the alpha channel of the ORM attachment as a blend factor,
+    //        but this channel now stores the material specular (F0) written during the geometry
+    //        pass. We mask alpha writes to preserve the underlying specular, at the cost of
+    //        making orm.specular ineffective for decals.
+    glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
+
+    R3D_RENDER_FOR_EACH(call, true, &R3D.viewState.frustum, R3D_RENDER_LIST_DECAL_INST, R3D_RENDER_LIST_DECAL)
     {
-        r3d_driver_disable(GL_STENCIL_TEST);
-        r3d_driver_disable(GL_DEPTH_TEST);
-        r3d_driver_enable(GL_BLEND);
-
-        r3d_driver_set_cull_face(GL_FRONT); // Only render back faces to avoid clipping issues
-
-        R3D_TARGET_BIND_LOAD(0, true, R3D_TARGET_DECAL);
-
-        // FIXME: The decal shader uses the alpha channel of the ORM attachment as a blend factor,
-        //        but this channel now stores the material specular (F0) written during the geometry
-        //        pass. We mask alpha writes to preserve the underlying specular, at the cost of
-        //        making orm.specular ineffective for decals.
-        glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_FALSE);
-
-        R3D_RENDER_FOR_EACH(call, true, &R3D.viewState.frustum, R3D_RENDER_LIST_DECAL_INST, R3D_RENDER_LIST_DECAL)
-        {
-            raster_decal(call);
-        }
-
-        glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+        raster_decal(call);
     }
+
+    glColorMaski(2, GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 }
 
 void pass_prepare_pyramid(void)

--- a/src/r3d_draw.c
+++ b/src/r3d_draw.c
@@ -1792,6 +1792,8 @@ void pass_scene_opaque(void)
 
         r3d_driver_set_cull_face(GL_FRONT); // Only render back faces to avoid clipping issues
 
+        R3D_TARGET_BIND_LOAD(0, true, R3D_TARGET_DECAL);
+
         // FIXME: The decal shader uses the alpha channel of the ORM attachment as a blend factor,
         //        but this channel now stores the material specular (F0) written during the geometry
         //        pass. We mask alpha writes to preserve the underlying specular, at the cost of

--- a/src/r3d_surface_shader.c
+++ b/src/r3d_surface_shader.c
@@ -23,13 +23,12 @@
 
 typedef uint32_t usage_hint_t;
 
-#define USAGE_HINT_OPAQUE        (1 << 0)   //< Build: geometry
-#define USAGE_HINT_PREPASS       (1 << 1)   //< Build: geometry, forward, depth
-#define USAGE_HINT_TRANSPARENT   (1 << 2)   //< Build: forward
-#define USAGE_HINT_UNLIT         (1 << 3)   //< Build: unlit
-#define USAGE_HINT_SHADOW        (1 << 4)   //< Build: depth, depthCube
-#define USAGE_HINT_DECAL         (1 << 5)   //< Build: decal
-#define USAGE_HINT_PROBE         (1 << 6)   //< Build: probe
+#define USAGE_HINT_OPAQUE  (1 << 0)   //< Build: geometry
+#define USAGE_HINT_BLEND   (1 << 2)   //< Build: forward
+#define USAGE_HINT_UNLIT   (1 << 3)   //< Build: unlit
+#define USAGE_HINT_SHADOW  (1 << 4)   //< Build: depth, depthCube
+#define USAGE_HINT_DECAL   (1 << 5)   //< Build: decal
+#define USAGE_HINT_PROBE   (1 << 6)   //< Build: probeForward, probeUnlit
 
 // ========================================
 // INTERNAL FUNCTIONS
@@ -296,13 +295,12 @@ usage_hint_t parse_pragma_usage(const char** ptr)
             size_t len;
             usage_hint_t flag;
         } hints[] = {
-            {"opaque",      6,  USAGE_HINT_OPAQUE},
-            {"prepass",     7,  USAGE_HINT_PREPASS},
-            {"transparent", 11, USAGE_HINT_TRANSPARENT},
-            {"unlit",       5,  USAGE_HINT_UNLIT},
-            {"shadow",      6,  USAGE_HINT_SHADOW},
-            {"decal",       5,  USAGE_HINT_DECAL},
-            {"probe",       5,  USAGE_HINT_PROBE}
+            {"opaque", 6, USAGE_HINT_OPAQUE},
+            {"blend",  5, USAGE_HINT_BLEND},
+            {"unlit",  5, USAGE_HINT_UNLIT},
+            {"shadow", 6, USAGE_HINT_SHADOW},
+            {"decal",  5, USAGE_HINT_DECAL},
+            {"probe",  5, USAGE_HINT_PROBE}
         };
 
         bool matched = false;
@@ -351,12 +349,11 @@ const char* get_usage_hint_string(usage_hint_t hints)
     } while(0)
 
     if (hints & USAGE_HINT_OPAQUE) APPEND("Opaque");
-    if (hints & USAGE_HINT_PREPASS) APPEND("Prepass");
-    if (hints & USAGE_HINT_TRANSPARENT) APPEND("Transparent");
-    if (hints & USAGE_HINT_UNLIT) APPEND("Unlit");
+    if (hints & USAGE_HINT_BLEND)  APPEND("Blend");
+    if (hints & USAGE_HINT_UNLIT)  APPEND("Unlit");
     if (hints & USAGE_HINT_SHADOW) APPEND("Shadow");
-    if (hints & USAGE_HINT_DECAL) APPEND("Decal");
-    if (hints & USAGE_HINT_PROBE) APPEND("Probe");
+    if (hints & USAGE_HINT_DECAL)  APPEND("Decal");
+    if (hints & USAGE_HINT_PROBE)  APPEND("Probe");
 
     #undef APPEND
     *p = '\0';
@@ -380,14 +377,14 @@ bool compile_shader_variants(R3D_SurfaceShader* shader, usage_hint_t usage)
         usage_hint_t condition;
         r3d_shader_loader_func func;
     } variants[] = {
-        {"geometry",      USAGE_HINT_OPAQUE | USAGE_HINT_PREPASS,      R3D_MOD_SHADER_LOADER.scene.geometry},
-        {"forward",       USAGE_HINT_PREPASS | USAGE_HINT_TRANSPARENT, R3D_MOD_SHADER_LOADER.scene.forward},
-        {"unlit",         USAGE_HINT_UNLIT,                            R3D_MOD_SHADER_LOADER.scene.unlit},
-        {"depth",         USAGE_HINT_SHADOW | USAGE_HINT_PREPASS,      R3D_MOD_SHADER_LOADER.scene.depth},
-        {"depth-cube",    USAGE_HINT_SHADOW,                           R3D_MOD_SHADER_LOADER.scene.depthCube},
-        {"decal",         USAGE_HINT_DECAL,                            R3D_MOD_SHADER_LOADER.scene.decal},
-        {"probe-forward", USAGE_HINT_PROBE,                            R3D_MOD_SHADER_LOADER.scene.probeForward},
-        {"probe-unlit",   USAGE_HINT_PROBE | USAGE_HINT_UNLIT,         R3D_MOD_SHADER_LOADER.scene.probeUnlit},
+        {"geometry",      USAGE_HINT_OPAQUE, R3D_MOD_SHADER_LOADER.scene.geometry},
+        {"forward",       USAGE_HINT_BLEND , R3D_MOD_SHADER_LOADER.scene.forward},
+        {"unlit",         USAGE_HINT_UNLIT,  R3D_MOD_SHADER_LOADER.scene.unlit},
+        {"depth",         USAGE_HINT_SHADOW, R3D_MOD_SHADER_LOADER.scene.depth},
+        {"depth-cube",    USAGE_HINT_SHADOW, R3D_MOD_SHADER_LOADER.scene.depthCube},
+        {"decal",         USAGE_HINT_DECAL,  R3D_MOD_SHADER_LOADER.scene.decal},
+        {"probe-forward", USAGE_HINT_PROBE,  R3D_MOD_SHADER_LOADER.scene.probeForward},
+        {"probe-unlit",   USAGE_HINT_PROBE,  R3D_MOD_SHADER_LOADER.scene.probeUnlit},
     };
 
     for (int i = 0; i < 6; i++)


### PR DESCRIPTION
## Transparency Modes

This PR revises the transparency modes, introducing three modes: `OPAQUE`, `HYBRID`, and `BLEND`:

```c
typedef enum R3D_TransparencyMode {
    R3D_TRANSPARENCY_OPAQUE,        ///< Fully opaque in G-Buffer (supports hard alpha cutoff/masking). Ignores blend mode.
    R3D_TRANSPARENCY_HYBRID,        ///< Two-pass rendering: opaque cutoff in G-Buffer + forward blending.
    R3D_TRANSPARENCY_BLEND,         ///< Blended only (forward pass, no depth write / shadow casting).
} R3D_TransparencyMode;
```

The behavior is similar to the previous modes, but the internal logic is now clearer and more efficient.

The `HYBRID` mode first renders an opaque pass for fragments above the alpha cutoff, followed by a blended pass for fragments below the cutoff.

It's also worth noting that the hybrid logic naturally works with unlit materials without requiring any additional logic. There isn't much practical benefit to using it for unlit materials though, so it's preferable to render them directly using `BLEND`.

### Blend Modes

Blend modes are now only applied to `BLEND` and to the below-cutoff portion of `HYBRID`. Previously, there was a special case for `ADDITIVE` when transparency was `DISABLED`, which resulted in a different blend mode. This was somewhat unclear, so I introduced the `ADD_ALPHA` blend mode and kept `ADDITIVE` as a straightforward `ONE, ONE` blend.

Complete enum with the new `ADD_ALPHA`:
```c
typedef enum R3D_BlendMode {
    R3D_BLEND_ALPHA,                ///< Standard alpha blending: source color is blended using its alpha channel.
    R3D_BLEND_ADDITIVE,             ///< Pure additive blending: source color is added directly to destination (ignores alpha).
    R3D_BLEND_ADD_ALPHA,            ///< Alpha-modulated additive blending: source color scaled by alpha before adding to destination.
    R3D_BLEND_MULTIPLY,             ///< Multiply blending: source color is multiplied with destination, darkening the image.
    R3D_BLEND_PREMULTIPLIED_ALPHA   ///< Premultiplied alpha blending: assumes source color is already multiplied by its alpha.
} R3D_BlendMode;
```

### Shader Usages

For shader `#pragma usage`, the `prepass` mode has been removed, and `transparent` has been renamed to `blend` for consistency with `R3D_TransparencyMode`.

### Alpha Cutoff

The default material alpha cutoff has also been changed from `0.01f` to `0.5f`. This makes the behavior more natural in most cases and also matches the standard behavior expected for glTF models when no explicit alpha cutoff is defined.

### Internal Rendering Changes

I also made a few adjustments to the internal rendering-pass logic. These changes helped facilitate the new transparency system and will also serve as preliminary groundwork for the future scene/context architecture and transparent background support.
